### PR TITLE
feat(broker): substitute placeholders in body, path, and query (#17)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,6 +75,7 @@ proxy:
   listen: 127.0.0.1:1701     # host:port to listen on
   cache_ttl: 5m               # how long a resolved credential is cached
   on_no_match: passthrough    # passthrough | block
+  max_body_bytes: 1048576     # body buffering cap for body substitution (1 MiB)
 ```
 
 | Field | Required | Meaning |
@@ -82,6 +83,7 @@ proxy:
 | `listen` | yes | `host:port` the proxy binds. Point your agent's `HTTPS_PROXY` at this. |
 | `cache_ttl` | yes | Go duration (`5m`, `30s`). Must be greater than zero. How long a resolved credential is cached before re-fetching; one-time-password references are never cached. |
 | `on_no_match` | no | What to do when no rule matches. `passthrough` (default) forwards the request unchanged. |
+| `max_body_bytes` | no | Cap (in bytes) on how much of a request body postern buffers when a rule rewrites the body (`inject.in` includes `body`). Default 1 MiB when unset or `0`. A larger body is rejected with `413 Request Entity Too Large` and never reaches the upstream. Bound at startup; a hot-reload edit warns and does not take effect (a per-rule `inject.max_body_bytes` override does hot-reload). |
 
 > **Note — `on_no_match: block`.** The value is accepted today but not yet
 > enforced: every unmatched request currently passes through regardless. Don't
@@ -128,9 +130,52 @@ inject:
 
 | Field | Meaning |
 |---|---|
-| `type` | `header` sets a named header to the rendered template. `placeholder` substitutes a sentinel token (`name`) already present in the request's header values. |
+| `type` | `header` sets a named header to the rendered template. `placeholder` substitutes a sentinel token (`name`) already present in the request. |
 | `name` | For `header`, the header to set. For `placeholder`, the sentinel token to replace. |
 | `template` | The rendered credential string. `{{ CREDENTIAL }}` is replaced with the resolved value. Omitting the placeholder is a **fatal error**: the credential would be discarded and the request forwarded unauthenticated, so postern refuses to start. |
+| `in` | (`placeholder` only) The request surfaces to substitute, any subset of `header`, `body`, `path`, `query`. Defaults to `[header]`. |
+| `max_body_bytes` | (`placeholder` with `in` including `body`) Per-rule override of `proxy.max_body_bytes`. `0` (or unset) inherits the proxy-wide cap. |
+
+### Substitution surfaces (`placeholder` mode)
+
+By default a `placeholder` rule replaces the sentinel token only in header
+values. `inject.in` opts the rule into substituting other request surfaces; the
+value is percent- or string-encoded per surface so it can never corrupt the
+payload or inject structure:
+
+```yaml
+rules:
+  - host: openrouter.ai
+    secret_ref: op://Agents/OpenRouter/api_key
+    inject:
+      type: placeholder
+      name: __openrouter__          # RFC 3986 unreserved chars only (see below)
+      template: "{{ CREDENTIAL }}"
+      in: [body, query]
+```
+
+| Surface | Encoding of the injected value |
+|---|---|
+| `header` | Raw. A value containing CR or LF is rejected (header-injection guard) and the request fails closed. |
+| `path` | `url.PathEscape` — escaped as a single path segment. |
+| `query` | `url.QueryEscape` — escaped as a query component. |
+| `body` | Chosen by `Content-Type`: `application/json` → JSON string-escaped; `application/x-www-form-urlencoded` → query-escaped; `multipart/*` → **skipped** (forwarded unmodified); anything else → raw. A body with a `Content-Encoding` (compressed) is **skipped** and forwarded unmodified. |
+
+Notes:
+
+- **Token charset.** When any non-header surface is declared, `name` must use
+  only RFC 3986 unreserved characters (`A–Z a–z 0–9 - . _ ~`) so its encoded and
+  decoded forms are identical and path/query substitution is stable. Header-only
+  rules keep the looser charset.
+- **Aggregate match.** With several surfaces declared, the token being found on
+  any one eligible surface is success. If it is found on none, the request fails
+  closed with `502` and the upstream is never contacted. A body that is skipped
+  (compressed or multipart) is not an eligible surface — a body-only rule on
+  such a body forwards it untouched.
+- **Body size.** Bodies are buffered only when `body` is declared; everything
+  else streams. See `proxy.max_body_bytes` for the cap and the `413` behavior.
+- **WebSocket frames are out of scope.** postern brokers the HTTP request that
+  opens a connection; it does not inspect or rewrite WebSocket message frames.
 
 ### Built-in templates
 
@@ -156,6 +201,10 @@ Errors block startup. Common errors:
 - `inject.type` missing or not `header`/`placeholder`; `name` missing for a
   header injection; `template` missing or carrying no `{{ CREDENTIAL }}`
   placeholder.
+- `inject.in` set with `type: header`; an invalid surface name; a `placeholder`
+  token with reserved characters when a non-header surface is declared.
+- `proxy.max_body_bytes` (or a per-rule `inject.max_body_bytes`) negative; a
+  per-rule `max_body_bytes` set without `body` in `inject.in`.
 - `cache_ttl` not greater than zero; `listen` missing or not `host:port`.
 - A rule present but no credstore configured (set `token:` or `credstores:`).
 - Duplicate rule hosts or duplicate credstore names.

--- a/internal/broker/from_config.go
+++ b/internal/broker/from_config.go
@@ -19,7 +19,8 @@ func FromConfigRules(in []config.Rule) ([]Rule, error) {
 		return nil, nil
 	}
 	out := make([]Rule, len(in))
-	for i, src := range in {
+	for i := range in {
+		src := in[i]
 		t, err := injectTypeFromConfig(src.Inject.Type)
 		if err != nil {
 			// A template-only rule has no Host yet; fall back to the template
@@ -30,17 +31,56 @@ func FromConfigRules(in []config.Rule) ([]Rule, error) {
 			}
 			return nil, fmt.Errorf("rules[%d] (%s): %w", i, label, err)
 		}
+		surfaces, err := surfacesFromConfig(src.Inject.In)
+		if err != nil {
+			return nil, fmt.Errorf("rules[%d] (%s): %w", i, src.Host, err)
+		}
 		out[i] = Rule{
 			Host:      src.Host,
 			SecretRef: src.SecretRef,
 			Injection: InjectSpec{
-				Type:     t,
-				Name:     src.Inject.Name,
-				Template: src.Inject.Template,
+				Type:         t,
+				Name:         src.Inject.Name,
+				Template:     src.Inject.Template,
+				Surfaces:     surfaces,
+				MaxBodyBytes: derefBodyCap(src.Inject.MaxBodyBytes),
 			},
 		}
 	}
 	return out, nil
+}
+
+// surfacesFromConfig maps the YAML surface list to broker surfaces. An empty
+// list yields nil, which Inject treats as header-only.
+func surfacesFromConfig(in []config.InjectSurface) ([]Surface, error) {
+	if len(in) == 0 {
+		return nil, nil
+	}
+	out := make([]Surface, len(in))
+	for i, s := range in {
+		switch s {
+		case config.InjectSurfaceHeader:
+			out[i] = SurfaceHeader
+		case config.InjectSurfaceBody:
+			out[i] = SurfaceBody
+		case config.InjectSurfacePath:
+			out[i] = SurfacePath
+		case config.InjectSurfaceQuery:
+			out[i] = SurfaceQuery
+		default:
+			return nil, fmt.Errorf("unknown inject.in surface %q", s)
+		}
+	}
+	return out, nil
+}
+
+// derefBodyCap unwraps the optional per-rule body cap; a nil pointer (or a
+// non-positive value) means inherit the proxy-wide cap, signalled as 0.
+func derefBodyCap(p *int) int {
+	if p == nil || *p <= 0 {
+		return 0
+	}
+	return *p
 }
 
 func injectTypeFromConfig(t config.InjectType) (InjectType, error) {

--- a/internal/broker/from_config_test.go
+++ b/internal/broker/from_config_test.go
@@ -56,6 +56,61 @@ func TestFromConfigRules_TranslatesHeaderAndPlaceholder(t *testing.T) {
 	}
 }
 
+func TestFromConfigRules_TranslatesSurfacesAndCap(t *testing.T) {
+	t.Parallel()
+
+	cap := 4096
+	in := []config.Rule{{
+		Host:      "api.example.com",
+		SecretRef: "op://V/I/f",
+		Inject: config.Inject{
+			Type:         config.InjectTypePlaceholder,
+			Name:         "__tok__",
+			Template:     "{{ CREDENTIAL }}",
+			In:           []config.InjectSurface{config.InjectSurfaceBody, config.InjectSurfacePath, config.InjectSurfaceQuery, config.InjectSurfaceHeader},
+			MaxBodyBytes: &cap,
+		},
+	}}
+
+	got, err := broker.FromConfigRules(in)
+	if err != nil {
+		t.Fatalf("FromConfigRules: %v", err)
+	}
+
+	want := []broker.Rule{{
+		Host:      "api.example.com",
+		SecretRef: "op://V/I/f",
+		Injection: broker.InjectSpec{
+			Type:         broker.InjectPlaceholder,
+			Name:         "__tok__",
+			Template:     "{{ CREDENTIAL }}",
+			Surfaces:     []broker.Surface{broker.SurfaceBody, broker.SurfacePath, broker.SurfaceQuery, broker.SurfaceHeader},
+			MaxBodyBytes: 4096,
+		},
+	}}
+	if diff := cmp.Diff(want, got, cmpopts.EquateEmpty()); diff != "" {
+		t.Fatalf("rules diff (-want +got):\n%s", diff)
+	}
+}
+
+func TestFromConfigRules_RejectsUnknownSurface(t *testing.T) {
+	t.Parallel()
+
+	_, err := broker.FromConfigRules([]config.Rule{{
+		Host:      "api.example.com",
+		SecretRef: "op://V/I/f",
+		Inject: config.Inject{
+			Type:     config.InjectTypePlaceholder,
+			Name:     "__tok__",
+			Template: "{{ CREDENTIAL }}",
+			In:       []config.InjectSurface{"bogus"},
+		},
+	}})
+	if err == nil {
+		t.Fatalf("FromConfigRules with unknown surface: want error, got nil")
+	}
+}
+
 func TestFromConfigRules_RejectsUnknownInjectType(t *testing.T) {
 	t.Parallel()
 

--- a/internal/broker/hook.go
+++ b/internal/broker/hook.go
@@ -1,7 +1,9 @@
 package broker
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"net"
@@ -39,13 +41,21 @@ type Resolver interface {
 //     is never injected onto a cleartext hop.
 //  3. Resolve the matched rule's secret reference. The vaultID is always
 //     empty today; future multi-vault routing will populate it.
-//  4. Inject the resolved credential per the rule's InjectSpec.
+//  4. For a rule that rewrites the request body, buffer the body up to
+//     maxBodyBytes (per-rule override wins) before resolving — an oversized
+//     body returns 413 and the resolver is never called, so a flood of large
+//     bodies cannot hammer the credential vendor.
+//  5. Inject the resolved credential per the rule's InjectSpec.
 //
 // On any resolve or inject error the hook returns a synthesized 502 — fail
 // closed: the proxy must never let an unauthenticated request out to the
 // upstream once it has matched a rule. The underlying error message is
 // logged via logger but never surfaced to the client.
-func Hook(engine *Engine, resolver Resolver, onNoMatch config.OnNoMatch, logger *slog.Logger) func(*http.Request) *http.Response {
+//
+// maxBodyBytes is the proxy-wide body buffering cap; a value <= 0 falls back
+// to config.DefaultMaxBodyBytes. It is only consulted for rules that declare
+// the body surface.
+func Hook(engine *Engine, resolver Resolver, onNoMatch config.OnNoMatch, maxBodyBytes int, logger *slog.Logger) func(*http.Request) *http.Response {
 	if logger == nil {
 		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
 	}
@@ -76,6 +86,37 @@ func Hook(engine *Engine, resolver Resolver, onNoMatch config.OnNoMatch, logger 
 				slog.String("scheme", req.URL.Scheme),
 			)
 			return failClosed(req)
+		}
+
+		// Body buffering happens before resolve so an oversized body is
+		// rejected (413) without spending a credential fetch. Only rules that
+		// rewrite the body buffer it; everything else streams untouched.
+		if rule.usesBodySurface() {
+			bodyCap := effectiveBodyCap(maxBodyBytes, rule.Injection.MaxBodyBytes)
+			limited := http.MaxBytesReader(nil, req.Body, int64(bodyCap))
+			buf, rerr := io.ReadAll(limited)
+			if rerr != nil {
+				var maxErr *http.MaxBytesError
+				if errors.As(rerr, &maxErr) {
+					logger.Warn("broker rejected oversized body",
+						slog.String("host", host),
+						slog.String("rule", rule.Host),
+						slog.Int("limit_bytes", bodyCap),
+					)
+					return tooLarge(req)
+				}
+				logger.Warn("broker body read failed",
+					slog.String("host", host),
+					slog.String("rule", rule.Host),
+					slog.Any("err", rerr),
+				)
+				return failClosed(req)
+			}
+			// Replace the streamed body with the buffered copy. goproxy closes
+			// the original body via its own deferred Close, so we must not
+			// close it here (that would double-close).
+			req.Body = io.NopCloser(bytes.NewReader(buf))
+			req.ContentLength = int64(len(buf))
 		}
 
 		cred, err := resolver.Resolve(req.Context(), "", rule.SecretRef)
@@ -143,6 +184,42 @@ func failClosed(req *http.Request) *http.Response {
 		Body:          io.NopCloser(strings.NewReader(failClosedBody)),
 		ContentLength: int64(len(failClosedBody)),
 	}
+}
+
+// tooLargeBody is the body returned with a 413 when a brokered request's body
+// exceeds the buffering cap. Unlike the fail-closed 502 it names the condition:
+// an oversized body is a client error, not a credential-handling failure, so it
+// carries no failure-stage oracle.
+const tooLargeBody = "postern: request entity too large\n"
+
+// tooLarge builds the 413 the broker returns when a body-rewriting rule's
+// request body exceeds the configured cap. The upstream is never contacted.
+func tooLarge(req *http.Request) *http.Response {
+	return &http.Response{
+		Status:        http.StatusText(http.StatusRequestEntityTooLarge),
+		StatusCode:    http.StatusRequestEntityTooLarge,
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Request:       req,
+		Header:        http.Header{"Content-Type": []string{"text/plain; charset=utf-8"}},
+		Body:          io.NopCloser(strings.NewReader(tooLargeBody)),
+		ContentLength: int64(len(tooLargeBody)),
+	}
+}
+
+// effectiveBodyCap resolves the body buffering cap for a rule: a positive
+// per-rule override wins; otherwise the proxy-wide cap; otherwise the built-in
+// default. The result is always positive so MaxBytesReader never collapses to a
+// zero-byte limit.
+func effectiveBodyCap(global, perRule int) int {
+	if perRule > 0 {
+		return perRule
+	}
+	if global > 0 {
+		return global
+	}
+	return config.DefaultMaxBodyBytes
 }
 
 // stripPort drops the optional :port suffix from an HTTP request URL host.

--- a/internal/broker/hook_surfaces_test.go
+++ b/internal/broker/hook_surfaces_test.go
@@ -1,0 +1,104 @@
+package broker_test
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mmartinez/postern/internal/broker"
+	"github.com/mmartinez/postern/internal/config"
+)
+
+func bodySurfaceHook(t *testing.T, res broker.Resolver, maxBodyBytes int, rule broker.Rule) func(*http.Request) *http.Response {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return broker.Hook(broker.NewEngine([]broker.Rule{rule}), res, config.OnNoMatchPassthrough, maxBodyBytes, logger) //nolint:bodyclose // hook closure; broker owns synthetic bodies
+}
+
+// A body over the size cap is a 413 (client error), not a 502, and the
+// credential resolver is never called — buffering happens before resolve so a
+// flood of oversized bodies can't hammer the credential vendor.
+func TestHook_BodyOverCap_Returns413_ResolverNotCalled(t *testing.T) {
+	t.Parallel()
+
+	res := &fakeResolver{value: "sk-real"}
+	hook := bodySurfaceHook(t, res, 16, placeholderRule(broker.SurfaceBody))
+
+	req, err := http.NewRequest(http.MethodPost, "https://api.example.com/v1/x", strings.NewReader(strings.Repeat("x", 100)))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp := hook(req)
+	require.NotNil(t, resp)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode)
+	require.Zero(t, res.calls.Load(), "resolver must not be called when the body is rejected for size")
+}
+
+// A body within the cap is buffered, the placeholder substituted, and the
+// request forwarded (hook returns nil). Content-Length tracks the new body.
+func TestHook_BodyUnderCap_SubstitutesAndForwards(t *testing.T) {
+	t.Parallel()
+
+	res := &fakeResolver{value: "sk-real"}
+	hook := bodySurfaceHook(t, res, 1<<20, placeholderRule(broker.SurfaceBody)) //nolint:bodyclose // closure return type; resp is nil on the forward path
+
+	req, err := http.NewRequest(http.MethodPost, "https://api.example.com/v1/x", strings.NewReader(`{"k":"__tok__"}`))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp := hook(req) //nolint:bodyclose // nil on the forward path; nothing to close
+	require.Nil(t, resp, "hook must return nil to forward the mutated request")
+	require.Equal(t, int64(1), res.calls.Load())
+
+	got, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	require.Equal(t, `{"k":"sk-real"}`, string(got))
+	require.Equal(t, int64(len(got)), req.ContentLength)
+}
+
+// A per-rule max_body_bytes override takes precedence over the global cap.
+func TestHook_PerRuleCapOverridesGlobal(t *testing.T) {
+	t.Parallel()
+
+	rule := placeholderRule(broker.SurfaceBody)
+	rule.Injection.MaxBodyBytes = 8 // tighter than the generous global below
+
+	res := &fakeResolver{value: "sk-real"}
+	hook := bodySurfaceHook(t, res, 1<<20, rule)
+
+	req, err := http.NewRequest(http.MethodPost, "https://api.example.com/v1/x", strings.NewReader(strings.Repeat("y", 64)))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp := hook(req)
+	require.NotNil(t, resp)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode)
+}
+
+// A rule that declares no body surface must not buffer the body at all: the
+// hook leaves req.Body as the original stream so the proxy streams it upstream.
+func TestHook_NoBodySurface_DoesNotBufferBody(t *testing.T) {
+	t.Parallel()
+
+	res := &fakeResolver{value: "sk-real"}
+	rule := broker.Rule{
+		Host:      "api.example.com",
+		SecretRef: "op://V/I/f",
+		Injection: broker.InjectSpec{Type: broker.InjectHeader, Name: "x-api-key", Template: "{{ CREDENTIAL }}"},
+	}
+	hook := bodySurfaceHook(t, res, 8, rule) //nolint:bodyclose // closure return type; resp is nil on the forward path
+
+	orig := strings.NewReader(strings.Repeat("z", 1000))
+	req, err := http.NewRequest(http.MethodPost, "https://api.example.com/v1/x", orig)
+	require.NoError(t, err)
+
+	resp := hook(req) //nolint:bodyclose // nil on the forward path; nothing to close
+	require.Nil(t, resp, "header-only rule with an oversized body must still forward (body not buffered)")
+	require.Equal(t, "sk-real", req.Header.Get("x-api-key"))
+}

--- a/internal/broker/hook_test.go
+++ b/internal/broker/hook_test.go
@@ -36,7 +36,7 @@ func (f *fakeResolver) Resolve(_ context.Context, vaultID, ref string) (string, 
 func newHookFixture(t *testing.T, rule broker.Rule, res broker.Resolver) func(*http.Request) *http.Response {
 	t.Helper()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	return broker.Hook(broker.NewEngine([]broker.Rule{rule}), res, config.OnNoMatchPassthrough, logger) //nolint:bodyclose // hook is a closure; bodyclose can't trace ownership across return
+	return broker.Hook(broker.NewEngine([]broker.Rule{rule}), res, config.OnNoMatchPassthrough, 0, logger) //nolint:bodyclose // hook is a closure; bodyclose can't trace ownership across return
 }
 
 // closeIfNonNil drains and closes the hook's response body so tests can
@@ -83,7 +83,7 @@ func TestHook_NoMatchBlocksWhenOnNoMatchBlock(t *testing.T) {
 		Host:      "api.anthropic.com",
 		SecretRef: "op://V/I/f",
 		Injection: broker.InjectSpec{Type: broker.InjectHeader, Name: "x-api-key", Template: "{{ CREDENTIAL }}"},
-	}}), res, config.OnNoMatchBlock, nil)
+	}}), res, config.OnNoMatchBlock, 0, nil)
 
 	req, _ := http.NewRequest(http.MethodGet, "https://api.openai.com/v1/models", http.NoBody)
 	resp := hook(req) //nolint:bodyclose // closeIfNonNil below handles the non-nil branch
@@ -227,7 +227,7 @@ func TestHook_NilLoggerDefaultsToNoop(t *testing.T) {
 		Host:      "api.example.com",
 		SecretRef: "op://V/I/f",
 		Injection: broker.InjectSpec{Type: broker.InjectHeader, Name: "x-api-key", Template: "{{ CREDENTIAL }}"},
-	}}), res, config.OnNoMatchPassthrough, nil)
+	}}), res, config.OnNoMatchPassthrough, 0, nil)
 
 	req, _ := http.NewRequest(http.MethodGet, "https://api.example.com/", http.NoBody)
 	resp := hook(req) //nolint:bodyclose // closeIfNonNil below handles the non-nil branch

--- a/internal/broker/inject.go
+++ b/internal/broker/inject.go
@@ -1,17 +1,23 @@
 package broker
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"mime"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 )
 
 // ErrNoPlaceholder is returned by Inject in placeholder mode when the
-// placeholder token is absent from every header value. The rule matched and a
-// credential was resolved, but there is nowhere to put it, so the broker fails
-// closed rather than forward the request to the upstream unauthenticated.
-var ErrNoPlaceholder = errors.New("broker: placeholder token not found in any header")
+// placeholder token is absent from every eligible surface. The rule matched
+// and a credential was resolved, but there is nowhere to put it, so the broker
+// fails closed rather than forward the request to the upstream unauthenticated.
+var ErrNoPlaceholder = errors.New("broker: placeholder token not found on any declared surface")
 
 // ErrNoCredentialPlaceholder is returned by Inject when the rule's template
 // carries no {{ CREDENTIAL }} placeholder. Rendering would then discard the
@@ -24,13 +30,18 @@ var ErrNoCredentialPlaceholder = errors.New("broker: inject template contains no
 
 // ErrEmptyPlaceholderToken is returned by Inject in placeholder mode when the
 // placeholder token (InjectSpec.Name) is empty. An empty token is contained in
-// every header value, so the substitution would smear the credential across
-// every header — including agent-controlled, agent-readable ones — rather than
-// replace a single intended token. The broker fails closed instead. The config
-// validator rejects an empty placeholder name; this is the defense-in-depth
-// backstop for any path (a future caller, or a hot-reload edge) that reaches
-// Inject without that check.
+// every value, so the substitution would smear the credential everywhere
+// rather than replace a single intended token. The broker fails closed
+// instead. The config validator rejects an empty placeholder name; this is the
+// defense-in-depth backstop for any path (a future caller, or a hot-reload
+// edge) that reaches Inject without that check.
 var ErrEmptyPlaceholderToken = errors.New("broker: empty placeholder token")
+
+// ErrHeaderInjection is returned by Inject when the rendered value contains a
+// CR or LF. Splicing such a value into a header would let an attacker inject
+// extra headers or smuggle a second request, so the broker fails closed. The
+// guard covers both inject modes for any surface that writes a raw header.
+var ErrHeaderInjection = errors.New("broker: rendered value contains CR/LF; refusing header injection")
 
 // InjectType selects the strategy used by Rule.Inject. The zero value is
 // invalid and signals an unconfigured rule.
@@ -43,10 +54,29 @@ const (
 	// overriding any value the agent supplied.
 	InjectHeader InjectType = iota + 1
 
-	// InjectPlaceholder finds the placeholder token (InjectSpec.Name) in
-	// every header value and substitutes the rendered template in place.
-	// Body-level substitution is deferred.
+	// InjectPlaceholder finds the placeholder token (InjectSpec.Name) on
+	// every declared surface (InjectSpec.Surfaces) and substitutes the
+	// rendered template in place, with per-surface encoding.
 	InjectPlaceholder
+)
+
+// Surface names a request component placeholder substitution can rewrite. The
+// zero value is invalid. Only InjectPlaceholder consults surfaces.
+type Surface int
+
+// Substitution surfaces recognised by Rule.Inject in placeholder mode.
+const (
+	// SurfaceHeader substitutes the token in header values (the default).
+	SurfaceHeader Surface = iota + 1
+	// SurfaceBody substitutes the token in the request body, with encoding
+	// chosen by Content-Type.
+	SurfaceBody
+	// SurfacePath substitutes the token in the URL path, percent-escaping
+	// the value as a path segment.
+	SurfacePath
+	// SurfaceQuery substitutes the token in the URL query string,
+	// percent-escaping the value as a query component.
+	SurfaceQuery
 )
 
 // InjectSpec describes how a resolved credential is attached to an outbound
@@ -56,6 +86,16 @@ type InjectSpec struct {
 	Type     InjectType
 	Name     string
 	Template string
+
+	// Surfaces lists the request components placeholder mode rewrites. An
+	// empty slice means header-only, preserving pre-surfaces behavior.
+	// Ignored by InjectHeader.
+	Surfaces []Surface
+
+	// MaxBodyBytes is the per-rule override for the request-body buffering
+	// cap. Zero means inherit the proxy-wide default. Consulted by Hook,
+	// not by Inject.
+	MaxBodyBytes int
 }
 
 // Render substitutes the resolved credential into a template. The config
@@ -77,13 +117,22 @@ func hasCredentialPlaceholder(template string) bool {
 	return strings.Contains(template, "{{ CREDENTIAL }}") || strings.Contains(template, "{{CREDENTIAL}}")
 }
 
+// hasCRLF reports whether s contains a carriage return or line feed.
+func hasCRLF(s string) bool {
+	return strings.ContainsAny(s, "\r\n")
+}
+
 // Inject applies the rule's injection spec to req using credential as the
-// secret value. Header mode sets a single header; placeholder mode rewrites
-// every header value that contains the placeholder token, and returns
-// ErrNoPlaceholder when the token is absent from every header so the proxy
-// fails closed instead of forwarding the request unauthenticated. An unknown
-// InjectType is treated as a configuration error: Inject returns an error
-// without mutating req so the proxy can fail closed.
+// secret value. Header mode sets a single header. Placeholder mode rewrites
+// the token across every declared surface (header, body, path, query) with
+// per-surface encoding, and returns ErrNoPlaceholder when the token is absent
+// from every eligible surface so the proxy fails closed instead of forwarding
+// the request unauthenticated. An unknown InjectType is treated as a
+// configuration error: Inject returns an error so the proxy can fail closed.
+//
+// In placeholder mode body substitution reads req.Body; callers that declare
+// the body surface (Hook) must materialize req.Body into an in-memory,
+// size-bounded reader before calling Inject.
 func (r Rule) Inject(req *http.Request, credential string) error {
 	// Guard before mutating anything: a template with no placeholder would
 	// render to a constant and forward the request without the credential.
@@ -93,31 +142,191 @@ func (r Rule) Inject(req *http.Request, credential string) error {
 	}
 	switch r.Injection.Type {
 	case InjectHeader:
-		req.Header.Set(r.Injection.Name, Render(r.Injection.Template, credential))
+		value := Render(r.Injection.Template, credential)
+		if hasCRLF(value) {
+			return ErrHeaderInjection
+		}
+		req.Header.Set(r.Injection.Name, value)
 		return nil
 	case InjectPlaceholder:
-		// An empty token matches the empty substring in every header value, so
-		// the substitution below would smear the credential across every header.
-		// Fail closed rather than leak it.
-		if r.Injection.Name == "" {
-			return ErrEmptyPlaceholderToken
-		}
-		value := Render(r.Injection.Template, credential)
-		substitutions := 0
-		for k, vs := range req.Header {
-			for i, v := range vs {
-				if strings.Contains(v, r.Injection.Name) {
-					vs[i] = strings.ReplaceAll(v, r.Injection.Name, value)
-					substitutions++
-				}
-			}
-			req.Header[k] = vs
-		}
-		if substitutions == 0 {
-			return ErrNoPlaceholder
-		}
-		return nil
+		return r.injectPlaceholder(req, credential)
 	default:
 		return fmt.Errorf("broker: unsupported inject type %d", r.Injection.Type)
+	}
+}
+
+// injectPlaceholder rewrites the placeholder token across the rule's declared
+// surfaces. A surface is "eligible" when it can carry a substitution (a
+// compressed or multipart body is ineligible and forwarded untouched). The
+// match is aggregate: any one eligible surface carrying the token is success.
+// Zero substitutions across one or more eligible surfaces is a fail-closed
+// ErrNoPlaceholder. Zero eligible surfaces (e.g. a body-only rule on a
+// compressed body) forwards the request untouched.
+func (r Rule) injectPlaceholder(req *http.Request, credential string) error {
+	// An empty token matches the empty substring everywhere, smearing the
+	// credential across every value. Fail closed rather than leak it.
+	if r.Injection.Name == "" {
+		return ErrEmptyPlaceholderToken
+	}
+	token := r.Injection.Name
+	value := Render(r.Injection.Template, credential)
+
+	surfaces := r.Injection.Surfaces
+	if len(surfaces) == 0 {
+		surfaces = []Surface{SurfaceHeader}
+	}
+
+	subs, eligible := 0, 0
+	for _, s := range surfaces {
+		switch s {
+		case SurfaceHeader:
+			if hasCRLF(value) {
+				return ErrHeaderInjection
+			}
+			eligible++
+			subs += substituteHeaders(req, token, value)
+		case SurfacePath:
+			eligible++
+			n, err := substitutePath(req, token, value)
+			if err != nil {
+				return err
+			}
+			subs += n
+		case SurfaceQuery:
+			eligible++
+			subs += substituteQuery(req, token, value)
+		case SurfaceBody:
+			n, skipped, err := substituteBody(req, token, value)
+			if err != nil {
+				return err
+			}
+			if !skipped {
+				eligible++
+				subs += n
+			}
+		default:
+			return fmt.Errorf("broker: unsupported surface %d", s)
+		}
+	}
+
+	if eligible > 0 && subs == 0 {
+		return ErrNoPlaceholder
+	}
+	return nil
+}
+
+// substituteHeaders replaces token with value in every header value, returning
+// the number of values rewritten.
+func substituteHeaders(req *http.Request, token, value string) int {
+	subs := 0
+	for k, vs := range req.Header {
+		for i, v := range vs {
+			if strings.Contains(v, token) {
+				vs[i] = strings.ReplaceAll(v, token, value)
+				subs++
+			}
+		}
+		req.Header[k] = vs
+	}
+	return subs
+}
+
+// substitutePath replaces token in the wire-encoded path with a path-escaped
+// value, setting both URL.Path (decoded) and URL.RawPath (encoded) so
+// url.String() emits the substituted form without double-encoding.
+func substitutePath(req *http.Request, token, value string) (int, error) {
+	esc := req.URL.EscapedPath()
+	if !strings.Contains(esc, token) {
+		return 0, nil
+	}
+	newEsc := strings.ReplaceAll(esc, token, url.PathEscape(value))
+	decoded, err := url.PathUnescape(newEsc)
+	if err != nil {
+		return 0, fmt.Errorf("broker: rewrite path: %w", err)
+	}
+	req.URL.Path = decoded
+	req.URL.RawPath = newEsc
+	return strings.Count(esc, token), nil
+}
+
+// substituteQuery replaces token in the raw query string with a
+// query-escaped value.
+func substituteQuery(req *http.Request, token, value string) int {
+	rq := req.URL.RawQuery
+	if !strings.Contains(rq, token) {
+		return 0
+	}
+	req.URL.RawQuery = strings.ReplaceAll(rq, token, url.QueryEscape(value))
+	return strings.Count(rq, token)
+}
+
+// substituteBody replaces token in the request body with a value encoded for
+// the body's Content-Type, then rewrites req.Body and Content-Length. It
+// reports skipped=true (and leaves the body untouched) for bodies it must not
+// rewrite: a compressed body (Content-Encoding set) or a multipart body, which
+// cannot be safely text-spliced. Callers must have materialized req.Body into a
+// bounded in-memory reader first.
+func substituteBody(req *http.Request, token, value string) (subs int, skipped bool, err error) {
+	if req.Body == nil || req.Body == http.NoBody {
+		return 0, false, nil
+	}
+	// A compressed body is opaque bytes; text substitution would corrupt it.
+	if ce := req.Header.Get("Content-Encoding"); ce != "" && !strings.EqualFold(ce, "identity") {
+		return 0, true, nil
+	}
+	mediaType := parseMediaType(req.Header.Get("Content-Type"))
+	if strings.HasPrefix(mediaType, "multipart/") {
+		return 0, true, nil
+	}
+
+	raw, err := io.ReadAll(req.Body)
+	if err != nil {
+		return 0, false, fmt.Errorf("broker: read body: %w", err)
+	}
+	body := string(raw)
+	if !strings.Contains(body, token) {
+		// Restore the buffer so the unmodified body still forwards.
+		req.Body = io.NopCloser(bytes.NewReader(raw))
+		req.ContentLength = int64(len(raw))
+		return 0, false, nil
+	}
+
+	newBody := strings.ReplaceAll(body, token, encodeBodyValue(mediaType, value))
+	req.Body = io.NopCloser(strings.NewReader(newBody))
+	req.ContentLength = int64(len(newBody))
+	req.Header.Set("Content-Length", strconv.Itoa(len(newBody)))
+	return strings.Count(body, token), false, nil
+}
+
+// parseMediaType returns the lowercased media type from a Content-Type header,
+// dropping parameters. A malformed header yields "" (treated as raw).
+func parseMediaType(ct string) string {
+	if ct == "" {
+		return ""
+	}
+	mt, _, err := mime.ParseMediaType(ct)
+	if err != nil {
+		return ""
+	}
+	return mt
+}
+
+// encodeBodyValue encodes value for splicing into a body of the given media
+// type: form values are query-escaped, JSON values are JSON-string-escaped,
+// everything else is spliced raw.
+func encodeBodyValue(mediaType, value string) string {
+	switch mediaType {
+	case "application/x-www-form-urlencoded":
+		return url.QueryEscape(value)
+	case "application/json":
+		// json.Marshal of a string yields a quoted, fully-escaped JSON
+		// string; strip the surrounding quotes to get the escaped contents.
+		b, err := json.Marshal(value)
+		if err != nil || len(b) < 2 {
+			return value
+		}
+		return string(b[1 : len(b)-1])
+	default:
+		return value
 	}
 }

--- a/internal/broker/inject_surfaces_test.go
+++ b/internal/broker/inject_surfaces_test.go
@@ -1,0 +1,237 @@
+package broker_test
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mmartinez/postern/internal/broker"
+)
+
+// placeholderRule builds a placeholder-mode rule over the given surfaces with
+// the canonical token + identity template, the shape every surface test reuses.
+func placeholderRule(surfaces ...broker.Surface) broker.Rule {
+	return broker.Rule{
+		Host:      "api.example.com",
+		SecretRef: "op://V/I/f",
+		Injection: broker.InjectSpec{
+			Type:     broker.InjectPlaceholder,
+			Name:     "__tok__",
+			Template: "{{ CREDENTIAL }}",
+			Surfaces: surfaces,
+		},
+	}
+}
+
+func reqWithBody(t *testing.T, method, rawURL, contentType, body string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(method, rawURL, strings.NewReader(body))
+	require.NoError(t, err)
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	return req
+}
+
+func readBody(t *testing.T, req *http.Request) string {
+	t.Helper()
+	b, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	return string(b)
+}
+
+func TestInjectPlaceholder_Path_EscapesValue(t *testing.T) {
+	t.Parallel()
+
+	r := placeholderRule(broker.SurfacePath)
+	req, err := http.NewRequest(http.MethodGet, "https://api.example.com/v1/__tok__/models", http.NoBody)
+	require.NoError(t, err)
+
+	require.NoError(t, r.Inject(req, "a/b c"))
+
+	// url.PathEscape("a/b c") == "a%2Fb%20c"; both Path (decoded) and RawPath
+	// (encoded) must be set so url.String() doesn't double-encode.
+	require.Equal(t, "/v1/a%2Fb%20c/models", req.URL.EscapedPath())
+	require.Equal(t, "/v1/a%2Fb%20c/models", req.URL.RawPath)
+	require.Equal(t, "/v1/a/b c/models", req.URL.Path)
+	require.Equal(t, "/v1/a%2Fb%20c/models", req.URL.RequestURI())
+}
+
+func TestInjectPlaceholder_Query_EscapesValue(t *testing.T) {
+	t.Parallel()
+
+	r := placeholderRule(broker.SurfaceQuery)
+	req, err := http.NewRequest(http.MethodGet, "https://api.example.com/v1/models?key=__tok__&x=1", http.NoBody)
+	require.NoError(t, err)
+
+	require.NoError(t, r.Inject(req, "a b&c"))
+
+	// url.QueryEscape("a b&c") == "a+b%26c".
+	require.Equal(t, "key=a+b%26c&x=1", req.URL.RawQuery)
+}
+
+func TestInjectPlaceholder_Body_JSONEscaped(t *testing.T) {
+	t.Parallel()
+
+	r := placeholderRule(broker.SurfaceBody)
+	req := reqWithBody(t, http.MethodPost, "https://api.example.com/v1/x", "application/json", `{"api_key":"__tok__"}`)
+
+	require.NoError(t, r.Inject(req, `he said "hi"`+"\n"))
+
+	got := readBody(t, req)
+	require.Equal(t, `{"api_key":"he said \"hi\"\n"}`, got)
+	require.Equal(t, int64(len(got)), req.ContentLength)
+	require.Equal(t, "30", req.Header.Get("Content-Length"))
+}
+
+func TestInjectPlaceholder_Body_FormURLEncoded(t *testing.T) {
+	t.Parallel()
+
+	r := placeholderRule(broker.SurfaceBody)
+	req := reqWithBody(t, http.MethodPost, "https://api.example.com/v1/x", "application/x-www-form-urlencoded", "grant=__tok__&y=2")
+
+	require.NoError(t, r.Inject(req, "a b&c"))
+
+	require.Equal(t, "grant=a+b%26c&y=2", readBody(t, req))
+}
+
+func TestInjectPlaceholder_Body_RawForUnknownContentType(t *testing.T) {
+	t.Parallel()
+
+	r := placeholderRule(broker.SurfaceBody)
+	req := reqWithBody(t, http.MethodPost, "https://api.example.com/v1/x", "text/plain", "secret=__tok__")
+
+	require.NoError(t, r.Inject(req, "p l a i n"))
+
+	require.Equal(t, "secret=p l a i n", readBody(t, req))
+}
+
+// A multipart body is forwarded unmodified: postern cannot safely text-splice
+// across MIME part boundaries. With body as the only surface and nothing to
+// substitute, Inject returns nil (forward untouched), not ErrNoPlaceholder.
+func TestInjectPlaceholder_Body_MultipartSkipped(t *testing.T) {
+	t.Parallel()
+
+	const body = "--x\r\nContent-Disposition: form-data; name=\"k\"\r\n\r\n__tok__\r\n--x--\r\n"
+	r := placeholderRule(broker.SurfaceBody)
+	req := reqWithBody(t, http.MethodPost, "https://api.example.com/v1/x", "multipart/form-data; boundary=x", body)
+
+	require.NoError(t, r.Inject(req, "sk-real"))
+	require.Equal(t, body, readBody(t, req), "multipart body must be forwarded byte-for-byte")
+}
+
+// A compressed body (Content-Encoding set) is forwarded unmodified: postern
+// cannot text-substitute into a compressed payload.
+func TestInjectPlaceholder_Body_CompressedSkipped(t *testing.T) {
+	t.Parallel()
+
+	const body = "this looks like __tok__ but is gzip bytes"
+	r := placeholderRule(broker.SurfaceBody)
+	req := reqWithBody(t, http.MethodPost, "https://api.example.com/v1/x", "application/json", body)
+	req.Header.Set("Content-Encoding", "gzip")
+
+	require.NoError(t, r.Inject(req, "sk-real"))
+	require.Equal(t, body, readBody(t, req), "compressed body must be forwarded byte-for-byte")
+}
+
+// A rendered value carrying CR/LF must never be spliced into a header value:
+// that is request smuggling / header injection. Fail closed, leave headers be.
+func TestInjectPlaceholder_Header_RejectsCRLF(t *testing.T) {
+	t.Parallel()
+
+	r := placeholderRule(broker.SurfaceHeader)
+	req, err := http.NewRequest(http.MethodGet, "https://api.example.com/v1", http.NoBody)
+	require.NoError(t, err)
+	req.Header.Set("x-api-key", "__tok__")
+
+	injErr := r.Inject(req, "evil\r\nX-Injected: 1")
+	require.ErrorIs(t, injErr, broker.ErrHeaderInjection)
+	require.Equal(t, "__tok__", req.Header.Get("x-api-key"), "header must be untouched on fail closed")
+}
+
+// Header inject mode (type: header) must also reject a CR/LF-bearing value.
+func TestInjectHeader_RejectsCRLF(t *testing.T) {
+	t.Parallel()
+
+	r := broker.Rule{
+		Host: "api.example.com",
+		Injection: broker.InjectSpec{
+			Type:     broker.InjectHeader,
+			Name:     "authorization",
+			Template: "Bearer {{ CREDENTIAL }}",
+		},
+	}
+	req, err := http.NewRequest(http.MethodGet, "https://api.example.com/v1", http.NoBody)
+	require.NoError(t, err)
+
+	require.ErrorIs(t, r.Inject(req, "tok\nevil"), broker.ErrHeaderInjection)
+	require.Empty(t, req.Header.Get("authorization"))
+}
+
+// Aggregate match: with several surfaces declared, a token found on any one of
+// them is success. Here the token is only in the query; the header carries no
+// token and must be left untouched.
+func TestInjectPlaceholder_MultiSurface_AnyMatchSucceeds(t *testing.T) {
+	t.Parallel()
+
+	r := placeholderRule(broker.SurfaceHeader, broker.SurfaceQuery)
+	req, err := http.NewRequest(http.MethodGet, "https://api.example.com/v1?key=__tok__", http.NoBody)
+	require.NoError(t, err)
+	req.Header.Set("x-trace", "no-token-here")
+
+	require.NoError(t, r.Inject(req, "sk-real"))
+	require.Equal(t, "key=sk-real", req.URL.RawQuery)
+	require.Equal(t, "no-token-here", req.Header.Get("x-trace"))
+}
+
+// A declared surface with the token nowhere on any eligible surface fails
+// closed so the hook returns 502 rather than forward unauthenticated.
+func TestInjectPlaceholder_NoTokenOnDeclaredSurface_FailsClosed(t *testing.T) {
+	t.Parallel()
+
+	r := placeholderRule(broker.SurfaceQuery)
+	req, err := http.NewRequest(http.MethodGet, "https://api.example.com/v1?key=value", http.NoBody)
+	require.NoError(t, err)
+
+	require.ErrorIs(t, r.Inject(req, "sk-real"), broker.ErrNoPlaceholder)
+	require.Equal(t, "key=value", req.URL.RawQuery, "query must be untouched on fail closed")
+}
+
+// Empty surfaces default to header-only, preserving pre-#17 behavior.
+func TestInjectPlaceholder_EmptySurfacesDefaultsToHeader(t *testing.T) {
+	t.Parallel()
+
+	r := placeholderRule() // no surfaces
+	req, err := http.NewRequest(http.MethodGet, "https://api.example.com/v1", http.NoBody)
+	require.NoError(t, err)
+	req.Header.Set("x-api-key", "__tok__")
+
+	require.NoError(t, r.Inject(req, "sk-real"))
+	require.Equal(t, "sk-real", req.Header.Get("x-api-key"))
+}
+
+func TestInjectPlaceholder_UnknownSurface_Errors(t *testing.T) {
+	t.Parallel()
+
+	r := placeholderRule(broker.Surface(0))
+	req, err := http.NewRequest(http.MethodGet, "https://api.example.com/v1", http.NoBody)
+	require.NoError(t, err)
+
+	require.Error(t, r.Inject(req, "sk-real"))
+}
+
+// Compile-time anchor: surface constants are distinct values.
+func TestSurfaceConstants_Distinct(t *testing.T) {
+	t.Parallel()
+
+	all := []broker.Surface{broker.SurfaceHeader, broker.SurfaceBody, broker.SurfacePath, broker.SurfaceQuery}
+	seen := map[broker.Surface]bool{}
+	for _, s := range all {
+		require.False(t, seen[s], "surface value %d duplicated", s)
+		seen[s] = true
+	}
+	require.Len(t, seen, 4)
+}

--- a/internal/broker/integration_surfaces_test.go
+++ b/internal/broker/integration_surfaces_test.go
@@ -1,0 +1,196 @@
+package broker_test
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mmartinez/postern/internal/broker"
+	"github.com/mmartinez/postern/internal/config"
+	"github.com/mmartinez/postern/internal/proxy"
+)
+
+// surfaceProxy stands up the full MITM path (CA + minter + goproxy + broker
+// hook + fake resolver) against upstream, returning a client that talks
+// through the proxy. maxBodyBytes is the global body cap passed to the hook.
+func surfaceProxy(t *testing.T, upstream *httptest.Server, rule broker.Rule, value string, maxBodyBytes int) (*http.Client, *fakeResolver) {
+	t.Helper()
+	root := fixtureCA(t)
+	minter := fixtureMinter(t, root)
+	res := &fakeResolver{value: value}
+	hook := broker.Hook(broker.NewEngine([]broker.Rule{rule}), res, config.OnNoMatchPassthrough, maxBodyBytes, slog.New(slog.NewTextHandler(io.Discard, nil))) //nolint:bodyclose // synthetic body; goproxy closes it after writing to the client
+
+	p, err := proxy.New(proxy.Config{
+		CA:                 root,
+		Minter:             minter,
+		Logger:             slog.New(slog.NewTextHandler(io.Discard, nil)),
+		UpstreamTLS:        upstreamTLS(t, upstream),
+		PreUpstreamHandler: hook,
+	})
+	require.NoError(t, err)
+	return clientThroughProxy(t, startProxy(t, p), root), res
+}
+
+func surfaceRule(surfaces ...broker.Surface) broker.Rule {
+	return broker.Rule{
+		Host:      "127.0.0.1",
+		SecretRef: "op://Agents/X/api_key",
+		Injection: broker.InjectSpec{
+			Type:     broker.InjectPlaceholder,
+			Name:     "__tok__",
+			Template: "{{ CREDENTIAL }}",
+			Surfaces: surfaces,
+		},
+	}
+}
+
+// E2E: a placeholder in a JSON body arrives at the upstream JSON-escaped. The
+// resolver value carries a double quote, so a raw splice would corrupt the
+// JSON; correct escaping makes it decode back to the original value.
+func TestE2E_BodySubstitution_JSONEscaped(t *testing.T) {
+	t.Parallel()
+
+	const value = `sk"x`
+	var hits atomic.Int64
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+		hits.Add(1)
+		body, _ := io.ReadAll(req.Body)
+		var got map[string]string
+		require.NoError(t, json.Unmarshal(body, &got), "upstream body must be valid JSON")
+		require.Equal(t, value, got["api_key"], "JSON-escaped placeholder must decode to the resolved value")
+	}))
+	t.Cleanup(upstream.Close)
+
+	client, res := surfaceProxy(t, upstream, surfaceRule(broker.SurfaceBody), value, 1<<20)
+	resp, err := client.Post(upstream.URL+"/v1/x", "application/json", strings.NewReader(`{"api_key":"__tok__"}`))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, int64(1), hits.Load())
+	require.Equal(t, int64(1), res.calls.Load())
+}
+
+// E2E: a placeholder in the URL path arrives path-escaped. The value contains a
+// slash, which must reach the upstream as %2F (one segment), not a raw "/".
+func TestE2E_PathSubstitution_PathEscaped(t *testing.T) {
+	t.Parallel()
+
+	const value = "a/b"
+	var hits atomic.Int64
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+		hits.Add(1)
+		require.Contains(t, req.RequestURI, "/v1/a%2Fb/models", "path value must arrive percent-escaped")
+	}))
+	t.Cleanup(upstream.Close)
+
+	client, _ := surfaceProxy(t, upstream, surfaceRule(broker.SurfacePath), value, 1<<20)
+	resp, err := client.Get(upstream.URL + "/v1/__tok__/models")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, int64(1), hits.Load())
+}
+
+// E2E: a placeholder in the query string arrives query-escaped. The value
+// contains a space and an ampersand; correct escaping keeps it a single param.
+func TestE2E_QuerySubstitution_QueryEscaped(t *testing.T) {
+	t.Parallel()
+
+	const value = "a b&c"
+	var hits atomic.Int64
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+		hits.Add(1)
+		require.Equal(t, value, req.URL.Query().Get("key"), "query value must round-trip through escaping")
+	}))
+	t.Cleanup(upstream.Close)
+
+	client, _ := surfaceProxy(t, upstream, surfaceRule(broker.SurfaceQuery), value, 1<<20)
+	resp, err := client.Get(upstream.URL + "/v1/models?key=__tok__")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, int64(1), hits.Load())
+}
+
+// E2E: a body over the cap is rejected with 413 and the upstream is never
+// contacted (and the resolver is never called).
+func TestE2E_BodyOverCap_413_UpstreamNotContacted(t *testing.T) {
+	t.Parallel()
+
+	var hits atomic.Int64
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+	}))
+	t.Cleanup(upstream.Close)
+
+	client, res := surfaceProxy(t, upstream, surfaceRule(broker.SurfaceBody), "sk-real", 16)
+	resp, err := client.Post(upstream.URL+"/v1/x", "application/json", strings.NewReader(strings.Repeat("x", 256)))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode)
+	require.Zero(t, hits.Load(), "upstream must not be contacted for an oversized body")
+	require.Zero(t, res.calls.Load(), "resolver must not be called for an oversized body")
+}
+
+// E2E: a compressed body (Content-Encoding set) is forwarded byte-for-byte; the
+// proxy cannot text-substitute into opaque compressed bytes.
+func TestE2E_CompressedBody_ForwardedUnmodified(t *testing.T) {
+	t.Parallel()
+
+	const sent = `{"api_key":"__tok__"}`
+	var hits atomic.Int64
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+		hits.Add(1)
+		body, _ := io.ReadAll(req.Body)
+		require.Equal(t, sent, string(body), "compressed body must be forwarded unmodified")
+	}))
+	t.Cleanup(upstream.Close)
+
+	client, _ := surfaceProxy(t, upstream, surfaceRule(broker.SurfaceBody), "sk-real", 1<<20)
+	req, err := http.NewRequest(http.MethodPost, upstream.URL+"/v1/x", strings.NewReader(sent))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "gzip") // not really gzip; postern must not touch it
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, int64(1), hits.Load())
+}
+
+// E2E: a multipart body is forwarded byte-for-byte.
+func TestE2E_MultipartBody_ForwardedUnmodified(t *testing.T) {
+	t.Parallel()
+
+	const sent = "--x\r\nContent-Disposition: form-data; name=\"k\"\r\n\r\n__tok__\r\n--x--\r\n"
+	var hits atomic.Int64
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+		hits.Add(1)
+		body, _ := io.ReadAll(req.Body)
+		require.Equal(t, sent, string(body), "multipart body must be forwarded unmodified")
+	}))
+	t.Cleanup(upstream.Close)
+
+	client, _ := surfaceProxy(t, upstream, surfaceRule(broker.SurfaceBody), "sk-real", 1<<20)
+	req, err := http.NewRequest(http.MethodPost, upstream.URL+"/v1/x", strings.NewReader(sent))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "multipart/form-data; boundary=x")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, int64(1), hits.Load())
+}

--- a/internal/broker/integration_test.go
+++ b/internal/broker/integration_test.go
@@ -56,7 +56,7 @@ func TestE2E_BrokerInjectsHeaderThroughMITMProxy(t *testing.T) {
 		},
 	}})
 	res := &fakeResolver{value: "sk-from-resolver"}
-	hook := broker.Hook(engine, res, config.OnNoMatchPassthrough, slog.New(slog.NewTextHandler(io.Discard, nil))) //nolint:bodyclose // synthetic body; goproxy closes it after writing to the client
+	hook := broker.Hook(engine, res, config.OnNoMatchPassthrough, 0, slog.New(slog.NewTextHandler(io.Discard, nil))) //nolint:bodyclose // synthetic body; goproxy closes it after writing to the client
 
 	p, err := proxy.New(proxy.Config{
 		CA:                 root,
@@ -107,7 +107,7 @@ func TestE2E_ResolverErrorReturns502_UpstreamNotContacted(t *testing.T) {
 		},
 	}})
 	res := &fakeResolver{err: errors.New("token revoked")}
-	hook := broker.Hook(engine, res, config.OnNoMatchPassthrough, slog.New(slog.NewTextHandler(io.Discard, nil))) //nolint:bodyclose // synthetic body; goproxy closes it after writing to the client
+	hook := broker.Hook(engine, res, config.OnNoMatchPassthrough, 0, slog.New(slog.NewTextHandler(io.Discard, nil))) //nolint:bodyclose // synthetic body; goproxy closes it after writing to the client
 
 	p, err := proxy.New(proxy.Config{
 		CA:                 root,
@@ -156,7 +156,7 @@ func TestE2E_OnNoMatchBlock_UpstreamNotContacted(t *testing.T) {
 		},
 	}})
 	res := &fakeResolver{value: "sk-from-resolver"}
-	hook := broker.Hook(engine, res, config.OnNoMatchBlock, slog.New(slog.NewTextHandler(io.Discard, nil))) //nolint:bodyclose // synthetic body; goproxy closes it after writing to the client
+	hook := broker.Hook(engine, res, config.OnNoMatchBlock, 0, slog.New(slog.NewTextHandler(io.Discard, nil))) //nolint:bodyclose // synthetic body; goproxy closes it after writing to the client
 
 	p, err := proxy.New(proxy.Config{
 		CA:                 root,

--- a/internal/broker/redteam_failopen_test.go
+++ b/internal/broker/redteam_failopen_test.go
@@ -59,7 +59,7 @@ func TestRedTeam_NoPlaceholderTemplate_FailsClosed(t *testing.T) {
 		Injection: broker.InjectSpec{Type: broker.InjectHeader, Name: "authorization", Template: "Bearer "},
 	}})
 	res := &fakeResolver{value: "sk-the-real-secret"}
-	hook := broker.Hook(engine, res, config.OnNoMatchPassthrough, slog.New(slog.NewTextHandler(io.Discard, nil))) //nolint:bodyclose // synthetic body
+	hook := broker.Hook(engine, res, config.OnNoMatchPassthrough, 0, slog.New(slog.NewTextHandler(io.Discard, nil))) //nolint:bodyclose // synthetic body
 
 	p, err := proxy.New(proxy.Config{
 		CA:                 root,
@@ -97,8 +97,8 @@ func TestRedTeam_EmptyResolvedCredential_FailsClosed(t *testing.T) {
 		SecretRef: "op://V/I/f",
 		Injection: broker.InjectSpec{Type: broker.InjectHeader, Name: "authorization", Template: "Bearer {{ CREDENTIAL }}"},
 	}})
-	res := &fakeResolver{value: ""}                                                                               // resolver returns empty, no error
-	hook := broker.Hook(engine, res, config.OnNoMatchPassthrough, slog.New(slog.NewTextHandler(io.Discard, nil))) //nolint:bodyclose // synthetic body
+	res := &fakeResolver{value: ""}                                                                                  // resolver returns empty, no error
+	hook := broker.Hook(engine, res, config.OnNoMatchPassthrough, 0, slog.New(slog.NewTextHandler(io.Discard, nil))) //nolint:bodyclose // synthetic body
 
 	p, err := proxy.New(proxy.Config{
 		CA:                 root,
@@ -142,11 +142,11 @@ func TestRedTeam_FailClosedBodyIsUniform(t *testing.T) {
 	// Stage A: resolver error.
 	hookResolveErr := broker.Hook(broker.NewEngine([]broker.Rule{rule}), //nolint:bodyclose // synthetic body
 		&fakeResolver{err: errors.New("token revoked")},
-		config.OnNoMatchPassthrough, slog.New(slog.NewTextHandler(io.Discard, nil)))
+		config.OnNoMatchPassthrough, 0, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	// Stage B: insecure transport (plain http) for a matched host.
 	hookTransport := broker.Hook(broker.NewEngine([]broker.Rule{rule}), //nolint:bodyclose // synthetic body
 		&fakeResolver{value: "sk"},
-		config.OnNoMatchPassthrough, slog.New(slog.NewTextHandler(io.Discard, nil)))
+		config.OnNoMatchPassthrough, 0, slog.New(slog.NewTextHandler(io.Discard, nil)))
 
 	reqHTTPS, _ := http.NewRequest(http.MethodGet, "https://api.example.com/v1", http.NoBody)
 	reqHTTP, _ := http.NewRequest(http.MethodGet, "http://api.example.com/v1", http.NoBody)

--- a/internal/broker/reloader.go
+++ b/internal/broker/reloader.go
@@ -113,6 +113,12 @@ func warnDriftedFields(reloaded *config.Config, baseline Baseline, logger *slog.
 			slog.String("reason", "on_no_match is bound at startup; restart postern to apply"),
 		)
 	}
+	if reloaded.Proxy.MaxBodyBytes != baseline.Proxy.MaxBodyBytes {
+		logger.Warn("config edit ignored",
+			slog.String("field", "proxy.max_body_bytes"),
+			slog.String("reason", "the proxy-wide body cap is bound at startup; restart postern to apply (per-rule inject.max_body_bytes hot-reloads)"),
+		)
+	}
 	if !credStoresEqual(reloaded.CredStores, baseline.CredStores) {
 		logger.Warn("config edit ignored",
 			slog.String("field", "credstores"),

--- a/internal/broker/reloader_test.go
+++ b/internal/broker/reloader_test.go
@@ -270,6 +270,62 @@ func TestRunReloader_WarnsOnBaselineDrift(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond, "expected a Warn about cache_ttl drift; got %s", logBuf.String())
 }
 
+// TestRunReloader_WarnsOnMaxBodyBytesDrift confirms that editing the
+// proxy-wide body cap (bound at startup, captured in the hook closure) trips a
+// restart warning, mirroring the other boot-bound proxy fields.
+func TestRunReloader_WarnsOnMaxBodyBytesDrift(t *testing.T) {
+	t.Parallel()
+
+	engine := broker.NewEngine(nil)
+	logBuf := &syncBuffer{}
+	logger := slog.New(slog.NewJSONHandler(logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	baseline := &broker.Baseline{
+		Proxy: config.Proxy{
+			Listen:       "127.0.0.1:1701",
+			CacheTTL:     15 * time.Minute,
+			OnNoMatch:    config.OnNoMatchPassthrough,
+			MaxBodyBytes: 1 << 20,
+		},
+		CredStores: []config.CredStore{{
+			Name:  config.DefaultCredStoreName,
+			Token: config.Token{Source: config.TokenSourceAuto, EnvVar: "OP_SERVICE_ACCOUNT_TOKEN"},
+		}},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	events := make(chan config.Event, 1)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		broker.RunReloader(ctx, engine, events, logger, baseline)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		close(events)
+		wg.Wait()
+	})
+
+	events <- config.Event{
+		New: &config.Config{
+			Proxy: config.Proxy{
+				Listen:       "127.0.0.1:1701",
+				CacheTTL:     15 * time.Minute,
+				OnNoMatch:    config.OnNoMatchPassthrough,
+				MaxBodyBytes: 8 << 20,
+			},
+			CredStores: baseline.CredStores,
+		},
+	}
+
+	require.Eventually(t, func() bool {
+		s := logBuf.String()
+		return strings.Contains(s, "config edit ignored") && strings.Contains(s, "max_body_bytes")
+	}, 2*time.Second, 10*time.Millisecond, "expected a Warn about max_body_bytes drift; got %s", logBuf.String())
+}
+
 // TestRunReloader_DoesNotWarnOnCredStoreReorder confirms that a cosmetic
 // reorder of `credstores:` entries in YAML (semantically a no-op) does
 // not trip the drift warning. Order-sensitivity here trains operators

--- a/internal/broker/rule.go
+++ b/internal/broker/rule.go
@@ -25,6 +25,21 @@ type Rule struct {
 	Injection InjectSpec
 }
 
+// usesBodySurface reports whether the rule rewrites the request body. The hook
+// uses this to decide whether to buffer (and size-bound) the body before
+// injecting; rules that don't touch the body stream their bodies untouched.
+func (r Rule) usesBodySurface() bool {
+	if r.Injection.Type != InjectPlaceholder {
+		return false
+	}
+	for _, s := range r.Injection.Surfaces {
+		if s == SurfaceBody {
+			return true
+		}
+	}
+	return false
+}
+
 // Match reports whether the rule's host pattern matches host. Comparison is
 // case-insensitive (DNS hostnames are case-insensitive per RFC 4343). The
 // glob form follows TLS-wildcard semantics: "*" matches exactly one DNS

--- a/internal/cli/rules.go
+++ b/internal/cli/rules.go
@@ -90,7 +90,8 @@ func writeRulesTable(out io.Writer, rules []config.Rule) error {
 		}
 		return w.Flush()
 	}
-	for _, r := range rules {
+	for i := range rules {
+		r := rules[i]
 		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
 			r.Host, r.SecretRef, r.Inject.Type, r.Inject.Name, r.Inject.Template,
 		); err != nil {
@@ -116,7 +117,8 @@ type injectJSON struct {
 
 func writeRulesJSON(out io.Writer, rules []config.Rule) error {
 	jr := make([]ruleJSON, len(rules))
-	for i, r := range rules {
+	for i := range rules {
+		r := rules[i]
 		jr[i] = ruleJSON{
 			Host:      r.Host,
 			SecretRef: r.SecretRef,

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -254,7 +254,7 @@ func buildBrokerHook(ctx context.Context, reg *credstore.Registry, cfgPath strin
 		slog.Duration("cache_ttl", cfg.Proxy.CacheTTL),
 	)
 	return brokerBundle{
-		hook:    broker.Hook(engine, cached, cfg.Proxy.OnNoMatch, logger), //nolint:bodyclose // hook is a closure; broker owns the synthetic body
+		hook:    broker.Hook(engine, cached, cfg.Proxy.OnNoMatch, cfg.Proxy.MaxBodyBytes, logger), //nolint:bodyclose // hook is a closure; broker owns the synthetic body
 		engine:  engine,
 		cfgPath: cfgPath,
 		listen:  cfg.Proxy.Listen,

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -80,7 +80,8 @@ func ValidateProviders(cfg *Config, root *yaml.Node, facts ProviderFacts) []Lint
 	}
 
 	if facts.ConfiguredSchemes != nil {
-		for i, r := range cfg.Rules {
+		for i := range cfg.Rules {
+			r := cfg.Rules[i]
 			scheme, _, ok := strings.Cut(r.SecretRef, "://")
 			if !ok || scheme == "" {
 				// Malformed refs are already flagged by the schema validator;

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -41,6 +41,23 @@ const (
 	InjectTypePlaceholder InjectType = "placeholder"
 )
 
+// InjectSurface names a request component placeholder substitution can rewrite.
+// Surfaces are opt-in per rule via inject.in; the default is header-only.
+type InjectSurface string
+
+// Injection surface values accepted in YAML.
+const (
+	InjectSurfaceHeader InjectSurface = "header"
+	InjectSurfaceBody   InjectSurface = "body"
+	InjectSurfacePath   InjectSurface = "path"
+	InjectSurfaceQuery  InjectSurface = "query"
+)
+
+// DefaultMaxBodyBytes is the proxy-wide body buffering cap used when
+// proxy.max_body_bytes is unset (or non-positive). A request body that a
+// body-rewriting rule would buffer beyond this size is rejected with 413.
+const DefaultMaxBodyBytes = 1 << 20 // 1 MiB
+
 // Config is the root of the YAML schema (~/.postern/config.yaml).
 //
 // Two top-level credential-vendor shapes are accepted, but only one at a
@@ -127,6 +144,12 @@ type Proxy struct {
 	Listen    string        `yaml:"listen"`
 	CacheTTL  time.Duration `yaml:"cache_ttl"`
 	OnNoMatch OnNoMatch     `yaml:"on_no_match"`
+
+	// MaxBodyBytes caps how much of a request body postern buffers when a
+	// rule rewrites the body (inject.in includes "body"). Zero means use
+	// DefaultMaxBodyBytes. A body larger than the cap is rejected with 413.
+	// Bound at startup; a hot-reload edit warns and does not take effect.
+	MaxBodyBytes int `yaml:"max_body_bytes,omitempty"`
 }
 
 // DefaultListenAddr is the loopback bind postern uses when no listen address
@@ -153,4 +176,14 @@ type Inject struct {
 	Type     InjectType `yaml:"type"`
 	Name     string     `yaml:"name,omitempty"`
 	Template string     `yaml:"template"`
+
+	// In lists the request surfaces placeholder mode rewrites (any subset of
+	// header, body, path, query). Empty means header-only. Valid only with
+	// type: placeholder.
+	In []InjectSurface `yaml:"in,omitempty"`
+
+	// MaxBodyBytes overrides proxy.max_body_bytes for this rule's body
+	// buffering. Zero means inherit the proxy-wide cap. Meaningful only when
+	// In includes "body".
+	MaxBodyBytes *int `yaml:"max_body_bytes,omitempty"`
 }

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -48,6 +48,12 @@ func (e LintError) Error() string {
 // editing the config validator.
 var secretRefPattern = regexp.MustCompile(`^[a-z][a-z0-9+.\-]*://.+$`)
 
+// unreservedTokenPattern matches a placeholder token built only from RFC 3986
+// unreserved characters. Such a token survives URL path/query escaping
+// unchanged, so its encoded and decoded forms are identical — a prerequisite
+// for stable substitution outside header values.
+var unreservedTokenPattern = regexp.MustCompile(`^[A-Za-z0-9._~-]+$`)
+
 // Validate walks cfg and returns the slice of findings. Root is the AST from
 // Load and supplies line numbers; pass nil to skip location info.
 func Validate(cfg *Config, root *yaml.Node) []LintError {
@@ -112,6 +118,9 @@ func (v *validator) checkProxy(p *Proxy) {
 	default:
 		v.add("proxy.on_no_match", fmt.Sprintf("invalid on_no_match value %q (want passthrough|block)", p.OnNoMatch), SeverityError)
 	}
+	if p.MaxBodyBytes < 0 {
+		v.add("proxy.max_body_bytes", fmt.Sprintf("max_body_bytes must be >= 0 (got %d); 0 means use the default", p.MaxBodyBytes), SeverityError)
+	}
 }
 
 // checkCredStores enforces the multi-credstore form's structural rules:
@@ -147,7 +156,8 @@ func (v *validator) checkCredStores(cs []CredStore) {
 
 func (v *validator) checkRulesSkipping(rules []Rule, skip map[int]struct{}) {
 	seenHosts := make(map[string]int, len(rules))
-	for i, r := range rules {
+	for i := range rules {
+		r := rules[i]
 		if _, skipRule := skip[i]; skipRule {
 			continue
 		}
@@ -205,6 +215,48 @@ func (v *validator) checkInject(base string, in Inject) {
 		// unauthenticated — a silent fail-open. Reject it at validate time so the
 		// proxy never boots (or hot-reloads) into that state.
 		v.add(base+".template", "template must contain a {{ CREDENTIAL }} placeholder; without it the resolved credential is discarded and the request is forwarded unauthenticated", SeverityError)
+	}
+
+	v.checkInjectSurfaces(base, in)
+}
+
+// checkInjectSurfaces validates the per-rule substitution surface list and its
+// dependent fields. Surfaces are valid only in placeholder mode; substituting
+// outside headers tightens the token charset and brings the body-buffering cap
+// into play.
+func (v *validator) checkInjectSurfaces(base string, in Inject) {
+	if len(in.In) > 0 && in.Type != InjectTypePlaceholder {
+		v.add(base+".in", "inject.in is valid only with inject.type=placeholder", SeverityError)
+		return
+	}
+
+	hasNonHeader, hasBody := false, false
+	for _, s := range in.In {
+		switch s {
+		case InjectSurfaceHeader:
+		case InjectSurfaceBody:
+			hasNonHeader, hasBody = true, true
+		case InjectSurfacePath, InjectSurfaceQuery:
+			hasNonHeader = true
+		default:
+			v.add(base+".in", fmt.Sprintf("invalid surface %q (want any of header|body|path|query)", s), SeverityError)
+		}
+	}
+
+	// Outside header values the token is percent-escaped; a token containing
+	// reserved characters would not round-trip, so restrict it to the RFC 3986
+	// unreserved set. Header-only rules keep the looser charset for back-compat.
+	if hasNonHeader && in.Name != "" && !unreservedTokenPattern.MatchString(in.Name) {
+		v.add(base+".name", "placeholder token must use only RFC 3986 unreserved characters (A-Z a-z 0-9 - . _ ~) when substituting outside headers", SeverityError)
+	}
+
+	if in.MaxBodyBytes != nil {
+		if *in.MaxBodyBytes < 0 {
+			v.add(base+".max_body_bytes", fmt.Sprintf("max_body_bytes must be >= 0 (got %d); 0 means inherit proxy.max_body_bytes", *in.MaxBodyBytes), SeverityError)
+		}
+		if !hasBody {
+			v.add(base+".max_body_bytes", "max_body_bytes is meaningful only when inject.in includes \"body\"", SeverityError)
+		}
 	}
 }
 

--- a/internal/config/validator_surfaces_test.go
+++ b/internal/config/validator_surfaces_test.go
@@ -1,0 +1,146 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mmartinez/postern/internal/config"
+)
+
+// placeholderSurfacesConfig is a placeholder-mode rule template the surface
+// tests tweak per case. %s is the inject body (name/template/in/max_body_bytes).
+const placeholderSurfacesConfig = `
+token:
+  source: auto
+  env_var: OP_SERVICE_ACCOUNT_TOKEN
+proxy:
+  listen: 127.0.0.1:1701
+  cache_ttl: 5m
+  on_no_match: passthrough
+%s
+rules:
+  - host: api.example.com
+    secret_ref: op://Vault/Item/field
+    inject:
+%s
+`
+
+func surfacesYAML(proxyExtra, inject string) string {
+	return strings.Replace(strings.Replace(placeholderSurfacesConfig, "%s", proxyExtra, 1), "%s", inject, 1)
+}
+
+func TestLoadAndValidate_Surfaces(t *testing.T) {
+	t.Parallel()
+
+	cases := []validateCase{
+		{
+			name: "valid placeholder with body and query surfaces",
+			yaml: surfacesYAML("", `      type: placeholder
+      name: __tok__
+      template: "{{ CREDENTIAL }}"
+      in: [body, query]`),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				require.Empty(t, lints, "unreserved token over body+query is valid")
+			},
+		},
+		{
+			name: "valid per-rule max_body_bytes with body surface",
+			yaml: surfacesYAML("", `      type: placeholder
+      name: __tok__
+      template: "{{ CREDENTIAL }}"
+      in: [body]
+      max_body_bytes: 4096`),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				require.Empty(t, lints)
+			},
+		},
+		{
+			name: "in with header inject type is rejected",
+			yaml: surfacesYAML("", `      type: header
+      name: x-api-key
+      template: "{{ CREDENTIAL }}"
+      in: [body]`),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "inject.in is valid only with inject.type=placeholder")
+			},
+		},
+		{
+			name: "unknown surface value",
+			yaml: surfacesYAML("", `      type: placeholder
+      name: __tok__
+      template: "{{ CREDENTIAL }}"
+      in: [bogus]`),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "invalid surface")
+			},
+		},
+		{
+			name: "reserved-char token rejected for non-header surface",
+			yaml: surfacesYAML("", `      type: placeholder
+      name: "key/with/slash"
+      template: "{{ CREDENTIAL }}"
+      in: [path]`),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "unreserved characters")
+			},
+		},
+		{
+			name: "reserved-char token allowed for header-only rule",
+			yaml: surfacesYAML("", `      type: placeholder
+      name: "{weird}"
+      template: "{{ CREDENTIAL }}"`),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				require.Empty(t, lints, "header-only placeholder keeps the looser token charset")
+			},
+		},
+		{
+			name: "negative proxy max_body_bytes",
+			yaml: surfacesYAML("  max_body_bytes: -1", `      type: placeholder
+      name: __tok__
+      template: "{{ CREDENTIAL }}"
+      in: [body]`),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "max_body_bytes")
+			},
+		},
+		{
+			name: "negative per-rule max_body_bytes",
+			yaml: surfacesYAML("", `      type: placeholder
+      name: __tok__
+      template: "{{ CREDENTIAL }}"
+      in: [body]
+      max_body_bytes: -5`),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "max_body_bytes must be >= 0")
+			},
+		},
+		{
+			name: "per-rule max_body_bytes without body surface",
+			yaml: surfacesYAML("", `      type: placeholder
+      name: __tok__
+      template: "{{ CREDENTIAL }}"
+      in: [query]
+      max_body_bytes: 4096`),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "meaningful only when inject.in includes")
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, lints, err := config.LoadAndValidate(strings.NewReader(tc.yaml))
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tc.wantLints != nil {
+				tc.wantLints(t, lints)
+			}
+		})
+	}
+}

--- a/internal/proxy/transport_guard_test.go
+++ b/internal/proxy/transport_guard_test.go
@@ -59,6 +59,7 @@ func TestProxy_PlainHTTPMatch_FailsClosed_UpstreamNotContacted(t *testing.T) {
 		broker.NewEngine([]broker.Rule{rule}),
 		countingResolver{&resolverCalls},
 		config.OnNoMatchPassthrough,
+		0,
 		slog.New(slog.NewTextHandler(io.Discard, nil)),
 	)
 


### PR DESCRIPTION
Closes #17.

## What

Extends placeholder substitution beyond headers to the request **body**, URL **path**, and **query string**, opt-in per rule via `inject.in` (default `[header]`). Header inject mode is unchanged.

## Design

- **Config:** `inject.in: [header,body,path,query]` (placeholder type only); per-rule `inject.max_body_bytes` override; global `proxy.max_body_bytes` (default 1 MiB).
- **Per-surface encoding** (the crux — a raw splice corrupts payloads / injects structure):
  - `path` → `url.PathEscape`, sets both `URL.Path` and `URL.RawPath`
  - `query` → `url.QueryEscape` in `URL.RawQuery`
  - `header` → raw, **rejects CR/LF** (header-injection guard → fail closed)
  - `body` → by `Content-Type`: JSON string-escape / form query-escape / `multipart/*` skipped / else raw; **skipped if `Content-Encoding` set** (compressed)
- **Body buffering** lives in the goproxy hook: only when a rule rewrites the body, wrapped in `http.MaxBytesReader`; oversize → **413** *before* resolve (no credential fetch on a flood); sets `ContentLength` + `Content-Length`.
- **Fail-closed:** aggregate match (≥1 substitution across eligible surfaces); zero eligible substitutions → 502; partial-mutation never forwarded.
- **Validator:** token restricted to RFC 3986 unreserved when a non-header surface is declared; line-numbered errors for invalid combos.

WebSocket frames are out of scope (goproxy has no WS-frame hook) — possible future issue.

## Tests

- Unit: per-surface encoding, CR/LF guard, aggregate match, multipart/compressed skip, unknown surface, from-config mapping, validator combos.
- E2E through real goproxy: body (JSON-escaped), path (PathEscaped), query (QueryEscaped) each arrive correctly encoded; oversized body → 413 with upstream + resolver counters at 0; compressed/multipart forwarded byte-for-byte.
- Coverage: broker 89.9%, config 88.6% (gate 80%). `-race` clean.

## Note on local `make vuln`

Local `make ci` flags `GO-2026-5037`/`GO-2026-5039` — **stdlib advisories fixed in go1.26.4**, not reachable through this change (traces are `config.Load`/`runtime.Run`). The devcontainer is stale at go1.26.3; CI's `setup-go` resolves `1.26` → 1.26.4, so CI runs clean. A local container refresh (+ optional go.mod patch pin) is a separate follow-up.

<!-- greptile_comment -->

<h3>Confidence Score: 3/5</h3>

The core substitution and encoding logic is solid and well-tested, but the body buffering path in hook.go reads compressed/multipart bodies into memory even though substituteBody will skip them — a large skipped body hits the size cap and returns 413 instead of being forwarded unchanged as the docs promise.

The aggregate-match semantics, per-surface encoding, and CR/LF guard are all correct and covered by E2E tests. The issue is in hook.go: usesBodySurface() triggers buffering before Content-Encoding or multipart checks, so a body-surface rule on a service that sends large compressed payloads will unexpectedly reject those requests with 413. This contradicts the documented behaviour ('forwarded untouched') and the design's own framing ('only when a rule rewrites the body').

internal/broker/hook.go — the body buffering block (lines 94–120) needs a pre-check on Content-Encoding and Content-Type before calling MaxBytesReader so that bodies that will be skipped by substituteBody are streamed rather than capped.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/broker/hook.go | Adds body buffering (MaxBytesReader + io.ReadAll) before credential resolution for body-surface rules; introduces tooLarge (413) response. Body is buffered unconditionally when usesBodySurface() is true, even for compressed/multipart payloads that substituteBody will skip — a large skipped body returns 413 instead of forwarding unchanged. |
| internal/broker/inject.go | Core surface substitution logic: per-surface encoding (PathEscape/QueryEscape/JSON/form), aggregate match semantics, CR/LF guard for headers. substituteBody sets req.Header["Content-Length"] redundantly alongside req.ContentLength; the header is ignored by Go's HTTP transport for outgoing requests. |
| internal/broker/inject_surfaces_test.go | New unit tests covering path/query/body encoding, CR/LF guard, multipart/compressed skip, aggregate match, fail-closed, and surface constant distinctness. Good coverage of the happy paths and designed failure modes. |
| internal/broker/hook_surfaces_test.go | Unit tests for body buffering in the hook: 413 on over-cap body, correct forwarding under cap, per-rule cap override, and no-buffering for header-only rules. Correctly verifies resolver is not called on 413. |
| internal/broker/integration_surfaces_test.go | E2E tests through real goproxy: JSON body escaping, path percent-encoding, query escaping, 413 with upstream/resolver counters at zero, compressed and multipart passthrough. Solid end-to-end coverage. |
| internal/config/validator.go | Adds checkInjectSurfaces: validates inject.in only on placeholder type, rejects unknown surfaces, enforces RFC 3986 unreserved charset for non-header tokens, validates max_body_bytes ranges and presence constraints. |
| internal/config/schema.go | Adds InjectSurface type, surface constants, DefaultMaxBodyBytes (1 MiB), MaxBodyBytes to Proxy, and In/MaxBodyBytes to Inject. Clean schema extension. |
| internal/broker/rule.go | Adds usesBodySurface() helper to distinguish body-rewriting rules from streaming ones. Simple and correct. |
| internal/broker/reloader.go | Adds drift detection for proxy.max_body_bytes — warns on hot-reload edits since the value is bound at startup. Consistent with the existing on_no_match and cache_ttl drift guards. |
| internal/broker/from_config.go | Maps config surfaces to broker surfaces and unwraps the optional per-rule MaxBodyBytes. Loop idiom changed from for-range to indexed access in multiple places without a correctness reason in Go 1.22+. |
| internal/cli/server.go | Passes cfg.Proxy.MaxBodyBytes to broker.Hook — single-line wiring change, correct. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent
    participant goproxy
    participant Hook
    participant Inject
    participant Resolver
    participant Upstream

    Agent->>goproxy: HTTPS request (placeholder in body/path/query)
    goproxy->>Hook: PreUpstreamHandler(req)
    Hook->>Hook: Match rule (engine.Match)
    alt no match
        Hook-->>goproxy: nil (passthrough)
    else matched, http not https
        Hook-->>goproxy: 502 fail-closed
    else body surface declared
        Hook->>Hook: MaxBytesReader(bodyCap)
        alt "body > cap"
            Hook-->>goproxy: 413 tooLarge
        else body ok
            Hook->>Hook: buf req.Body, set ContentLength
            Hook->>Resolver: Resolve(secretRef)
            Resolver-->>Hook: credential
            Hook->>Inject: rule.Inject(req, credential)
            Inject->>Inject: substituteHeaders (CR/LF guard)
            Inject->>Inject: substitutePath (PathEscape)
            Inject->>Inject: substituteQuery (QueryEscape)
            Inject->>Inject: substituteBody (JSON/form/raw, skip compressed/multipart)
            alt "eligible > 0 and subs == 0"
                Inject-->>Hook: ErrNoPlaceholder
                Hook-->>goproxy: 502 fail-closed
            else substituted
                Inject-->>Hook: nil
                Hook-->>goproxy: nil (forward mutated req)
            end
        end
    end
    goproxy->>Upstream: forwarded request
    Upstream-->>Agent: response
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/broker/from_config.go`, line 95-96 ([link](https://github.com/mmartinez/postern/blob/0810fad584cbce6b465af6b6d8430181774cecac/internal/broker/from_config.go#L95-L96)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Non-idiomatic range loop applied in several files**

   The pattern `for i := range in { src := in[i] }` is used here and in `cli/rules.go`, `config/providers.go`, and `config/validator.go` for straightforward read-only iteration. The idiomatic Go form `for i, src := range in` is equivalent, avoids the extra `r := slice[i]` line, and requires no special handling in Go 1.22+ (where loop-variable capture semantics are fixed). None of the loops take the address of the variable, so there is no correctness reason for the indexed form.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(broker): substitute placeholders in..."](https://github.com/mmartinez/postern/commit/0810fad584cbce6b465af6b6d8430181774cecac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35403362)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->