### PR TITLE
chore: bump Go to 1.26.4 (GO-2026-5037, GO-2026-5039)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: "1.26"
+  GO_VERSION: "1.26.4"
   GOLANGCI_VERSION: "v2.12.2"
   GITLEAKS_VERSION: "8.21.4"
   GOFUMPT_VERSION: "v0.7.0"
@@ -76,7 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.26.x"]
+        go: ["1.26.4"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ permissions:
   id-token: write # goreleaser: keyless cosign signing via GitHub OIDC
 
 env:
-  GO_VERSION: "1.26"
+  GO_VERSION: "1.26.4"
   # Kept in lockstep with .github/workflows/ci.yml and .mise.toml.
   GORELEASER_VERSION: "v2.16.0"
   ZIG_VERSION: "0.14.0"

--- a/.mise.toml
+++ b/.mise.toml
@@ -2,7 +2,7 @@
 # Bump versions deliberately; lockstep with .github/workflows/ci.yml matrix.
 
 [tools]
-go             = "1.26"
+go             = "1.26.4"
 golangci-lint  = "2.12"
 gofumpt        = "0.7"
 lefthook       = "1.10"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mmartinez/postern
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/1password/onepassword-sdk-go v0.4.0


### PR DESCRIPTION
Bumps the Go toolchain 1.26.3 → 1.26.4 to clear two **reachable standard-library** advisories `govulncheck` flags under 1.26.3:

- **GO-2026-5039** — `net/textproto` includes unescaped inputs in errors (reached via `config.Load`).
- **GO-2026-5037** — inefficient hostname parsing in `crypto/x509` (reached via the TLS serve path / SDK client).

No first-party code change; this is purely a toolchain patch.

### Why an exact pin
`setup-go` resolved the floating `"1.26"` to the still-cached **1.26.3** on the runner, so CI kept failing `vuln`. Pinning the exact patch in `go.mod`, `.mise.toml`, and both workflows forces 1.26.4.

### Verified
`make ci` fully green locally on 1.26.4: lint, `-race` test, `govulncheck` (No vulnerabilities found), licenses (no `THIRD_PARTY_NOTICES.md` drift).

### Devcontainer note
Existing devcontainers need `mise install` plus a reinstall of the `go install`-based tools (`govulncheck`, `go-licenses`) so their shims rebind to 1.26.4.