### PR TITLE
fix(broker): forward oversized compressed/multipart bodies instead of 413

### DIFF
--- a/internal/broker/hook.go
+++ b/internal/broker/hook.go
@@ -90,8 +90,11 @@ func Hook(engine *Engine, resolver Resolver, onNoMatch config.OnNoMatch, maxBody
 
 		// Body buffering happens before resolve so an oversized body is
 		// rejected (413) without spending a credential fetch. Only rules that
-		// rewrite the body buffer it; everything else streams untouched.
-		if rule.usesBodySurface() {
+		// rewrite the body buffer it; everything else streams untouched. A body
+		// the injector will skip (compressed or multipart) is never rewritten,
+		// so it must stream through uncapped — buffering it would 413 an
+		// oversized body the proxy is supposed to forward unchanged.
+		if rule.usesBodySurface() && !bodySkippable(req) {
 			bodyCap := effectiveBodyCap(maxBodyBytes, rule.Injection.MaxBodyBytes)
 			limited := http.MaxBytesReader(nil, req.Body, int64(bodyCap))
 			buf, rerr := io.ReadAll(limited)

--- a/internal/broker/hook_surfaces_test.go
+++ b/internal/broker/hook_surfaces_test.go
@@ -61,6 +61,48 @@ func TestHook_BodyUnderCap_SubstitutesAndForwards(t *testing.T) {
 	require.Equal(t, int64(len(got)), req.ContentLength)
 }
 
+// A compressed body is skipped by substituteBody (text-splicing opaque bytes
+// would corrupt them), so the hook must not buffer or size-cap it: an oversized
+// compressed body forwards untouched rather than returning 413.
+func TestHook_CompressedBodyOverCap_ForwardsUnbuffered(t *testing.T) {
+	t.Parallel()
+
+	res := &fakeResolver{value: "sk-real"}
+	hook := bodySurfaceHook(t, res, 16, placeholderRule(broker.SurfaceBody)) //nolint:bodyclose // closure return type; resp is nil on the forward path
+
+	req, err := http.NewRequest(http.MethodPost, "https://api.example.com/v1/x", strings.NewReader(strings.Repeat("x", 100)))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "gzip")
+
+	resp := hook(req) //nolint:bodyclose // nil on the forward path; nothing to close
+	require.Nil(t, resp, "an oversized compressed body must forward untouched, not 413")
+
+	got, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	require.Equal(t, strings.Repeat("x", 100), string(got), "compressed body must stream through unchanged")
+}
+
+// A multipart body is likewise skipped by substituteBody, so an oversized
+// multipart body forwards untouched rather than returning 413.
+func TestHook_MultipartBodyOverCap_ForwardsUnbuffered(t *testing.T) {
+	t.Parallel()
+
+	res := &fakeResolver{value: "sk-real"}
+	hook := bodySurfaceHook(t, res, 16, placeholderRule(broker.SurfaceBody)) //nolint:bodyclose // closure return type; resp is nil on the forward path
+
+	req, err := http.NewRequest(http.MethodPost, "https://api.example.com/v1/x", strings.NewReader(strings.Repeat("x", 100)))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "multipart/form-data; boundary=abc")
+
+	resp := hook(req) //nolint:bodyclose // nil on the forward path; nothing to close
+	require.Nil(t, resp, "an oversized multipart body must forward untouched, not 413")
+
+	got, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	require.Equal(t, strings.Repeat("x", 100), string(got), "multipart body must stream through unchanged")
+}
+
 // A per-rule max_body_bytes override takes precedence over the global cap.
 func TestHook_PerRuleCapOverridesGlobal(t *testing.T) {
 	t.Parallel()

--- a/internal/broker/inject.go
+++ b/internal/broker/inject.go
@@ -9,7 +9,6 @@ import (
 	"mime"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 )
 
@@ -260,6 +259,19 @@ func substituteQuery(req *http.Request, token, value string) int {
 	return strings.Count(rq, token)
 }
 
+// bodySkippable reports whether substituteBody will forward req's body
+// untouched instead of rewriting it: a compressed body (Content-Encoding other
+// than identity) or a multipart body cannot be safely text-spliced. The hook
+// consults this so it skips buffering (and size-capping) a body it would only
+// stream through unchanged — otherwise an oversized skippable body would 413
+// instead of forwarding, contradicting the documented passthrough.
+func bodySkippable(req *http.Request) bool {
+	if ce := req.Header.Get("Content-Encoding"); ce != "" && !strings.EqualFold(ce, "identity") {
+		return true
+	}
+	return strings.HasPrefix(parseMediaType(req.Header.Get("Content-Type")), "multipart/")
+}
+
 // substituteBody replaces token in the request body with a value encoded for
 // the body's Content-Type, then rewrites req.Body and Content-Length. It
 // reports skipped=true (and leaves the body untouched) for bodies it must not
@@ -270,14 +282,10 @@ func substituteBody(req *http.Request, token, value string) (subs int, skipped b
 	if req.Body == nil || req.Body == http.NoBody {
 		return 0, false, nil
 	}
-	// A compressed body is opaque bytes; text substitution would corrupt it.
-	if ce := req.Header.Get("Content-Encoding"); ce != "" && !strings.EqualFold(ce, "identity") {
+	if bodySkippable(req) {
 		return 0, true, nil
 	}
 	mediaType := parseMediaType(req.Header.Get("Content-Type"))
-	if strings.HasPrefix(mediaType, "multipart/") {
-		return 0, true, nil
-	}
 
 	raw, err := io.ReadAll(req.Body)
 	if err != nil {
@@ -294,7 +302,6 @@ func substituteBody(req *http.Request, token, value string) (subs int, skipped b
 	newBody := strings.ReplaceAll(body, token, encodeBodyValue(mediaType, value))
 	req.Body = io.NopCloser(strings.NewReader(newBody))
 	req.ContentLength = int64(len(newBody))
-	req.Header.Set("Content-Length", strconv.Itoa(len(newBody)))
 	return strings.Count(body, token), false, nil
 }
 

--- a/internal/broker/inject_surfaces_test.go
+++ b/internal/broker/inject_surfaces_test.go
@@ -84,7 +84,6 @@ func TestInjectPlaceholder_Body_JSONEscaped(t *testing.T) {
 	got := readBody(t, req)
 	require.Equal(t, `{"api_key":"he said \"hi\"\n"}`, got)
 	require.Equal(t, int64(len(got)), req.ContentLength)
-	require.Equal(t, "30", req.Header.Get("Content-Length"))
 }
 
 func TestInjectPlaceholder_Body_FormURLEncoded(t *testing.T) {


### PR DESCRIPTION
Addresses the Greptile review on #32 (merged). Three comments; two fixed, one declined with rationale below.

## ✅ P1 — `hook.go`: oversized compressed/multipart bodies wrongly 413'd

`usesBodySurface()` triggered body buffering (`MaxBytesReader`) for any rule declaring the `body` surface, **before** `substituteBody` could detect a compressed (`Content-Encoding`) or `multipart/*` body and skip it. An oversized body the injector would forward untouched therefore hit the cap and returned **413** — contradicting the documented passthrough ("forwarded untouched") and the design's own "only when a rule *rewrites* the body" framing.

**Fix:** extracted `bodySkippable(req)` as the single source of truth for the skip decision (`Content-Encoding` other than `identity`, or a multipart media type), shared by `substituteBody` and the hook. The hook now buffers only when `usesBodySurface() && !bodySkippable(req)`, so compressed/multipart bodies stream through uncapped. Two new tests (compressed + multipart over-cap) prove they forward unchanged instead of 413.

## ✅ P2 — `inject.go`: redundant `Content-Length` header set

`req.Header.Set("Content-Length", …)` is a no-op for outgoing requests — Go's transport excludes `Content-Length` from the header map (`reqWriteExcludeHeader`) and writes it from `req.ContentLength`, which `substituteBody` already sets. Dropped the line and the now-unused `strconv` import; updated the one test that asserted the dead header (it already asserts `req.ContentLength`).

## ❌ P3 — `for i := range x { v := x[i] }` → `for i, v := range x` — **declined (linter conflict)**

Applying greptile's suggested form breaks the project's authoritative linter:

```
gocritic: rangeValCopy: each iteration copies 128 bytes (consider pointers or indexing)
```

`config.Rule` / `broker.Rule` are 128-byte structs; `for i, v := range` binds a value copy per iteration, which `gocritic`'s `rangeValCopy` rejects. The indexed `for i := range x { v := x[i] }` form is the codebase's deliberate idiom to satisfy that linter — the two suggestions are mutually exclusive on these large structs. Keeping the existing form per CLAUDE.md (golangci-lint is the authoritative enforcer; never bypass).

## Verification

`make ci` clean inside the devcontainer: golangci-lint **0 issues**, full `-race` suite green (`broker` **90.0%**, gate 80%), `govulncheck` none, license notices unchanged.

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted bug fix with no regressions introduced.

The fix is mechanically straightforward: a single predicate (bodySkippable) is extracted and reused so the hook's buffering gate and substituteBody stay in sync by construction. Both the hook path and the injector path were reviewed and the logic is consistent — headers are never mutated between the two checks, so the two-call pattern cannot diverge. The removed Content-Length header write was already a no-op per Go's transport layer, and the dead import cleanup is clean. New tests cover both the compressed and multipart over-cap paths and verify the body bytes are preserved unchanged.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/broker/inject.go | Extracts bodySkippable() as a shared predicate, consolidating the duplicate Content-Encoding and multipart checks from substituteBody; removes the dead req.Header.Set("Content-Length", …) no-op and its unused strconv import. |
| internal/broker/hook.go | Tightens the body-buffering guard to usesBodySurface() && !bodySkippable(req), fixing the bug where compressed/multipart bodies hit the MaxBytesReader cap and returned 413 instead of streaming through. |
| internal/broker/hook_surfaces_test.go | Adds two regression tests (compressed body over cap, multipart body over cap) proving nil is returned (forward path) rather than 413, and that the body bytes are preserved unchanged. |
| internal/broker/inject_surfaces_test.go | Removes the now-dead assertion on req.Header.Get("Content-Length") following the removal of the no-op header set in substituteBody. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent
    participant Hook
    participant bodySkippable
    participant Resolver
    participant substituteBody
    participant Upstream

    Agent->>Hook: POST /v1/x (body, possibly compressed/multipart)
    Hook->>Hook: engine.Match(host)
    Hook->>Hook: usesBodySurface()?

    alt "usesBodySurface() && !bodySkippable(req)"
        Hook->>bodySkippable: bodySkippable(req)?
        bodySkippable-->>Hook: false (plain body)
        Hook->>Hook: MaxBytesReader → buffer body
        alt "body > cap"
            Hook-->>Agent: 413 Request Entity Too Large
        end
    else "usesBodySurface() && bodySkippable(req)"
        Hook->>bodySkippable: bodySkippable(req)?
        bodySkippable-->>Hook: true (compressed / multipart)
        Note over Hook: skip buffering — streams untouched
    end

    Hook->>Resolver: Resolve(secretRef)
    Resolver-->>Hook: credential

    Hook->>substituteBody: substituteBody(req, token, value)
    substituteBody->>bodySkippable: bodySkippable(req)?
    alt skippable
        bodySkippable-->>substituteBody: true
        substituteBody-->>Hook: "subs=0, skipped=true"
    else not skippable
        bodySkippable-->>substituteBody: false
        substituteBody->>substituteBody: text-splice credential into body
        substituteBody-->>Hook: "subs=N, skipped=false"
    end

    Hook-->>Upstream: forward request (nil response)
```

<sub>Reviews (1): Last reviewed commit: ["fix(broker): forward oversized compresse..."](https://github.com/mmartinez/postern/commit/4e31ae445c6571ee02100cd92355dffa7770345c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35421695)</sub>

<!-- /greptile_comment -->