### PR TITLE
fix(credstore): retain 1Password SDK client so GC finalizer can't free it

### DIFF
--- a/internal/credstore/onepassword/client.go
+++ b/internal/credstore/onepassword/client.go
@@ -37,7 +37,14 @@ type secretsResolver interface {
 // Client is the narrow surface other postern packages depend on. It is
 // constructed from a service-account token and exposes the minimum set of
 // operations the broker runtime needs.
+//
+// sdk is the owning *sdk.Client. It is retained for the Client's lifetime so
+// the SDK's GC finalizer (which calls ReleaseClient and frees the underlying
+// core client) cannot fire while the vaults/secrets handles are still in use:
+// those handles do not keep the parent client reachable on their own. See
+// Resolver, which propagates this reference to the long-lived resolver.
 type Client struct {
+	sdk     *sdk.Client
 	vaults  vaultsLister
 	secrets secretsResolver
 }
@@ -54,7 +61,7 @@ func New(ctx context.Context, token, integrationVersion string) (*Client, error)
 	if err != nil {
 		return nil, fmt.Errorf("1password client: %w", err)
 	}
-	return &Client{vaults: s.Vaults(), secrets: s.Secrets()}, nil
+	return &Client{sdk: s, vaults: s.Vaults(), secrets: s.Secrets()}, nil
 }
 
 // Resolver returns a broker.Resolver backed by this Client's SDK secrets
@@ -62,7 +69,7 @@ func New(ctx context.Context, token, integrationVersion string) (*Client, error)
 // passing it to the broker so TTL and non-cacheable-ref semantics are
 // uniform across vendors.
 func (c *Client) Resolver() broker.Resolver {
-	return &sdkResolver{secrets: c.secrets}
+	return &sdkResolver{secrets: c.secrets, keepAlive: c}
 }
 
 // HealthCheck verifies the configured service-account token is valid and

--- a/internal/credstore/onepassword/client_test.go
+++ b/internal/credstore/onepassword/client_test.go
@@ -3,9 +3,13 @@ package onepassword
 import (
 	"context"
 	"errors"
+	"runtime"
+	"sync/atomic"
 	"testing"
 
 	sdk "github.com/1password/onepassword-sdk-go"
+
+	"github.com/mmartinez/postern/internal/broker"
 )
 
 // fakeVaults satisfies the package's vaultsLister consumer interface. Only
@@ -75,6 +79,50 @@ func TestHealthCheckPropagatesError(t *testing.T) {
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("HealthCheck error = %v, want wrap of %v", err, sentinel)
 	}
+}
+
+// TestResolverKeepsSDKClientReachable is the regression guard for the
+// intermittent "invalid client id" production failure. The 1Password SDK
+// attaches a GC finalizer to *sdk.Client that calls ReleaseClient, freeing the
+// underlying core client; the Secrets()/Vaults() handles do not keep that
+// parent client reachable. Once Postern held only those handles, the GC could
+// finalize the client under load and every later resolve failed with
+// "invalid client id" until restart. The resolver returned by Resolver() must
+// pin the client for its whole lifetime so the finalizer never fires.
+func TestResolverKeepsSDKClientReachable(t *testing.T) {
+	// Not parallel: drives runtime.GC and inspects finalizer scheduling.
+	var finalized int32
+
+	// Build the client and resolver inside a closure so the *sdk.Client and the
+	// *Client locals go out of scope when it returns. Only the resolver escapes
+	// — exactly the shape the broker keeps after New/Resolver return. If the
+	// resolver retains the client it stays reachable; if not, it becomes
+	// unreachable here and the finalizer is free to run.
+	r := func() broker.Resolver {
+		s := &sdk.Client{}
+		runtime.SetFinalizer(s, func(*sdk.Client) { atomic.StoreInt32(&finalized, 1) })
+		c := &Client{sdk: s, secrets: &fakeSecrets{value: "sk"}}
+		return c.Resolver()
+	}()
+
+	// A few GC cycles, yielding to the finalizer goroutine between them, give an
+	// eligible finalizer ample opportunity to run.
+	for i := 0; i < 10 && atomic.LoadInt32(&finalized) == 0; i++ {
+		runtime.GC()
+		runtime.Gosched()
+	}
+
+	if atomic.LoadInt32(&finalized) != 0 {
+		t.Fatal(`sdk client was finalized while the resolver was still live: resolves would fail with "invalid client id"`)
+	}
+
+	// The resolver must outlive the GC loop above for the assertion to mean
+	// anything; resolving through it here keeps it reachable and confirms the
+	// retained handle still works.
+	if _, err := r.Resolve(context.Background(), "", "op://V/I/f"); err != nil {
+		t.Fatalf("Resolve after GC: %v", err)
+	}
+	runtime.KeepAlive(r)
 }
 
 func TestNewRejectsEmptyToken(t *testing.T) {

--- a/internal/credstore/onepassword/sdk_resolver.go
+++ b/internal/credstore/onepassword/sdk_resolver.go
@@ -8,8 +8,16 @@ import (
 // sdkResolver adapts the 1Password Go SDK's secrets API to broker.Resolver.
 // It is constructed via Client.Resolver(); tests in this package construct
 // it directly with a secretsResolver fake.
+//
+// keepAlive pins the owning *Client (and through it the *sdk.Client) for the
+// resolver's lifetime. The broker keeps the resolver alive for the whole
+// process, so this transitively keeps the SDK client reachable and prevents
+// its GC finalizer from calling ReleaseClient out from under the secrets
+// handle. Without it, a resolve after the client is finalized fails with
+// "invalid client id". It is nil in unit tests that exercise Resolve directly.
 type sdkResolver struct {
-	secrets secretsResolver
+	secrets   secretsResolver
+	keepAlive *Client
 }
 
 // Resolve delegates to the SDK with the secret reference unchanged. The


### PR DESCRIPTION
## Bug

Long-running `postern server` resolves 1Password credentials fine at first, then after uptime + a burst of concurrent traffic, resolves start failing with `sdk resolve: ... invalid client id` and the proxy returns a fail-closed **502** for every brokered request. Restarting clears it until it recurs. Reported against v0.3.1.

`op read` with the same token succeeds at the same moment; rate limit fine; fresh-start resolves fine. Not the token, account, or config.

## Root cause (confirmed at SDK source, onepassword-sdk-go v0.4.0)

`client_builder.go:63` attaches a GC finalizer to the outer `*sdk.Client`:

```go
runtime.SetFinalizer(&client, func(f *Client) {
    core.ReleaseClient(*clientID)   // core forgets this client
})
```

`s.Secrets()` / `s.Vaults()` embed only `*internal.InnerClient` (ID/Core/Config) — they do **not** keep the outer `*sdk.Client` reachable. Our `New()` returned `&Client{vaults: s.Vaults(), secrets: s.Secrets()}` and dropped `s`; `Resolver()` then dropped the `*Client` too. Nothing in the long-lived resolver path pinned the outer client.

Under GC pressure from the concurrent burst, the finalizer fired → `ReleaseClient` → the WASM core forgot the client → every later `Resolve` returned `invalid client id`. Restart = fresh client = back to 200. Matches the reported timeline exactly.

The concurrency in the report is a red herring for *corruption*: the SDK core is concurrency-safe (`internal/extism_core.go:88` locks a `sync.Mutex` on every `Invoke`/`InitClient`/`ReleaseClient`, and it's a process-wide singleton). Concurrency's only role was triggering GC.

## Fix

Retain the `*sdk.Client` on `Client`, and propagate the reference to the long-lived `sdkResolver` via `keepAlive`. The broker holds the resolver for the whole process, so `resolver → keepAlive(*Client) → sdk(*sdk.Client)` keeps the client reachable for the resolver's lifetime and the finalizer never fires while the secrets handle is in use. On config hot-reload the old resolver is dropped and its client is correctly released; the new resolver carries its own.

~3 lines of production change. No `runtime.KeepAlive` in the resolve path (that's for a local dying mid-function; heap-field retention is the correct mechanism here).

## Why not the report's other three points

- **Re-init + retry on `invalid client id`** — dead code once the client is retained (the finalizer never fires). The error is **untyped** in v0.4.0 (`errors.go` routes everything except `DesktopSessionExpired`/`RateLimitExceeded` to `errors.New(msg)`), so detecting it requires string-matching a vendor message — which our conventions ban — and rebuilding the client would force keeping the SA token resident, widening credential exposure.
- **Serialize re-init / client pool** — premised on the SDK not being concurrency-safe. It is (the core mutex above).
- **Bounded retry + backoff** — scope creep; fail-closed-502 on a resolve error is the documented security model.

## Test

`TestResolverKeepsSDKClientReachable` builds the client + resolver inside a closure so only the resolver escapes (the broker's shape), sets a finalizer on a bare `&sdk.Client{}`, runs a GC loop (yielding to the finalizer goroutine, no `time.Sleep`), and asserts the finalizer did not fire. Verified RED (finalizer fires) → GREEN; re-proven RED by reverting the `keepAlive` wiring.

## Verification

`make ci` green in-container: lint 0 issues, `-race` suite passes, no vulns, `THIRD_PARTY_NOTICES.md` unchanged (no dependency change). Fail-closed behavior untouched.

## Out of scope (filed separately)

A secondary leak — a credential carried in a URL path/query is logged in cleartext at `--log-level info` in passthrough (e.g. Telegram `/bot<token>/`) — is intentionally not addressed here. It is a different root cause in the proxy logging path.

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, targeted heap-retention fix with a purpose-built regression test that was verified RED before the fix and GREEN after.

Three files changed, all within the same narrow package. The production change is three lines: one new field on each struct and one field addition in two constructor sites. The regression test correctly models the broker's object graph (only the resolver escapes a closure, mirroring real usage), uses atomic flags to avoid races, and places runtime.KeepAlive at the right boundary. No behavioral changes to Resolve, HealthCheck, or the fail-closed 502 path.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/credstore/onepassword/client.go | Adds sdk *sdk.Client field to Client and threads it through New() and Resolver(); fix is minimal and correct. |
| internal/credstore/onepassword/sdk_resolver.go | Adds keepAlive *Client field to sdkResolver to pin the SDK client for the resolver's lifetime; nil-safe since the field is never dereferenced. |
| internal/credstore/onepassword/client_test.go | Adds a well-structured GC reachability regression test with correct use of runtime.SetFinalizer, atomic flags, and runtime.KeepAlive; intentionally not parallel with clear justification. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Broker["broker (process lifetime)"]
    Resolver["sdkResolver\n{ secrets, keepAlive }"]
    Client["*Client\n{ sdk, vaults, secrets }"]
    SDKClient["*sdk.Client\n(GC finalizer → ReleaseClient)"]
    WAsmCore["WASM core\n(ReleaseClient frees this)"]

    Broker -->|"holds resolver\nfor process lifetime"| Resolver
    Resolver -->|"keepAlive\n(heap field retention)"| Client
    Client -->|"sdk\n(heap field retention)"| SDKClient
    SDKClient -->|"manages"| WAsmCore

    style SDKClient fill:#d4edda,stroke:#28a745
    style Resolver fill:#cce5ff,stroke:#004085
    style Client fill:#cce5ff,stroke:#004085
```

<sub>Reviews (1): Last reviewed commit: ["fix(credstore): retain 1Password SDK cli..."](https://github.com/mmartinez/postern/commit/c80c0a074d5654da50ddcc6aca5184ed713c9387) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35469542)</sub>

<!-- /greptile_comment -->