### PR TITLE
feat(broker): route placeholder tokens to per-agent secrets

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -8,12 +8,27 @@ useDefault = true
 
 # Project-specific allowlist (very conservative — anything we add here must
 # be reviewed and justified).
-[[allowlists]]
-description = "Documentation files where brand/secret-shaped marketing copy is intentional"
+#
+# NOTE: this is the singular [allowlist] table, not the plural [[allowlists]].
+# With [extend].useDefault the pinned gitleaks (8.21.4, matched by CI) silently
+# ignores the plural form, so the entries below must live under [allowlist] to
+# take effect. Within the block, a finding is exempt if it matches any path OR
+# any regex.
+[allowlist]
+description = "postern documentation and synthetic test fixtures"
 paths = [
     '''^NOTICE$''',
     '''^LICENSE$''',
     '''^README\.md$''',
     '''^THIRD_PARTY_NOTICES\.md$''',
     '''^docs/.*''',
+]
+# Synthetic placeholder-routing example tokens used in tests and the commented
+# default.yaml example. They are deliberately high-entropy — to exercise the
+# routing token-entropy lint's "no warning" path — which makes the default
+# generic-api-key rule treat them as real keys. They are fixed, fake, and never
+# resolve to anything. Scoped to the exact synthetic prefix (not a broad path)
+# so a genuinely leaked key cannot hide behind this entry.
+regexes = [
+    '''tg_(max|john|alice)_[A-Za-z0-9]+''',
 ]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,8 +146,9 @@ rules:
 | Field | Required | Meaning |
 |---|---|---|
 | `host` | yes* | A literal hostname (`api.example.com`) or a single-`*` glob (`*.example.com`, matching exactly one label). **Do not use a wildcard on a multi-tenant or shared-suffix domain** (e.g. `*.s3.amazonaws.com`, `*.blob.core.windows.net`): any host an attacker can register under that suffix would also match the rule and receive the injected credential. Reserve wildcards for single-tenant domains you control. |
-| `secret_ref` | yes | A `<scheme>://<rest>` URI the matching provider resolves (e.g. `op://VAULT/ITEM/FIELD`). |
+| `secret_ref` | yes | A `<scheme>://<rest>` URI the matching provider resolves (e.g. `op://VAULT/ITEM/FIELD`). Omit when using `routes` (each route carries its own). |
 | `inject` | yes* | How to attach the resolved credential — see below. |
+| `routes` | no | Placeholder-routing entries: per-token secret selection for a shared host. Mutually exclusive with `secret_ref`/`inject.name`; see below. |
 | `template` | no | Name of a built-in preset (see below) that fills in `host` and `inject` defaults. |
 
 \* When `template` is set, `host` and `inject` may be omitted and are filled
@@ -211,6 +212,60 @@ Notes:
 - **WebSocket frames are out of scope.** postern brokers the HTTP request that
   opens a connection; it does not inspect or rewrite WebSocket message frames.
 
+### Placeholder routing (`routes`)
+
+A `placeholder` rule can carry a `routes` list instead of a single rule-level
+`secret_ref` and `inject.name`. Each route's `token` does double duty: presenting
+it on a declared surface both **selects** which secret to resolve and is the
+placeholder **replaced** in place by the resolved value. This lets several agents
+share one host rule, each presenting its own token.
+
+```yaml
+rules:
+  - host: api.telegram.org
+    inject:
+      type: placeholder
+      in: [header]
+      template: "{{ CREDENTIAL }}"   # agent sends "Authorization: Bearer <token>"
+    routes:
+      - name: max
+        token: tg_max_8Kq2Lp9wZ
+        secret_ref: op://Agents/telegram-max/token
+      - name: john
+        token: tg_john_3Rt7Yx1mQ
+        secret_ref: op://Agents/telegram-john/token
+```
+
+| Field | Meaning |
+|---|---|
+| `name` | Operator-facing label for the agent, surfaced in logs. The token value itself is **never** logged. |
+| `token` | The placeholder the agent presents; matching it selects this route. Must be unique and non-overlapping across the rule (see below). |
+| `secret_ref` | The `<scheme>://<rest>` URI resolved when this route's token matches. |
+
+- **Mutually exclusive** with rule-level `secret_ref` and `inject.name`. `routes`
+  requires `type: placeholder`; the shared `inject` block still supplies
+  `template`, `in`, and `max_body_bytes`.
+- **Allowlist + fail closed.** Only enumerated tokens resolve anything. A request
+  carrying no configured token — or two different tokens (ambiguous) — fails
+  closed with `502`, and the resolver is never called.
+- **Token entropy is load-bearing.** When agents are mutually untrusted, the
+  token is effectively the only thing separating one agent's secret from
+  another's. Pick high-entropy, unguessable tokens. postern emits a non-fatal
+  **warning** for a token whose estimated entropy is below ~64 bits (short or
+  low-diversity, e.g. `tgMax`); it does not block boot, since the operator owns
+  the trust decision. postern also **rejects** (fatal) tokens that overlap (one
+  a substring of another), because substitution matches by substring.
+- **Surfaces** behave exactly as above: tokens are scanned for, and replaced on,
+  the surfaces named in `inject.in` (default `[header]`), with the same
+  per-surface encoding and the non-header charset restriction.
+- **Substitution replaces _every_ occurrence on the declared surfaces.** Once a
+  route is selected, the resolved credential is spliced in everywhere its token
+  appears across those surfaces (e.g. every header value containing it). Do not
+  echo a route token into pass-through fields you don't want the credential to
+  land in (a duplicated `User-Agent`, a trace header), or the real secret will be
+  forwarded there too. This only ever places the agent's _own_ secret in its
+  _own_ request to the already-authorized upstream — never another agent's.
+
 ### Built-in templates
 
 Naming a `template` lets a rule skip restating the host pattern, header name,
@@ -237,6 +292,12 @@ Errors block startup. Common errors:
   placeholder.
 - `inject.in` set with `type: header`; an invalid surface name; a `placeholder`
   token with reserved characters when a non-header surface is declared.
+- `routes` combined with a rule-level `secret_ref` or `inject.name`; `routes`
+  without `type: placeholder`; a route missing `name`, `token`, or a well-formed
+  `secret_ref`; duplicate or overlapping route tokens.
+
+Warnings (reported, non-fatal): a route `token` with low estimated entropy
+(below ~64 bits) — a guessability hint, not a hard failure.
 - `proxy.max_body_bytes` (or a per-rule `inject.max_body_bytes`) negative; a
   per-rule `max_body_bytes` set without `body` in `inject.in`.
 - `cache_ttl` not greater than zero (when no `cache` block is set); `cache.ttl`

--- a/docs/ideas/placeholder-token-routing.md
+++ b/docs/ideas/placeholder-token-routing.md
@@ -1,0 +1,80 @@
+# Placeholder-Token Routing (multi-agent, one host)
+
+## Problem Statement
+How might we let 2-10 agents share one postern instance per host, each presenting
+its own token, and have that token select which real secret postern injects -- with
+no agent ever holding another's credential?
+
+## Recommended Direction
+Extend `type: placeholder` rules with a `routes:` list of named entries
+`{name, token, secret_ref}`. The token does double duty: it selects the secret AND
+is the in-request placeholder that gets replaced by the resolved value. Operator-
+opt-in; postern exposes the cross-agent risk and ships guards (overlap rejection,
+fail-closed selection, leak-free logging by route name) but does not impose a trust
+model. Stays an allowlist by construction -- only enumerated tokens resolve anything,
+unknown/ambiguous/zero -> 502, upstream never called.
+
+Chosen over "multiple rules per host" because it is the only shape with a safe place
+to attribute each request to an agent (the `name`) without logging the token, which
+the operator flagged as required alongside config ergonomics and isolation.
+
+Example:
+
+```yaml
+rules:
+  - host: api.telegram.org
+    inject:
+      type: placeholder
+      in: [header]
+      template: "{{ CREDENTIAL }}"   # agent sends "Authorization: Bearer <token>"
+    routes:
+      - name: max
+        token: tg_max_8Kq2Lp9wZ      # high-entropy; never logged
+        secret_ref: op://Agents/telegram-max/token
+      - name: john
+        token: tg_john_3Rt7Yx1mQ
+        secret_ref: op://Agents/telegram-john/token
+```
+
+Request: `Authorization: Bearer tg_max_8Kq2Lp9wZ`
+  -> host match -> scan surfaces -> exactly one token (max) -> resolve max ref
+  -> replace token with real value -> log {host, route:"max"} (never the token).
+
+## Key Assumptions to Validate
+- [ ] Every request to the routed host can carry a token on a declared surface
+      (test with the real deployment's request shapes; missing token = fail closed).
+- [ ] Operators will pick high-entropy tokens when agents are untrusted
+      (mitigate: docs + optional low-entropy lint; they own the risk via opt-in).
+- [ ] Handful (<=10) scale holds (if it grows, templated-ref hatch, not built now).
+
+## MVP Scope
+IN:
+- `routes []Route{Name,Token,SecretRef}` on Rule (schema + broker), placeholder mode only.
+- Selection: scan declared surfaces; exactly one route token present -> that route;
+  zero or multiple distinct tokens -> failClosed 502, resolver never called.
+- Inject: replace matched token with resolved cred (reuse `substitute*` helpers).
+- Validation (validator.go, line-numbered): routes XOR (secret_ref + inject.name);
+  requires type:placeholder; each route secret_ref a valid URI; tokens non-empty,
+  unique, AND no token a substring of another; route name non-empty.
+- Logging: emit route name + host on inject; NEVER log the token value.
+- Hot-reload (FromConfigRules + Swap) and cache (keyed by secret_ref): free, no change.
+- TDD tests across validator/from_config/hook: correct token->correct secret,
+  unknown->502 + resolver-not-called, ambiguous->502, overlap->validate error,
+  token-never-logged assertion. Coverage >=80% broker/config.
+- default.yaml + docs note (entropy, fail-closed).
+
+OUT: see Not Doing.
+
+## Not Doing (and Why)
+- Templated/dynamic secret_ref (`{{token}}` in path) -- handful scale; interpolating
+  agent input into a vault path is the arbitrary-secret-read edge. Documented hatch only.
+- `on_no_token: passthrough` toggle -- breaks fail-closed; a footgun.
+- Resolving the token itself from a credstore -- overkill for <=10 agents.
+- vaultID/multi-vault plumbing -- routes carry the full ref; reserved param stays "".
+- Relaxing host-uniqueness -- routes live inside one rule, so the existing check stands.
+
+## Open Questions
+- Which surface holds the token in the real deployment (confirms `in:`)?
+- Low-entropy token check: warn-only or skip for v1? (lean skip; operator owns the risk)
+- Is `name` required (better observability) or optional with a masked-token fallback?
+  (current plan: required)

--- a/internal/broker/engine.go
+++ b/internal/broker/engine.go
@@ -21,9 +21,12 @@ func NewEngine(rules []Rule) *Engine {
 // order the rules were supplied. The bool is false when no rule matches.
 // Engines must be obtained from NewEngine; the zero value is not usable.
 func (e *Engine) Match(host string) (Rule, bool) {
-	for _, r := range *e.rules.Load() {
-		if r.Match(host) {
-			return r, true
+	// Index rather than range-by-value: Rule is large enough that copying it
+	// per iteration trips gocritic's rangeValCopy.
+	rules := *e.rules.Load()
+	for i := range rules {
+		if rules[i].Match(host) {
+			return rules[i], true
 		}
 	}
 	return Rule{}, false

--- a/internal/broker/from_config.go
+++ b/internal/broker/from_config.go
@@ -45,9 +45,23 @@ func FromConfigRules(in []config.Rule) ([]Rule, error) {
 				Surfaces:     surfaces,
 				MaxBodyBytes: derefBodyCap(src.Inject.MaxBodyBytes),
 			},
+			Routes: routesFromConfig(src.Routes),
 		}
 	}
 	return out, nil
+}
+
+// routesFromConfig translates the YAML route list into broker routes. An empty
+// list yields nil (a non-routing rule).
+func routesFromConfig(in []config.Route) []Route {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]Route, len(in))
+	for i, r := range in {
+		out[i] = Route{Name: r.Name, Token: r.Token, SecretRef: r.SecretRef}
+	}
+	return out
 }
 
 // surfacesFromConfig maps the YAML surface list to broker surfaces. An empty

--- a/internal/broker/hook.go
+++ b/internal/broker/hook.go
@@ -122,6 +122,55 @@ func Hook(engine *Engine, resolver Resolver, onNoMatch config.OnNoMatch, maxBody
 			req.ContentLength = int64(len(buf))
 		}
 
+		// Placeholder-routing rule: the token the agent presents selects which
+		// secret to resolve and is itself the placeholder replaced in place.
+		// Selection scans the declared surfaces; zero or more-than-one distinct
+		// token fails closed. The token value is never logged — only the route's
+		// operator-facing name.
+		if len(rule.Routes) > 0 {
+			route, ok := rule.SelectRoute(req)
+			if !ok {
+				logger.Warn("broker route selection failed",
+					slog.String("host", host),
+					slog.String("rule", rule.Host),
+				)
+				return failClosed(req)
+			}
+			cred, err := resolver.Resolve(req.Context(), "", route.SecretRef)
+			if err != nil {
+				logger.Warn("broker resolve failed",
+					slog.String("host", host),
+					slog.String("rule", rule.Host),
+					slog.String("route", route.Name),
+					slog.Any("err", err),
+				)
+				return failClosed(req)
+			}
+			if cred == "" {
+				logger.Warn("broker resolved empty credential",
+					slog.String("host", host),
+					slog.String("rule", rule.Host),
+					slog.String("route", route.Name),
+				)
+				return failClosed(req)
+			}
+			if err := rule.InjectRoute(req, route, cred); err != nil {
+				logger.Warn("broker inject failed",
+					slog.String("host", host),
+					slog.String("rule", rule.Host),
+					slog.String("route", route.Name),
+					slog.Any("err", err),
+				)
+				return failClosed(req)
+			}
+			logger.Info("broker injected",
+				slog.String("host", host),
+				slog.String("rule", rule.Host),
+				slog.String("route", route.Name),
+			)
+			return nil
+		}
+
 		cred, err := resolver.Resolve(req.Context(), "", rule.SecretRef)
 		if err != nil {
 			logger.Warn("broker resolve failed",

--- a/internal/broker/inject.go
+++ b/internal/broker/inject.go
@@ -167,9 +167,32 @@ func (r Rule) injectPlaceholder(req *http.Request, credential string) error {
 	if r.Injection.Name == "" {
 		return ErrEmptyPlaceholderToken
 	}
-	token := r.Injection.Name
 	value := Render(r.Injection.Template, credential)
+	return r.substituteToken(req, r.Injection.Name, value)
+}
 
+// InjectRoute renders credential into the rule's shared template and
+// substitutes it for the route's token across the declared surfaces. It is the
+// placeholder-routing counterpart of Inject: the matched route supplies the
+// token (and selected the secret), while the rule supplies the template and
+// surfaces. Fails closed when the template carries no {{ CREDENTIAL }}
+// placeholder or the token is empty.
+func (r Rule) InjectRoute(req *http.Request, route Route, credential string) error {
+	if !hasCredentialPlaceholder(r.Injection.Template) {
+		return ErrNoCredentialPlaceholder
+	}
+	if route.Token == "" {
+		return ErrEmptyPlaceholderToken
+	}
+	value := Render(r.Injection.Template, credential)
+	return r.substituteToken(req, route.Token, value)
+}
+
+// substituteToken replaces token with the already-rendered value across the
+// rule's declared surfaces, per-surface encoded. The match is aggregate: any
+// one eligible surface carrying the token is success; zero substitutions across
+// one or more eligible surfaces is a fail-closed ErrNoPlaceholder.
+func (r Rule) substituteToken(req *http.Request, token, value string) error {
 	surfaces := r.Injection.Surfaces
 	if len(surfaces) == 0 {
 		surfaces = []Surface{SurfaceHeader}

--- a/internal/broker/integration_surfaces_test.go
+++ b/internal/broker/integration_surfaces_test.go
@@ -51,6 +51,71 @@ func surfaceRule(surfaces ...broker.Surface) broker.Rule {
 	}
 }
 
+// routedSurfaceRule is a placeholder-routing rule for the integration harness
+// (host 127.0.0.1, the httptest upstream): two agents, header surface.
+func routedSurfaceRule() broker.Rule {
+	return broker.Rule{
+		Host:      "127.0.0.1",
+		Injection: broker.InjectSpec{Type: broker.InjectPlaceholder, Template: "{{ CREDENTIAL }}"},
+		Routes: []broker.Route{
+			{Name: "max", Token: "tg_max_8Kq2Lp9wZ", SecretRef: "op://Agents/telegram-max/token"},
+			{Name: "john", Token: "tg_john_3Rt7Yx1mQ", SecretRef: "op://Agents/telegram-john/token"},
+		},
+	}
+}
+
+// E2E: a routed request reaches the real upstream with the agent's selected
+// credential injected in place of its token, and the resolver was asked for
+// exactly that route's secret_ref.
+func TestE2E_Routes_SelectsSecretAndUpstreamReceivesIt(t *testing.T) {
+	t.Parallel()
+
+	const value = "sk-routed"
+	var hits atomic.Int64
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+		hits.Add(1)
+		require.Equal(t, "Bearer "+value, req.Header.Get("Authorization"), "upstream must receive the resolved credential, not the token")
+	}))
+	t.Cleanup(upstream.Close)
+
+	client, res := surfaceProxy(t, upstream, routedSurfaceRule(), value, 1<<20)
+	req, err := http.NewRequest(http.MethodGet, upstream.URL+"/v1/x", http.NoBody)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer tg_john_3Rt7Yx1mQ")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, int64(1), hits.Load())
+	require.Equal(t, int64(1), res.calls.Load())
+	require.Equal(t, "op://Agents/telegram-john/token", res.lastVR.ref, "must resolve the john route's secret")
+}
+
+// E2E: an unknown token fails closed end to end — the upstream is never
+// contacted and the resolver is never called.
+func TestE2E_Routes_UnknownTokenFailsClosed_UpstreamNotContacted(t *testing.T) {
+	t.Parallel()
+
+	var hits atomic.Int64
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+	}))
+	t.Cleanup(upstream.Close)
+
+	client, res := surfaceProxy(t, upstream, routedSurfaceRule(), "sk-routed", 1<<20)
+	req, err := http.NewRequest(http.MethodGet, upstream.URL+"/v1/x", http.NoBody)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer tg_nobody_unknown")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusBadGateway, resp.StatusCode)
+	require.Zero(t, hits.Load(), "upstream must not be contacted for an unknown token")
+	require.Zero(t, res.calls.Load(), "resolver must not be called for an unknown token")
+}
+
 // E2E: a placeholder in a JSON body arrives at the upstream JSON-escaped. The
 // resolver value carries a double quote, so a raw splice would corrupt the
 // JSON; correct escaping makes it decode back to the original value.

--- a/internal/broker/routing_test.go
+++ b/internal/broker/routing_test.go
@@ -1,0 +1,423 @@
+package broker_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/mmartinez/postern/internal/broker"
+	"github.com/mmartinez/postern/internal/config"
+)
+
+// routedRule is the canonical placeholder-routing rule used across these tests:
+// one host, two named routes whose tokens each select a distinct secret. The
+// shared inject spec is placeholder mode, header surface (the default).
+func routedRule() broker.Rule {
+	return broker.Rule{
+		Host: "api.telegram.org",
+		Routes: []broker.Route{
+			{Name: "max", Token: "tg_max_8Kq2Lp9wZ", SecretRef: "op://Agents/telegram-max/token"},
+			{Name: "john", Token: "tg_john_3Rt7Yx1mQ", SecretRef: "op://Agents/telegram-john/token"},
+		},
+		Injection: broker.InjectSpec{Type: broker.InjectPlaceholder, Template: "{{ CREDENTIAL }}"},
+	}
+}
+
+func TestFromConfigRules_TranslatesRoutes(t *testing.T) {
+	t.Parallel()
+
+	in := []config.Rule{{
+		Host: "api.telegram.org",
+		Inject: config.Inject{
+			Type:     config.InjectTypePlaceholder,
+			Template: "{{ CREDENTIAL }}",
+		},
+		Routes: []config.Route{
+			{Name: "max", Token: "tg_max_8Kq2Lp9wZ", SecretRef: "op://Agents/telegram-max/token"},
+			{Name: "john", Token: "tg_john_3Rt7Yx1mQ", SecretRef: "op://Agents/telegram-john/token"},
+		},
+	}}
+
+	got, err := broker.FromConfigRules(in)
+	if err != nil {
+		t.Fatalf("FromConfigRules: %v", err)
+	}
+
+	want := []broker.Rule{{
+		Host: "api.telegram.org",
+		Injection: broker.InjectSpec{
+			Type:     broker.InjectPlaceholder,
+			Template: "{{ CREDENTIAL }}",
+		},
+		Routes: []broker.Route{
+			{Name: "max", Token: "tg_max_8Kq2Lp9wZ", SecretRef: "op://Agents/telegram-max/token"},
+			{Name: "john", Token: "tg_john_3Rt7Yx1mQ", SecretRef: "op://Agents/telegram-john/token"},
+		},
+	}}
+	if diff := cmp.Diff(want, got, cmpopts.EquateEmpty()); diff != "" {
+		t.Fatalf("rules diff (-want +got):\n%s", diff)
+	}
+}
+
+// The token an agent presents selects which secret postern resolves: the
+// resolver must be invoked with the matched route's secret_ref, and the token
+// in the request must be replaced by the resolved credential.
+func TestHook_RouteSelectsSecretByToken(t *testing.T) {
+	t.Parallel()
+
+	res := &fakeResolver{value: "sk-secret"}
+	hook := newHookFixture(t, routedRule(), res) //nolint:bodyclose // hook is a closure; subtests below close each response
+
+	t.Run("max token routes to max secret", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodPost, "https://api.telegram.org/sendMessage", http.NoBody)
+		req.Header.Set("authorization", "Bearer tg_max_8Kq2Lp9wZ")
+		resp := hook(req) //nolint:bodyclose // closeIfNonNil handles the non-nil branch
+		defer closeIfNonNil(t, resp)
+
+		if resp != nil {
+			t.Fatalf("hook returned response on routed match: %+v, want nil", resp)
+		}
+		if got := res.lastVR.ref; got != "op://Agents/telegram-max/token" {
+			t.Fatalf("resolver ref = %q, want max route ref", got)
+		}
+		if got := req.Header.Get("authorization"); got != "Bearer sk-secret" {
+			t.Fatalf("authorization = %q, want %q (token replaced)", got, "Bearer sk-secret")
+		}
+	})
+
+	t.Run("john token routes to john secret", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodPost, "https://api.telegram.org/sendMessage", http.NoBody)
+		req.Header.Set("authorization", "Bearer tg_john_3Rt7Yx1mQ")
+		resp := hook(req) //nolint:bodyclose // closeIfNonNil handles the non-nil branch
+		defer closeIfNonNil(t, resp)
+
+		if resp != nil {
+			t.Fatalf("hook returned response on routed match: %+v, want nil", resp)
+		}
+		if got := res.lastVR.ref; got != "op://Agents/telegram-john/token" {
+			t.Fatalf("resolver ref = %q, want john route ref", got)
+		}
+	})
+}
+
+// Routing on the body surface: selection scans the buffered body (and must
+// restore it) and the matched token is rewritten in place. Guards the
+// read-and-restore path that selection adds before injection re-reads the body.
+func TestHook_RouteSelectsByBodyToken(t *testing.T) {
+	t.Parallel()
+
+	res := &fakeResolver{value: "sk-secret"}
+	rule := routedRule()
+	rule.Injection.Surfaces = []broker.Surface{broker.SurfaceBody}
+	hook := newHookFixture(t, rule, res)
+
+	body := `{"token":"tg_john_3Rt7Yx1mQ"}`
+	req, _ := http.NewRequest(http.MethodPost, "https://api.telegram.org/sendMessage", strings.NewReader(body))
+	req.Header.Set("content-type", "application/json")
+	resp := hook(req) //nolint:bodyclose // closeIfNonNil handles the non-nil branch
+	defer closeIfNonNil(t, resp)
+
+	if resp != nil {
+		t.Fatalf("hook returned response on routed body match: %+v, want nil", resp)
+	}
+	if got := res.lastVR.ref; got != "op://Agents/telegram-john/token" {
+		t.Fatalf("resolver ref = %q, want john route ref", got)
+	}
+	got, _ := io.ReadAll(req.Body)
+	if string(got) != `{"token":"sk-secret"}` {
+		t.Fatalf("body = %q, want token replaced by credential", got)
+	}
+}
+
+// An unknown token (no configured route) must fail closed without ever calling
+// the resolver — the allowlist contract: only enumerated tokens resolve.
+func TestHook_RouteUnknownTokenFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	res := &fakeResolver{value: "sk-secret"}
+	hook := newHookFixture(t, routedRule(), res)
+
+	req, _ := http.NewRequest(http.MethodPost, "https://api.telegram.org/sendMessage", http.NoBody)
+	req.Header.Set("authorization", "Bearer tg_nobody_unknown")
+	resp := hook(req) //nolint:bodyclose // closeIfNonNil handles the non-nil branch
+	defer closeIfNonNil(t, resp)
+
+	if resp == nil {
+		t.Fatalf("unknown token: want non-nil 502, got nil (would forward unauthenticated)")
+	}
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", resp.StatusCode)
+	}
+	if got := res.calls.Load(); got != 0 {
+		t.Fatalf("resolver.calls = %d, want 0 (unknown token must not resolve)", got)
+	}
+}
+
+// A resolver error on a selected route must fail closed (502) and leave no
+// partial credential on the request: the route was selected (resolver called)
+// but injection never runs.
+func TestHook_RouteResolverErrorFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	res := &fakeResolver{err: errors.New("token revoked")}
+	hook := newHookFixture(t, routedRule(), res)
+
+	req, _ := http.NewRequest(http.MethodPost, "https://api.telegram.org/sendMessage", http.NoBody)
+	req.Header.Set("authorization", "Bearer tg_max_8Kq2Lp9wZ")
+	resp := hook(req) //nolint:bodyclose // closeIfNonNil handles the non-nil branch
+	defer closeIfNonNil(t, resp)
+
+	if resp == nil || resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("resolver error on routed match: want 502, got %+v", resp)
+	}
+	if got := res.calls.Load(); got != 1 {
+		t.Fatalf("resolver.calls = %d, want 1 (route was selected then resolve failed)", got)
+	}
+	if got := req.Header.Get("authorization"); got != "Bearer tg_max_8Kq2Lp9wZ" {
+		t.Fatalf("authorization mutated on failed resolve: %q (no partial credential allowed)", got)
+	}
+}
+
+// A resolver that returns ("", nil) on a selected route must fail closed rather
+// than inject an empty credential ("Bearer ").
+func TestHook_RouteEmptyCredentialFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	res := &fakeResolver{value: ""}
+	hook := newHookFixture(t, routedRule(), res)
+
+	req, _ := http.NewRequest(http.MethodPost, "https://api.telegram.org/sendMessage", http.NoBody)
+	req.Header.Set("authorization", "Bearer tg_max_8Kq2Lp9wZ")
+	resp := hook(req) //nolint:bodyclose // closeIfNonNil handles the non-nil branch
+	defer closeIfNonNil(t, resp)
+
+	if resp == nil || resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("empty credential on routed match: want 502, got %+v", resp)
+	}
+	if got := req.Header.Get("authorization"); got == "Bearer " {
+		t.Fatalf("empty credential injected; want fail closed before injection")
+	}
+}
+
+// Two distinct route tokens present in one request is ambiguous: postern must
+// not guess which secret the agent wanted. Fail closed, resolver untouched.
+func TestHook_RouteAmbiguousFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	res := &fakeResolver{value: "sk-secret"}
+	hook := newHookFixture(t, routedRule(), res)
+
+	req, _ := http.NewRequest(http.MethodPost, "https://api.telegram.org/sendMessage", http.NoBody)
+	req.Header.Set("authorization", "Bearer tg_max_8Kq2Lp9wZ")
+	req.Header.Set("x-alt", "tg_john_3Rt7Yx1mQ")
+	resp := hook(req) //nolint:bodyclose // closeIfNonNil handles the non-nil branch
+	defer closeIfNonNil(t, resp)
+
+	if resp == nil {
+		t.Fatalf("ambiguous tokens: want non-nil 502, got nil")
+	}
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", resp.StatusCode)
+	}
+	if got := res.calls.Load(); got != 0 {
+		t.Fatalf("resolver.calls = %d, want 0 (ambiguous selection must not resolve)", got)
+	}
+}
+
+// Routing logs must attribute the request to the route's name for observability
+// but must NEVER contain the token value, which is effectively a shared secret.
+func TestHook_RouteTokenNeverLogged(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	hook := broker.Hook(broker.NewEngine([]broker.Rule{routedRule()}), &fakeResolver{value: "sk-secret"}, config.OnNoMatchPassthrough, 0, logger) //nolint:bodyclose // closeIfNonNil handles the non-nil branch
+
+	req, _ := http.NewRequest(http.MethodPost, "https://api.telegram.org/sendMessage", http.NoBody)
+	req.Header.Set("authorization", "Bearer tg_max_8Kq2Lp9wZ")
+	resp := hook(req) //nolint:bodyclose // closeIfNonNil handles the non-nil branch
+	defer closeIfNonNil(t, resp)
+
+	logs := buf.String()
+	if !contains(logs, "api.telegram.org") {
+		t.Fatalf("logs missing host attribution; got %q", logs)
+	}
+	if !contains(logs, "max") {
+		t.Fatalf("logs missing route name attribution; got %q", logs)
+	}
+	if contains(logs, "tg_max_8Kq2Lp9wZ") {
+		t.Fatalf("logs leaked the route token; got %q", logs)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return bytes.Contains([]byte(haystack), []byte(needle))
+}
+
+// A body-surface route whose token sits in a body postern won't scan
+// (compressed/multipart) must fail closed: the token is unreadable, so no route
+// is selected and the resolver is never called.
+func TestHook_RouteBodyCompressedFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	res := &fakeResolver{value: "sk-secret"}
+	rule := routedRule()
+	rule.Injection.Surfaces = []broker.Surface{broker.SurfaceBody}
+	hook := newHookFixture(t, rule, res)
+
+	req, _ := http.NewRequest(http.MethodPost, "https://api.telegram.org/sendMessage",
+		strings.NewReader(`{"token":"tg_max_8Kq2Lp9wZ"}`))
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("content-encoding", "gzip") // opaque to postern; body is not scanned
+	resp := hook(req)                          //nolint:bodyclose // closeIfNonNil handles the non-nil branch
+	defer closeIfNonNil(t, resp)
+
+	if resp == nil || resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("compressed-body route: want 502, got %+v", resp)
+	}
+	if got := res.calls.Load(); got != 0 {
+		t.Fatalf("resolver.calls = %d, want 0 (an unscannable body must not select or resolve)", got)
+	}
+}
+
+// Two different route tokens present across different surfaces (one in a header,
+// one in the body) is ambiguous and must fail closed — selection aggregates
+// across surfaces, so this must not silently pick the first.
+func TestHook_RouteCrossSurfaceAmbiguityFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	res := &fakeResolver{value: "sk-secret"}
+	rule := routedRule()
+	rule.Injection.Surfaces = []broker.Surface{broker.SurfaceHeader, broker.SurfaceBody}
+	hook := newHookFixture(t, rule, res)
+
+	req, _ := http.NewRequest(http.MethodPost, "https://api.telegram.org/sendMessage",
+		strings.NewReader(`{"token":"tg_john_3Rt7Yx1mQ"}`))
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("authorization", "Bearer tg_max_8Kq2Lp9wZ")
+	resp := hook(req) //nolint:bodyclose // closeIfNonNil handles the non-nil branch
+	defer closeIfNonNil(t, resp)
+
+	if resp == nil || resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("cross-surface ambiguity: want 502, got %+v", resp)
+	}
+	if got := res.calls.Load(); got != 0 {
+		t.Fatalf("resolver.calls = %d, want 0 (ambiguous selection must not resolve)", got)
+	}
+}
+
+func TestHook_RouteSelectsByPathToken(t *testing.T) {
+	t.Parallel()
+
+	res := &fakeResolver{value: "sk-secret"}
+	rule := routedRule()
+	rule.Injection.Surfaces = []broker.Surface{broker.SurfacePath}
+	hook := newHookFixture(t, rule, res)
+
+	req, _ := http.NewRequest(http.MethodGet, "https://api.telegram.org/v1/tg_max_8Kq2Lp9wZ/models", http.NoBody)
+	resp := hook(req) //nolint:bodyclose // closeIfNonNil handles the non-nil branch
+	defer closeIfNonNil(t, resp)
+
+	if resp != nil {
+		t.Fatalf("hook returned response on path-routed match: %+v, want nil", resp)
+	}
+	if got := res.lastVR.ref; got != "op://Agents/telegram-max/token" {
+		t.Fatalf("resolver ref = %q, want max route ref", got)
+	}
+	if !strings.Contains(req.URL.EscapedPath(), "sk-secret") {
+		t.Fatalf("path = %q, want token replaced by credential", req.URL.EscapedPath())
+	}
+}
+
+func TestHook_RouteSelectsByQueryToken(t *testing.T) {
+	t.Parallel()
+
+	res := &fakeResolver{value: "sk-secret"}
+	rule := routedRule()
+	rule.Injection.Surfaces = []broker.Surface{broker.SurfaceQuery}
+	hook := newHookFixture(t, rule, res)
+
+	req, _ := http.NewRequest(http.MethodGet, "https://api.telegram.org/v1/models?key=tg_john_3Rt7Yx1mQ", http.NoBody)
+	resp := hook(req) //nolint:bodyclose // closeIfNonNil handles the non-nil branch
+	defer closeIfNonNil(t, resp)
+
+	if resp != nil {
+		t.Fatalf("hook returned response on query-routed match: %+v, want nil", resp)
+	}
+	if got := res.lastVR.ref; got != "op://Agents/telegram-john/token" {
+		t.Fatalf("resolver ref = %q, want john route ref", got)
+	}
+	if !strings.Contains(req.URL.RawQuery, "sk-secret") {
+		t.Fatalf("query = %q, want token replaced by credential", req.URL.RawQuery)
+	}
+}
+
+// InjectRoute carries the same defense-in-depth backstops as Inject: a template
+// without {{ CREDENTIAL }} and an empty route token both fail closed without
+// mutating the request, even though the validator already rejects both.
+func TestInjectRoute_FailsClosedGuards(t *testing.T) {
+	t.Parallel()
+
+	noCred := broker.Rule{
+		Host:      "api.telegram.org",
+		Injection: broker.InjectSpec{Type: broker.InjectPlaceholder, Template: "static-no-placeholder"},
+	}
+	req, _ := http.NewRequest(http.MethodGet, "https://api.telegram.org/", http.NoBody)
+	req.Header.Set("authorization", "Bearer tg_max_8Kq2Lp9wZ")
+	err := noCred.InjectRoute(req, broker.Route{Name: "max", Token: "tg_max_8Kq2Lp9wZ", SecretRef: "op://V/m"}, "sk")
+	if !errors.Is(err, broker.ErrNoCredentialPlaceholder) {
+		t.Fatalf("template without {{ CREDENTIAL }}: err = %v, want ErrNoCredentialPlaceholder", err)
+	}
+	if got := req.Header.Get("authorization"); got != "Bearer tg_max_8Kq2Lp9wZ" {
+		t.Fatalf("request mutated on guard failure: %q", got)
+	}
+
+	emptyTok := broker.Rule{
+		Host:      "api.telegram.org",
+		Injection: broker.InjectSpec{Type: broker.InjectPlaceholder, Template: "{{ CREDENTIAL }}"},
+	}
+	req2, _ := http.NewRequest(http.MethodGet, "https://api.telegram.org/", http.NoBody)
+	err = emptyTok.InjectRoute(req2, broker.Route{Name: "x", Token: "", SecretRef: "op://V/x"}, "sk")
+	if !errors.Is(err, broker.ErrEmptyPlaceholderToken) {
+		t.Fatalf("empty route token: err = %v, want ErrEmptyPlaceholderToken", err)
+	}
+}
+
+// A routes rule must survive engine.Swap (the atomic ruleset copy) intact: the
+// new ruleset's tokens select, and the pre-swap token no longer does.
+func TestEngine_SwapPreservesRoutesRule(t *testing.T) {
+	t.Parallel()
+
+	eng := broker.NewEngine([]broker.Rule{routedRule()})
+	swapped := broker.Rule{
+		Host:      "api.telegram.org",
+		Injection: broker.InjectSpec{Type: broker.InjectPlaceholder, Template: "{{ CREDENTIAL }}"},
+		Routes:    []broker.Route{{Name: "alice", Token: "tg_alice_Zz9Qq", SecretRef: "op://Agents/alice/token"}},
+	}
+	eng.Swap([]broker.Rule{swapped})
+
+	got, ok := eng.Match("api.telegram.org")
+	if !ok {
+		t.Fatalf("Match after Swap: rule not found")
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "https://api.telegram.org/", http.NoBody)
+	req.Header.Set("authorization", "Bearer tg_alice_Zz9Qq")
+	route, sel := got.SelectRoute(req)
+	if !sel || route.Name != "alice" || route.SecretRef != "op://Agents/alice/token" {
+		t.Fatalf("SelectRoute after Swap = (%+v, %v), want alice route", route, sel)
+	}
+
+	old, _ := http.NewRequest(http.MethodGet, "https://api.telegram.org/", http.NoBody)
+	old.Header.Set("authorization", "Bearer tg_max_8Kq2Lp9wZ")
+	if _, sel := got.SelectRoute(old); sel {
+		t.Fatalf("pre-swap token still selects after Swap (stale ruleset)")
+	}
+}

--- a/internal/broker/rule.go
+++ b/internal/broker/rule.go
@@ -4,7 +4,12 @@
 // the request upstream.
 package broker
 
-import "strings"
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+)
 
 // Rule is the runtime representation of a single host-broker entry. It is
 // derived from config.Rule by callers (typically the runtime wiring).
@@ -17,12 +22,124 @@ type Rule struct {
 	// SecretRef is the vendor-agnostic secret reference URI the resolver
 	// looks up when this rule matches an outbound request (e.g.,
 	// "op://Agents/Anthropic/api_key"). Validated upstream against the
-	// secret-reference URI grammar.
+	// secret-reference URI grammar. Empty for a placeholder-routing rule (see
+	// Routes), where each route carries its own ref.
 	SecretRef string
 
 	// Injection describes how the resolved credential is attached to the
 	// outbound request. See InjectSpec and Rule.Inject.
 	Injection InjectSpec
+
+	// Routes, when non-empty, makes this a placeholder-routing rule: the token
+	// an agent presents on a declared surface selects (and is replaced by) the
+	// route's secret. See SelectRoute and InjectRoute.
+	Routes []Route
+}
+
+// Route is one entry of a placeholder-routing rule: presenting Token selects
+// SecretRef and replaces Token in place with the resolved value. Name is the
+// log-safe label for the agent; the token value is never logged.
+type Route struct {
+	Name      string
+	Token     string
+	SecretRef string
+}
+
+// SelectRoute scans the rule's declared surfaces for route tokens and returns
+// the single route whose token is present in the request. ok is false when no
+// route token is found or when more than one distinct route token is present
+// (ambiguous); the caller fails closed in both cases rather than guess. For a
+// body-surface rule the caller must have materialized req.Body into a bounded
+// in-memory reader first (Hook does).
+func (r Rule) SelectRoute(req *http.Request) (Route, bool) {
+	surfaces := r.Injection.Surfaces
+	if len(surfaces) == 0 {
+		surfaces = []Surface{SurfaceHeader}
+	}
+
+	// Read the body at most once for the whole selection: scanning it per route
+	// would copy the (already buffered) body N times. body is nil when no
+	// surface scans it or the body is one we never rewrite (nil, compressed,
+	// multipart); req.Body is restored exactly once here for later injection.
+	var body []byte
+	if scansBody(surfaces) {
+		body = readBodyForScan(req)
+	}
+
+	var matched Route
+	found := 0
+	for _, rt := range r.Routes {
+		if rt.Token == "" {
+			continue
+		}
+		if tokenPresent(req, surfaces, rt.Token, body) {
+			matched = rt
+			found++
+		}
+	}
+	if found != 1 {
+		return Route{}, false
+	}
+	return matched, true
+}
+
+// scansBody reports whether the surface list includes the body surface.
+func scansBody(surfaces []Surface) bool {
+	for _, s := range surfaces {
+		if s == SurfaceBody {
+			return true
+		}
+	}
+	return false
+}
+
+// tokenPresent reports whether token appears on any of the declared surfaces.
+// body is the once-read request body (nil if the body surface is not scanned or
+// the body is not text-rewritable); the header/path/query scans are cheap and
+// read directly from req.
+func tokenPresent(req *http.Request, surfaces []Surface, token string, body []byte) bool {
+	for _, s := range surfaces {
+		switch s {
+		case SurfaceHeader:
+			for _, vs := range req.Header {
+				for _, v := range vs {
+					if strings.Contains(v, token) {
+						return true
+					}
+				}
+			}
+		case SurfacePath:
+			if strings.Contains(req.URL.EscapedPath(), token) {
+				return true
+			}
+		case SurfaceQuery:
+			if strings.Contains(req.URL.RawQuery, token) {
+				return true
+			}
+		case SurfaceBody:
+			if body != nil && bytes.Contains(body, []byte(token)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// readBodyForScan reads the request body once for token scanning and restores
+// it so a later injection can read it again. It returns nil for a body that
+// must not be scanned (nil, NoBody, compressed, or multipart), matching
+// substituteBody's passthrough.
+func readBodyForScan(req *http.Request) []byte {
+	if req.Body == nil || req.Body == http.NoBody || bodySkippable(req) {
+		return nil
+	}
+	raw, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil
+	}
+	req.Body = io.NopCloser(bytes.NewReader(raw))
+	req.ContentLength = int64(len(raw))
+	return raw
 }
 
 // usesBodySurface reports whether the rule rewrites the request body. The hook

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -347,13 +347,22 @@ func pickProvider(reg *credstore.Registry, cs config.CredStore) (credstore.Provi
 // credstore case, which the per-scheme router would otherwise only reject at
 // the first matching request.
 func assertRulesRoutable(rules []broker.Rule, resolvers map[string]broker.Resolver) error {
-	for _, r := range rules {
-		scheme, _, ok := strings.Cut(r.SecretRef, "://")
-		if !ok || scheme == "" {
-			continue
+	for i := range rules {
+		r := &rules[i]
+		// A placeholder-routing rule has an empty rule-level SecretRef and one
+		// ref per route; check every ref the rule can resolve to.
+		refs := []string{r.SecretRef}
+		for _, rt := range r.Routes {
+			refs = append(refs, rt.SecretRef)
 		}
-		if _, ok := resolvers[scheme]; !ok {
-			return fmt.Errorf("rule %q references secret_ref scheme %q but no credstore resolves it", r.Host, scheme)
+		for _, ref := range refs {
+			scheme, _, ok := strings.Cut(ref, "://")
+			if !ok || scheme == "" {
+				continue
+			}
+			if _, ok := resolvers[scheme]; !ok {
+				return fmt.Errorf("rule %q references secret_ref scheme %q but no credstore resolves it", r.Host, scheme)
+			}
 		}
 	}
 	return nil

--- a/internal/cli/server_broker_test.go
+++ b/internal/cli/server_broker_test.go
@@ -206,6 +206,24 @@ func TestAssertRulesRoutable(t *testing.T) {
 	if !strings.Contains(err.Error(), "bw") {
 		t.Fatalf("error should name the unroutable scheme: %v", err)
 	}
+
+	// A placeholder-routing rule has an empty rule-level SecretRef; its
+	// per-route secret_ref schemes must still be checked, or an unroutable route
+	// would only surface as a 502 at the first matching request.
+	unroutableRoutes := []broker.Rule{{Host: "api.telegram.org", Routes: []broker.Route{
+		{Name: "max", Token: "tgMax", SecretRef: "op://V/max"},
+		{Name: "john", Token: "tgJohn", SecretRef: "bw://C/john"},
+	}}}
+	if err := assertRulesRoutable(unroutableRoutes, resolvers); err == nil {
+		t.Fatalf("routes rule with unroutable route scheme: want error, got nil")
+	}
+
+	routableRoutes := []broker.Rule{{Host: "api.telegram.org", Routes: []broker.Route{
+		{Name: "max", Token: "tgMax", SecretRef: "op://V/max"},
+	}}}
+	if err := assertRulesRoutable(routableRoutes, resolvers); err != nil {
+		t.Fatalf("routes rule with routable scheme: unexpected error %v", err)
+	}
 }
 
 func writeConfig(t *testing.T, body string) string {

--- a/internal/config/default.yaml
+++ b/internal/config/default.yaml
@@ -56,3 +56,22 @@ rules:
       type: header
       name: authorization
       template: "Bearer {{ CREDENTIAL }}"
+
+  # Placeholder routing: let several agents share one host rule, each presenting
+  # its own token. The token selects which secret to inject AND is the value
+  # postern replaces in place. Use instead of secret_ref + inject.name (mutually
+  # exclusive). Pick high-entropy tokens: a token is effectively the only thing
+  # separating one agent's secret from another's. Unknown or ambiguous tokens
+  # fail closed (502); the token value is never logged (only the route name).
+  # - host: api.telegram.org
+  #   inject:
+  #     type: placeholder
+  #     in: [header]
+  #     template: "{{ CREDENTIAL }}"   # agent sends "Authorization: Bearer <token>"
+  #   routes:
+  #     - name: max
+  #       token: tg_max_8Kq2Lp9wZ
+  #       secret_ref: op://Agents/telegram-max/token
+  #     - name: john
+  #       token: tg_john_3Rt7Yx1mQ
+  #       secret_ref: op://Agents/telegram-john/token

--- a/internal/config/routes_test.go
+++ b/internal/config/routes_test.go
@@ -1,0 +1,252 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mmartinez/postern/internal/config"
+)
+
+// baseRoutesConfig is a valid placeholder-routing config: one host, two named
+// routes whose tokens each select a distinct secret. Cases below mutate it.
+const baseRoutesConfig = `
+token:
+  source: auto
+  env_var: OP_SERVICE_ACCOUNT_TOKEN
+  keychain_account: default
+proxy:
+  listen: 127.0.0.1:1701
+  cache_ttl: 5m
+  on_no_match: passthrough
+rules:
+  - host: api.telegram.org
+    inject:
+      type: placeholder
+      template: "{{ CREDENTIAL }}"
+    routes:
+      - name: max
+        token: tg_max_8Kq2Lp9wZ
+        secret_ref: op://Agents/telegram-max/token
+      - name: john
+        token: tg_john_3Rt7Yx1mQ
+        secret_ref: op://Agents/telegram-john/token
+`
+
+func TestValidateRoutes(t *testing.T) {
+	t.Parallel()
+
+	cases := []validateCase{
+		{
+			name: "valid routes",
+			yaml: baseRoutesConfig,
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				require.Empty(t, lints, "a valid routes block should produce no lints")
+			},
+		},
+		{
+			name: "routes and rule-level secret_ref are mutually exclusive",
+			yaml: strings.Replace(baseRoutesConfig,
+				"  - host: api.telegram.org\n",
+				"  - host: api.telegram.org\n    secret_ref: op://V/I/f\n",
+				1),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "secret_ref")
+			},
+		},
+		{
+			name: "routes with inject.name is rejected",
+			yaml: strings.Replace(baseRoutesConfig,
+				"      type: placeholder\n",
+				"      type: placeholder\n      name: __tok__\n",
+				1),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "name")
+			},
+		},
+		{
+			name: "routes require placeholder inject type",
+			yaml: strings.Replace(baseRoutesConfig,
+				"      type: placeholder\n",
+				"      type: header\n      name: x-api-key\n",
+				1),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "placeholder")
+			},
+		},
+		{
+			name: "route with bad secret_ref shape",
+			yaml: strings.Replace(baseRoutesConfig,
+				"op://Agents/telegram-max/token",
+				"not-a-secret-ref",
+				1),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "secret_ref")
+			},
+		},
+		{
+			name: "duplicate route tokens",
+			yaml: strings.Replace(baseRoutesConfig,
+				"tg_john_3Rt7Yx1mQ",
+				"tg_max_8Kq2Lp9wZ",
+				1),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "duplicate")
+			},
+		},
+		{
+			name: "duplicate route names",
+			yaml: strings.Replace(baseRoutesConfig,
+				"      - name: john\n",
+				"      - name: max\n",
+				1),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "duplicate route name")
+			},
+		},
+		{
+			name: "overlapping route tokens (one a substring of the other)",
+			yaml: strings.Replace(baseRoutesConfig,
+				"tg_john_3Rt7Yx1mQ",
+				"tg_max_8Kq2Lp9wZ_admin",
+				1),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "overlap")
+			},
+		},
+		{
+			name: "empty route name",
+			yaml: strings.Replace(baseRoutesConfig,
+				"      - name: max\n",
+				"      - name: \"\"\n",
+				1),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "name")
+			},
+		},
+		{
+			name: "empty route token",
+			yaml: strings.Replace(baseRoutesConfig,
+				"        token: tg_max_8Kq2Lp9wZ\n",
+				"        token: \"\"\n",
+				1),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "token")
+			},
+		},
+		{
+			name: "valid route tokens on body surface",
+			yaml: strings.Replace(baseRoutesConfig,
+				"      type: placeholder\n",
+				"      type: placeholder\n      in: [body]\n",
+				1),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				require.Empty(t, lints, "unreserved tokens are valid on the body surface")
+			},
+		},
+		{
+			name: "route token with reserved chars on non-header surface",
+			yaml: strings.Replace(
+				strings.Replace(baseRoutesConfig,
+					"      type: placeholder\n",
+					"      type: placeholder\n      in: [body]\n",
+					1),
+				"tg_max_8Kq2Lp9wZ", "tg/max/reserved", 1),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "unreserved")
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, lints, err := config.LoadAndValidate(strings.NewReader(tc.yaml))
+			if tc.wantErr {
+				require.Error(t, err, "expected a parse-level error")
+				return
+			}
+			require.NoError(t, err, "unexpected parse-level error")
+			if tc.wantLints != nil {
+				tc.wantLints(t, lints)
+			}
+		})
+	}
+}
+
+// A route token is effectively a shared secret in multi-agent deployments, so
+// validator messages that reference a token must fingerprint it, never echo it
+// whole (a failing `config validate` can land in CI logs).
+func TestValidateRoutes_MasksTokenInMessages(t *testing.T) {
+	t.Parallel()
+
+	const token = "tg_max_8Kq2Lp9wZ"
+	dup := strings.Replace(baseRoutesConfig, "tg_john_3Rt7Yx1mQ", token, 1)
+
+	_, lints, err := config.LoadAndValidate(strings.NewReader(dup))
+	require.NoError(t, err)
+	requireLintContains(t, lints, "duplicate")
+	for _, l := range lints {
+		if strings.Contains(l.Message, token) {
+			t.Fatalf("validator message leaked the full token %q: %q", token, l.Message)
+		}
+	}
+}
+
+// A token may contain multi-byte UTF-8 characters on the header surface (where
+// the unreserved-charset restriction does not apply). The token fingerprint in
+// validator messages must remain valid UTF-8 — never slice mid-rune.
+func TestValidateRoutes_MaskTokenStaysValidUTF8(t *testing.T) {
+	t.Parallel()
+
+	const tok = "tg_max_café_ünîçødé" // multi-byte; matches the gitleaks test-token allowlist
+	cfg := strings.NewReplacer(
+		"tg_max_8Kq2Lp9wZ", tok,
+		"tg_john_3Rt7Yx1mQ", tok,
+	).Replace(baseRoutesConfig)
+
+	_, lints, err := config.LoadAndValidate(strings.NewReader(cfg))
+	require.NoError(t, err)
+	require.NotEmpty(t, lints, "duplicate multi-byte token should lint")
+	for _, l := range lints {
+		require.True(t, utf8.ValidString(l.Message), "lint message must be valid UTF-8: %q", l.Message)
+	}
+}
+
+// A guessable (low-entropy) route token is a non-fatal warning, not an error:
+// the operator owns the risk, so the config still loads. High-entropy tokens
+// produce no entropy finding, and the warning masks the token.
+func TestValidateRoutes_WarnsOnGuessableToken(t *testing.T) {
+	t.Parallel()
+
+	// baseRoutesConfig uses long mixed-class tokens — no entropy finding.
+	_, lints, err := config.LoadAndValidate(strings.NewReader(baseRoutesConfig))
+	require.NoError(t, err)
+	for _, l := range lints {
+		if strings.Contains(l.Message, "entropy") {
+			t.Fatalf("high-entropy tokens should not warn: %v", l)
+		}
+	}
+
+	// Short, human-named tokens are guessable → warning (not error).
+	guessable := strings.NewReplacer(
+		"tg_max_8Kq2Lp9wZ", "tgMax",
+		"tg_john_3Rt7Yx1mQ", "tgJohn",
+	).Replace(baseRoutesConfig)
+
+	_, lints, err = config.LoadAndValidate(strings.NewReader(guessable))
+	require.NoError(t, err)
+	requireLintContains(t, lints, "entropy")
+
+	var saw bool
+	for _, l := range lints {
+		if strings.Contains(l.Message, "entropy") {
+			saw = true
+			require.Equal(t, config.SeverityWarning, l.Severity, "entropy finding must be a warning, not fatal")
+			require.NotContains(t, l.Message, "tgMax", "entropy warning must mask the token")
+		}
+	}
+	require.True(t, saw, "expected an entropy warning for a guessable token")
+}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -246,6 +246,24 @@ type Rule struct {
 	Host      string `yaml:"host,omitempty"`
 	SecretRef string `yaml:"secret_ref"`
 	Inject    Inject `yaml:"inject,omitempty"`
+
+	// Routes turns a single host rule into a placeholder-routing rule: each
+	// entry's token both selects, and is replaced by, its own secret. Mutually
+	// exclusive with the rule-level SecretRef and inject.name, and valid only
+	// with inject.type=placeholder. Lets several agents share one host rule,
+	// each presenting its own token.
+	Routes []Route `yaml:"routes,omitempty"`
+}
+
+// Route is one entry of a placeholder-routing rule. Token is the placeholder an
+// agent presents on a declared inject surface; matching it selects SecretRef as
+// the secret to resolve, and the same token is replaced in place by the
+// resolved value. Name is an operator-facing label surfaced in logs to
+// attribute a request to an agent; the token value itself is never logged.
+type Route struct {
+	Name      string `yaml:"name"`
+	Token     string `yaml:"token"`
+	SecretRef string `yaml:"secret_ref"`
 }
 
 // Inject describes how a resolved credential is attached to outbound traffic.

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"math"
 	"net"
 	"regexp"
 	"strings"
@@ -220,6 +221,11 @@ func (v *validator) checkRule(base string, r Rule) {
 		v.add(base+".host", fmt.Sprintf("host %q must be a literal hostname or a single-* glob (e.g. *.example.com)", r.Host), SeverityError)
 	}
 
+	if len(r.Routes) > 0 {
+		v.checkRoutes(base, r)
+		return
+	}
+
 	if r.SecretRef == "" {
 		v.add(base+".secret_ref", "secret_ref is required", SeverityError)
 	} else if !secretRefPattern.MatchString(r.SecretRef) {
@@ -227,6 +233,176 @@ func (v *validator) checkRule(base string, r Rule) {
 	}
 
 	v.checkInject(base+".inject", r.Inject)
+}
+
+// checkRoutes validates a placeholder-routing rule. Routes mode replaces the
+// rule-level secret_ref and inject.name: each route carries its own token (the
+// placeholder) and secret_ref (the secret that token selects). The shared
+// inject block still supplies the template and surfaces, so its template is
+// validated here while its name must be empty.
+func (v *validator) checkRoutes(base string, r Rule) {
+	in := r.Inject
+	if r.SecretRef != "" {
+		v.add(base+".secret_ref", "secret_ref must be empty when routes is set; each route's secret_ref selects the secret", SeverityError)
+	}
+	if in.Type != InjectTypePlaceholder {
+		v.add(base+".inject.type", fmt.Sprintf("inject.type must be placeholder when routes is set (got %q)", in.Type), SeverityError)
+	}
+	if in.Name != "" {
+		v.add(base+".inject.name", "inject.name must be empty when routes is set; each route's token is the placeholder", SeverityError)
+	}
+	if in.Template == "" {
+		v.add(base+".inject.template", "template is required", SeverityError)
+	} else if !strings.Contains(in.Template, "{{ CREDENTIAL }}") && !strings.Contains(in.Template, "{{CREDENTIAL}}") {
+		v.add(base+".inject.template", "template must contain a {{ CREDENTIAL }} placeholder; without it the resolved credential is discarded and the request is forwarded unauthenticated", SeverityError)
+	}
+
+	v.checkInjectSurfaces(base+".inject", in)
+	v.checkRouteEntries(base, r.Routes, surfacesHaveNonHeader(in.In))
+}
+
+// checkRouteEntries validates each route: required fields, a well-formed
+// secret_ref, a token charset that round-trips outside headers, and that tokens
+// are mutually unique and non-overlapping (no token a substring of another).
+// Overlap is fatal because substitution matches by substring: an agent's token
+// contained in another's would route to the wrong secret.
+func (v *validator) checkRouteEntries(base string, routes []Route, hasNonHeader bool) {
+	seenToken := make(map[string]int, len(routes))
+	seenName := make(map[string]int, len(routes))
+	for i, rt := range routes {
+		rb := fmt.Sprintf("%s.routes[%d]", base, i)
+		if rt.Name == "" {
+			v.add(rb+".name", "name is required", SeverityError)
+		} else if prev, dup := seenName[rt.Name]; dup {
+			// Names are the log/metric attribution handle; duplicates make a
+			// request impossible to attribute to one agent. Not a secret, so
+			// echo it plainly.
+			v.add(rb+".name", fmt.Sprintf("duplicate route name %q (first declared at %s.routes[%d])", rt.Name, base, prev), SeverityError)
+		} else {
+			seenName[rt.Name] = i
+		}
+		if rt.Token == "" {
+			v.add(rb+".token", "token is required", SeverityError)
+		}
+		if rt.SecretRef == "" {
+			v.add(rb+".secret_ref", "secret_ref is required", SeverityError)
+		} else if !secretRefPattern.MatchString(rt.SecretRef) {
+			v.add(rb+".secret_ref", fmt.Sprintf("secret_ref %q must be a URI of the form <scheme>://<rest> (e.g., op://VAULT/ITEM/FIELD)", rt.SecretRef), SeverityError)
+		}
+		if hasNonHeader && rt.Token != "" && !unreservedTokenPattern.MatchString(rt.Token) {
+			v.add(rb+".token", "token must use only RFC 3986 unreserved characters (A-Z a-z 0-9 - . _ ~) when substituting outside headers", SeverityError)
+		}
+		if rt.Token != "" {
+			if prev, dup := seenToken[rt.Token]; dup {
+				v.add(rb+".token", fmt.Sprintf("duplicate token %s (first declared at %s.routes[%d])", maskToken(rt.Token), base, prev), SeverityError)
+			} else {
+				seenToken[rt.Token] = i
+			}
+			// A guessable token lets a co-tenant agent reach another route's
+			// secret. Warn (not fatal) — the operator owns the trust decision.
+			if bits := tokenEntropyBits(rt.Token); bits < minRecommendedTokenEntropyBits {
+				v.add(rb+".token", fmt.Sprintf("token %s looks low-entropy (~%.0f bits); a guessable token lets a co-tenant agent reach another route's secret — use a high-entropy token (>= %d bits, e.g. 16+ random characters)", maskToken(rt.Token), bits, minRecommendedTokenEntropyBits), SeverityWarning)
+			}
+		}
+	}
+
+	for i := range routes {
+		ti := routes[i].Token
+		if ti == "" {
+			continue
+		}
+		for j := range routes {
+			if i == j {
+				continue
+			}
+			tj := routes[j].Token
+			if tj == "" || ti == tj {
+				continue
+			}
+			if strings.Contains(ti, tj) {
+				v.add(fmt.Sprintf("%s.routes[%d].token", base, i),
+					fmt.Sprintf("token %s overlaps token %s (one is a substring of the other); routing matches by substring, so tokens must be mutually non-overlapping", maskToken(ti), maskToken(tj)),
+					SeverityError)
+			}
+		}
+	}
+}
+
+// surfacesHaveNonHeader reports whether the surface list names any surface other
+// than header, which tightens the token charset (the token is percent-escaped
+// outside header values and must round-trip).
+func surfacesHaveNonHeader(in []InjectSurface) bool {
+	for _, s := range in {
+		if s == InjectSurfaceBody || s == InjectSurfacePath || s == InjectSurfaceQuery {
+			return true
+		}
+	}
+	return false
+}
+
+// minRecommendedTokenEntropyBits is the estimated-entropy floor below which a
+// route token earns a warning. 64 bits is the common "strong shared secret"
+// bar; below it a token starts to look human-named or short enough that a
+// co-tenant agent could guess it. The estimate (see tokenEntropyBits) is
+// length times log2 of the character-class alphabet, so it catches short or
+// low-diversity tokens, not dictionary words.
+const minRecommendedTokenEntropyBits = 64
+
+// tokenEntropyBits estimates a token's entropy as len * log2(alphabet), where
+// alphabet is the union of the character classes the token uses (lowercase,
+// uppercase, digits, other). It is a deliberately rough upper bound used only
+// to flag obviously-guessable tokens; it cannot detect a long dictionary word.
+func tokenEntropyBits(s string) float64 {
+	var lower, upper, digit, other bool
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+			lower = true
+		case r >= 'A' && r <= 'Z':
+			upper = true
+		case r >= '0' && r <= '9':
+			digit = true
+		default:
+			other = true
+		}
+	}
+	alphabet := 0
+	if lower {
+		alphabet += 26
+	}
+	if upper {
+		alphabet += 26
+	}
+	if digit {
+		alphabet += 10
+	}
+	if other {
+		alphabet += 32
+	}
+	if alphabet == 0 {
+		return 0
+	}
+	return float64(len([]rune(s))) * math.Log2(float64(alphabet))
+}
+
+// maskToken returns a log-safe fingerprint of a route token in the form
+// "first4…last4", fully masking anything too short to reveal safely. A route
+// token can be a shared secret in multi-agent deployments, so validator
+// messages identify it by fingerprint rather than echoing it whole (a failing
+// `config validate` may land in CI logs). Duplicated from token.Fingerprint
+// because config cannot import token (token imports config).
+func maskToken(s string) string {
+	const reveal = 4
+	if s == "" {
+		return "<empty>"
+	}
+	// Rune-aware so a multi-byte token (allowed on the header surface) is never
+	// sliced mid-rune into invalid UTF-8.
+	r := []rune(s)
+	if len(r) < 2*reveal+1 {
+		return strings.Repeat("*", len(r))
+	}
+	return string(r[:reveal]) + "…" + string(r[len(r)-reveal:])
 }
 
 func (v *validator) checkInject(base string, in Inject) {


### PR DESCRIPTION
## What

A `placeholder` rule can carry a `routes` list of `{name, token, secret_ref}`. The token an agent presents on a declared surface both **selects** which secret to resolve and is the placeholder **replaced** in place by the resolved value. This lets several agents share one host rule, each presenting its own token — without any agent holding another's credential.

```yaml
rules:
  - host: api.example.com
    inject:
      type: placeholder
      in: [header]                 # default
      template: "{{ CREDENTIAL }}" # agent sends "Authorization: Bearer <token>"
    routes:
      - name: max
        token: tg_max_8Kq2Lp9wZ
        secret_ref: op://Vault/max/credential
      - name: john
        token: tg_john_3Rt7Yx1mQ
        secret_ref: op://Vault/john/credential
```

Mutually exclusive with rule-level `secret_ref` + `inject.name`. Requires `type: placeholder`. Works across all surfaces (header/body/path/query) and both providers (`op://`, `bw://`).

## Security model

- **Closed allowlist + fail closed.** Only enumerated tokens resolve. Unknown, absent, or ambiguous (>1 distinct token present) → `502`, resolver never called, upstream never contacted. Verified by unit tests (resolver call-count 0) and E2E (upstream hit-count 0).
- **No token leak.** Logs carry the route `name` + host only; validator messages fingerprint the token (`first4…last4`). Dedicated regression tests for both.
- **Transport guard unchanged** — injection still refused over cleartext, before any resolve.
- **Substring-overlap rejected** at config load (substitution matches by substring, so an overlapping token would route to the wrong secret).
- **Token entropy is load-bearing** when agents are mutually untrusted. Postern emits a non-fatal **warning** for low-entropy tokens (< ~64 estimated bits, e.g. `tgMax`); the operator owns the trust decision so it does not block boot.

## Tests

- **validator**: routes XOR secret_ref/inject.name, placeholder-required, valid refs, duplicate/overlapping tokens, charset on non-header surfaces, token masking, low-entropy warning.
- **broker**: from_config translation; hook selection (header/body/path/query); unknown→502+no-resolve; ambiguous (same-surface and cross-surface)→502; resolver-error→502 (no partial credential); empty-cred→502; compressed-body→fail-closed; token-never-logged; `InjectRoute` backstops; `engine.Swap` hot-reload.
- **E2E** through the full MITM path: routed secret reaches upstream; unknown token → 502 with upstream hit-count and resolver call-count both 0.
- **cli**: `assertRulesRoutable` covers per-route refs.

Coverage: broker 90.9%, config 89.8% (≥80 gate). `make ci`-equivalent green: `golangci-lint` 0 issues, `go vet`/`build` clean, `go test -race ./...` pass, `govulncheck` clean, gofumpt clean, banned-strings clean, gitleaks (git-mode, CI command) 0 leaks.

## Note: gitleaks config fix

The repo's allowlist used the plural `[[allowlists]]` form, which the pinned gitleaks (8.21.4, matched by CI) **silently ignores** under `[extend].useDefault` — a latent no-op that only surfaced once a docs file gained an API-key-shaped string. Converted to the working singular `[allowlist]` and added a tightly-scoped regex (`tg_(max|john|alice)_…`) for the synthetic, deliberately-high-entropy test/example tokens.

## Rollback

Opt-in, additive YAML field — old configs unaffected (strict-parse reads `routes` only when present). Runtime rollback: delete the `routes:` block → hot-reload to single-secret form (no restart), or pin the prior version. RTO < 1 min.

<!-- greptile_comment -->

<h3>Confidence Score: 4/5</h3>

Safe to merge; the routing logic is fail-closed on every path and the token never appears in logs.

The security model is sound — unknown/ambiguous/empty-credential cases all return 502 before the resolver is called, the token is masked in all validator messages, and the transport guard and body cap apply before route selection. The three findings are style and observability issues: body is read N times during route selection rather than once, `maskToken` slices by byte rather than rune (garbled fingerprints for non-ASCII tokens only), and duplicate route names pass validation and silently produce ambiguous log lines.

`internal/config/validator.go` (duplicate name gap and byte-slicing in `maskToken`) and `internal/broker/rule.go` (N body reads in `SelectRoute`) are the files most worth a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/broker/rule.go | Adds `Route` struct and `SelectRoute`/`tokenPresent`/`bodyContains` for per-token route selection; body is read once per route in the scan loop, which is correct but produces N in-memory copies. |
| internal/broker/inject.go | Refactors `injectPlaceholder` into shared `substituteToken` helper and adds `InjectRoute` for per-route injection; defence-in-depth guards (empty token, missing CREDENTIAL placeholder) are correctly preserved. |
| internal/broker/hook.go | Routes block inserted after body buffering and HTTPS transport check; fail-closed on unknown/ambiguous/empty-cred, token never logged, resolver never called on selection failure. |
| internal/config/validator.go | Adds `checkRoutes`/`checkRouteEntries` with XOR validation, placeholder-required enforcement, duplicate/overlap token checks, entropy warning, and token masking; duplicate route `name` is not validated and `maskToken` uses byte-based slicing. |
| internal/broker/routing_test.go | Comprehensive new test file covering selection by header/body/path/query token, unknown/ambiguous/empty-cred fail-closed, resolver-not-called assertions, token-never-logged, engine Swap, and InjectRoute backstops. |
| .gitleaks.toml | Fixes latent no-op allowlist (plural `[[allowlists]]` → singular `[allowlist]`) and adds a regex scoped to the synthetic token prefix; any `tg_(max|john|alice)_…` key with that exact prefix would be exempt from gitleaks detection. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent
    participant Hook
    participant SelectRoute
    participant Resolver
    participant Upstream

    Agent->>Hook: HTTPS request (token on declared surface)
    Hook->>Hook: HTTPS transport check
    Hook->>Hook: Buffer body (if body surface)
    Hook->>SelectRoute: SelectRoute(req)
    SelectRoute->>SelectRoute: Scan surfaces for each route token
    alt Zero or ambiguous tokens
        SelectRoute-->>Hook: "ok=false"
        Hook-->>Agent: 502 (fail closed)
    else Exactly one token matched
        SelectRoute-->>Hook: "(route, ok=true)"
        Hook->>Resolver: Resolve("", route.SecretRef)
        alt Resolve error or empty cred
            Resolver-->>Hook: err / ""
            Hook-->>Agent: 502 (fail closed)
        else Credential resolved
            Resolver-->>Hook: credential
            Hook->>Hook: InjectRoute (replace token with cred)
            Hook->>Upstream: Modified request
            Upstream-->>Agent: Response
        end
    end
```

<sub>Reviews (1): Last reviewed commit: ["feat(broker): route placeholder tokens t..."](https://github.com/mmartinez/postern/commit/04a1cc3ef32e182b33c46816d4ee8452f1597767) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36073475)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->