### PR TITLE
docs: correct stale proxy/provider references against current code

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,7 +109,7 @@ restart, and postern logs a warning when a reload diverges on one of them.
 The broker depends only on a one-method `Resolver` interface, so it has no
 compile-time coupling to any vendor SDK. A credstore provider claims a URI
 scheme, validates its token at boot, and constructs a resolver. Adding a vendor
-is a single new sub-package plus one side-effect import in the binary's wiring
-(`cmd/postern/main.go` or `internal/cli/server.go`, where the shipped providers
-are registered); the broker and proxy logic are untouched. The contract is in
-[providers.md](providers.md).
+is a single new sub-package plus one blank side-effect import in
+`internal/cli/server.go` (the anchor block where all three shipped providers are
+registered, so the `server` command's registry is populated); the broker and
+proxy logic are untouched. The contract is in [providers.md](providers.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -85,8 +85,10 @@ any other private key.
 | `internal/proxy` | goproxy front end: CONNECT handling, MITM, panic recovery, response streaming. |
 | `internal/ca` | Local CA generation, per-host leaf minting, and system trust-store install. |
 | `internal/broker` | Host matching (`Engine`), credential injection (`Inject`), and the proxy hook that wires match → resolve → inject. |
-| `internal/credstore` | Provider registry keyed by URI scheme, plus the `SchemeRouter` that dispatches a `secret_ref` to the right provider. |
-| `internal/credstore/onepassword` | The production provider, backed by the 1Password Go SDK, plus the shared TTL/LRU resolver cache. |
+| `internal/credstore` | Provider registry keyed by URI scheme, the `SchemeRouter` that dispatches a `secret_ref` to the right provider, and the shared background-refreshing resolver cache (`cache.go`) every provider reuses. |
+| `internal/credstore/onepassword` | Provider for 1Password Service Accounts (`op://`), backed by the 1Password Go SDK. Registered by default. |
+| `internal/credstore/bitwarden` | Provider for Bitwarden Secrets Manager (`bw://`), shelling out to the `bws` CLI. Registered by default. |
+| `internal/credstore/oauth2` | Provider that mints short-lived bearer tokens (`oauth2://`) via `golang.org/x/oauth2` (client-credentials / refresh-token grants). Registered by default. |
 | `internal/config` | YAML schema, strict-mode loader, line-numbered validator, and the fsnotify-backed hot-reload watcher. |
 | `internal/token` | Service-account token resolution chain (file → env → keychain) and the OS-keychain-backed store. |
 | `internal/runtime` | Assembles the proxy listener, wires the broker hook, and owns graceful shutdown. |
@@ -107,5 +109,7 @@ restart, and postern logs a warning when a reload diverges on one of them.
 The broker depends only on a one-method `Resolver` interface, so it has no
 compile-time coupling to any vendor SDK. A credstore provider claims a URI
 scheme, validates its token at boot, and constructs a resolver. Adding a vendor
-is a single new sub-package plus a side-effect import in `main`; the broker,
-proxy, and CLI are untouched. The contract is in [providers.md](providers.md).
+is a single new sub-package plus one side-effect import in the binary's wiring
+(`cmd/postern/main.go` or `internal/cli/server.go`, where the shipped providers
+are registered); the broker and proxy logic are untouched. The contract is in
+[providers.md](providers.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,7 +86,7 @@ proxy:
 | `listen` | yes | `host:port` the proxy binds. Point your agent's `HTTPS_PROXY` at this. |
 | `cache` | no | Credential cache settings (see below). |
 | `cache_ttl` | no | **Legacy alias for `cache.ttl`.** Go duration (`5m`, `30s`). Accepted for backward compatibility; prefer the `cache` block. Setting both `cache_ttl` and `cache.ttl` to different values is a config error. |
-| `on_no_match` | no | What to do when no rule matches. `passthrough` (default) forwards the request unchanged. |
+| `on_no_match` | no | What to do when no rule matches. `passthrough` (default) forwards the request unchanged; `block` denies it with a `502` and never contacts the upstream (allowlist-only egress for proxied traffic). See [security.md](security.md#egress-containment-with-on_no_match). |
 | `max_body_bytes` | no | Cap (in bytes) on how much of a request body postern buffers when a rule rewrites the body (`inject.in` includes `body`). Default 1 MiB when unset or `0`. A larger body is rejected with `413 Request Entity Too Large` and never reaches the upstream. Bound at startup; a hot-reload edit warns and does not take effect (a per-rule `inject.max_body_bytes` override does hot-reload). |
 
 ### `proxy.cache`
@@ -119,14 +119,12 @@ vault is not re-hammered.
 > `max_stale` (or set it equal to `ttl` to disable stale-serving) for
 > revocation-sensitive deployments. See [security.md](security.md#credential-caching-and-revocation-window).
 
-> **Note — `on_no_match: block`.** The value is accepted today but not yet
-> enforced: every unmatched request currently passes through regardless. Don't
-> rely on it for egress control. See [security.md](security.md).
->
-> **Note — `listen`.** `postern bootstrap` reads `proxy.listen` when emitting
-> the agent's `HTTPS_PROXY` snippet. `postern server` currently also accepts an
-> `--addr` flag (default `127.0.0.1:1701`); aligning the server's bind to
-> `proxy.listen` is in progress, so keep the two in sync for now.
+> **Note — `listen` and `--addr`.** `postern bootstrap` reads `proxy.listen`
+> when emitting the agent's `HTTPS_PROXY` snippet. `postern server` resolves its
+> bind address with the precedence **`--addr` flag → `proxy.listen` →
+> `127.0.0.1:1701`** (the default): an explicit `--addr` wins, otherwise
+> `proxy.listen` is used, otherwise the built-in default. Set `proxy.listen` and
+> the two stay aligned automatically.
 
 ## `rules`
 
@@ -327,9 +325,13 @@ Errors block startup. Common errors:
 
 - `host is required` / a host that is neither a literal nor a single-`*` glob.
 - `secret_ref` missing or not of the form `<scheme>://<rest>`.
-- `inject.type` missing or not `header`/`placeholder`; `name` missing for a
-  header injection; `template` missing or carrying no `{{ CREDENTIAL }}`
+- `inject.type` missing or not `header`/`placeholder`/`oauth1`; `name` missing
+  for a header injection; `template` missing or carrying no `{{ CREDENTIAL }}`
   placeholder.
+- `inject.type: oauth1` with a rule-level `secret_ref`, or with `inject.name`,
+  `inject.template`, or `inject.in` set; or any of the four `*_ref` fields
+  missing or not of the form `<scheme>://<rest>`. (The `*_ref` fields are valid
+  only with `type: oauth1`.)
 - `inject.in` set with `type: header`; an invalid surface name; a `placeholder`
   token with reserved characters when a non-header surface is declared.
 - `routes` combined with a rule-level `secret_ref` or `inject.name`; `routes`

--- a/docs/ideas/placeholder-token-routing.md
+++ b/docs/ideas/placeholder-token-routing.md
@@ -1,5 +1,10 @@
 # Placeholder-Token Routing (multi-agent, one host)
 
+> **Status: shipped.** This design has been implemented as the `routes:` field on
+> `placeholder` rules. The note below is kept for design rationale; the
+> authoritative, current reference is
+> [configuration.md → Placeholder routing (`routes`)](../configuration.md#placeholder-routing-routes).
+
 ## Problem Statement
 How might we let 2-10 agents share one postern instance per host, each presenting
 its own token, and have that token select which real secret postern injects -- with

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -94,12 +94,15 @@ static, boot-time invariant, and silently overriding a previously
 registered provider would be a footgun. Pick a scheme that does not
 clash with an existing provider in the tree.
 
-To activate the provider, the binary needs a side-effect import of your
-provider package. The default postern binary registers three providers
-this way — `onepassword`, `bitwarden`, and `oauth2`, none behind a build
-tag — so they are available out of the box. A still-experimental provider
-gets a *tagged* side-effect import instead (see [Build tags](#build-tags-for-experimental-providers))
-so the default binary doesn't pull in its dependency until it graduates.
+To activate the provider, add a blank side-effect import of your provider
+package to the anchor block in `internal/cli/server.go` — that is where the
+`server` command's registry is populated, so an import added anywhere else
+(e.g. `cmd/postern/main.go`) leaves the provider unregistered at runtime. The
+default postern binary registers three providers there — `onepassword`,
+`bitwarden`, and `oauth2`, none behind a build tag — so they are available out
+of the box. A still-experimental provider gets a *tagged* side-effect import
+instead (see [Build tags](#build-tags-for-experimental-providers)) so the
+default binary doesn't pull in its dependency until it graduates.
 
 ## Layout convention
 
@@ -122,6 +125,9 @@ internal/credstore/
     settings.go            # parses server_url / bws_path settings
     resolver.go            # broker.Resolver that runs `bws secret get`
     live_test.go           # opt-in live test (BWS_E2E=1)
+  oauth2/                  # production provider (mints tokens via golang.org/x/oauth2)
+    provider.go            # implements credstore.Provider
+    resolver.go            # broker.Resolver that exchanges client creds for a bearer token
 ```
 
 A provider sub-package owns its SDK or CLI shell-out. The only public

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -94,10 +94,12 @@ static, boot-time invariant, and silently overriding a previously
 registered provider would be a footgun. Pick a scheme that does not
 clash with an existing provider in the tree.
 
-To activate the provider, the binary's `main` package needs to import
-your provider package as a side effect. The default postern binary
-already imports `internal/credstore/onepassword`; gated providers (see
-below) get a tagged side-effect import alongside it.
+To activate the provider, the binary needs a side-effect import of your
+provider package. The default postern binary registers three providers
+this way — `onepassword`, `bitwarden`, and `oauth2`, none behind a build
+tag — so they are available out of the box. A still-experimental provider
+gets a *tagged* side-effect import instead (see [Build tags](#build-tags-for-experimental-providers))
+so the default binary doesn't pull in its dependency until it graduates.
 
 ## Layout convention
 
@@ -108,11 +110,11 @@ internal/credstore/
   provider.go              # Provider interface + Registry types
   registry.go              # process-wide registry
   router.go                # SchemeRouter (broker.Resolver dispatcher)
+  cache.go                 # shared background-refreshing TTL/LRU cache (provider-agnostic)
   onepassword/             # production provider (links the SDK)
     provider.go            # implements credstore.Provider
     client.go              # SDK construction + HealthCheck
     sdk_resolver.go        # broker.Resolver backed by the SDK
-    cache.go               # LRU+TTL cache (provider-shared utility)
   bitwarden/               # production provider (shells out to the bws CLI)
     doc.go                 # package doc
     provider.go            # implements credstore.Provider
@@ -369,6 +371,6 @@ import to the default binary (the bitwarden provider followed this path).
 - Use the live SDK only behind an opt-in env var (e.g., `XX_E2E=1`)
   and an opt-in CI workflow trigger. See
   `internal/credstore/onepassword/live_test.go` for the pattern.
-- The cache in `internal/credstore/onepassword/cache.go` is generic;
-  consider reusing it rather than reimplementing TTL/LRU in your
-  provider.
+- The cache in `internal/credstore/cache.go` is generic and
+  provider-agnostic; consider reusing it rather than reimplementing
+  TTL/LRU in your provider.


### PR DESCRIPTION
Audited `docs/` against the current `internal/` code (repo at release 0.5.0) and fixed the places where the documentation had drifted from the implementation. Docs-only — no code or behavior changed.

## Corrected inaccuracies

- **`on_no_match: block`** — `configuration.md` said it was "accepted today but not yet enforced," contradicting `security.md`. The broker hook actually returns a `502` for unmatched hosts when `block` is set (`internal/broker/hook.go:66`). Removed the stale note and documented `block` in the field table.
- **`server --addr` vs `proxy.listen`** — the "alignment in progress" note was stale. Precedence (`--addr` → `proxy.listen` → default) is shipped via `resolveListenAddr` (`internal/cli/server.go:173`). Replaced the note with the actual rule.
- **Missing providers** — added `internal/credstore/bitwarden` (`bw://`) and `internal/credstore/oauth2` (`oauth2://`) to the architecture components table. Both register by default (side-effect imports in `internal/cli/server.go:27-28`), not behind build tags.
- **Shared resolver cache** — it lives at `internal/credstore/cache.go` (package `credstore`, provider-agnostic), not under `onepassword/`. Fixed the layout diagram, components table, and testing checklist in `providers.md`.
- **`inject.type=oauth1`** — was missing from the validation reference. Added it plus the oauth1-specific config errors (`internal/config/validator.go:476`).
- **Provider-activation note** — updated `providers.md` to reflect that three providers (`onepassword`, `bitwarden`, `oauth2`) ship registered by default.
- **`placeholder-token-routing` idea** — marked as shipped, with a pointer to the `routes:` reference in `configuration.md`.

Net change: 4 docs files, +36/−23 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
