### PR TITLE
Add postern exec: load vault secrets into a program's environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,11 +203,28 @@ Set `token.source: file` and `token.file:
 token read-only into the unit's private credentials directory for the lifetime of
 the process.
 
+### Environment injection
+
+For tools the proxy can't intercept — a database driver, `git` over SSH, a CLI
+that reads its credential from `$ENV` — `postern exec` resolves secrets from your
+vault and exports them into a command it launches:
+
+```sh
+postern exec -- node server.js
+```
+
+Add an `env:` block to the config (each value a `secret_ref`, each key an
+environment-variable name) and postern resolves it, then replaces itself with
+the command. It **fails closed** and never logs secret values. Note this hands
+the secret to the launched process, a weaker posture than the proxy — prefer a
+rule above for anything that speaks HTTPS. See [docs/exec.md](docs/exec.md).
+
 ## Documentation
 
 - [Architecture](docs/architecture.md) — request lifecycle, trust boundary, components.
 - [Security model](docs/security.md) — fail-closed semantics, logging, threat model, key handling.
 - [Configuration](docs/configuration.md) — the full YAML reference.
+- [Environment injection](docs/exec.md) — `postern exec`: resolve secrets into a command's environment.
 - [Providers](docs/providers.md) — the credential-vendor plugin contract (1Password, Bitwarden).
 
 ## Developing postern

--- a/cmd/postern/main.go
+++ b/cmd/postern/main.go
@@ -80,6 +80,7 @@ func newRootCmd() *cobra.Command {
 
 	cmd.AddCommand(cli.NewCACmd(defaultCADir(), defaultTrustDir()))
 	cmd.AddCommand(cli.NewServerCmd(defaultCADir(), reg, store))
+	cmd.AddCommand(cli.NewExecCmd(reg, store))
 	cmd.AddCommand(cli.NewRulesCmd())
 	cmd.AddCommand(cli.NewBootstrapCmd(defaultCADir()))
 

--- a/docs/exec.md
+++ b/docs/exec.md
@@ -1,0 +1,161 @@
+# Environment injection — `postern exec`
+
+`postern exec` resolves secrets from your vault and exports them as environment
+variables into a command it launches:
+
+```sh
+postern exec -- node server.js
+```
+
+It is the companion to the proxy. The proxy brokers credentials at the network
+layer so an agent never holds them; `postern exec` is the fallback for the
+things the proxy **cannot** intercept — a database driver, `git` over SSH, a CLI
+that reads its credential from `$ENV`.
+
+## The trade-off — read this first
+
+The proxy's whole point is that the agent never sees the credential. **Environment
+injection gives the secret to the launched process.** Once a value is an
+environment variable, the process holds it for its lifetime — a strictly weaker
+posture than brokering.
+
+So the rule of thumb is:
+
+> If the thing speaks HTTPS, route it through `postern server`. Use `postern
+> exec` only for protocols and tools the proxy can't reach.
+
+For a workload that does both (most do), run **both**: the proxy for the HTTPS
+APIs, and `postern exec` for the residue (the DB URL, SSH-based git, env-reading
+CLIs).
+
+## Declaring secrets: the `env:` block
+
+Add an `env:` block to your config. Each value is a `secret_ref` — the same
+`op://…` / `bw://…` reference the rules use — and each key is the
+environment-variable name the resolved value is exported under:
+
+```yaml
+credstores:
+  - name: vault
+    provider: 1password               # or: bitwarden
+    token:
+      source: env
+      env_var: OP_SERVICE_ACCOUNT_TOKEN
+
+proxy:
+  listen: 127.0.0.1:1701
+  cache_ttl: 5m
+
+env:
+  DATABASE_URL: op://Infra/droplet-db/url
+  STRIPE_SECRET_KEY: op://Infra/stripe/secret_key
+```
+
+`postern config validate` checks the block with line numbers: every key must be
+a valid environment-variable name, every value a routable `<scheme>://<rest>`
+reference whose scheme a configured credstore resolves.
+
+Then launch your command after `--`:
+
+```sh
+postern exec -- node server.js
+postern exec --config /etc/postern/config.yaml -- ./run-migrations.sh
+```
+
+`postern` resolves each `env:` entry, adds it to the environment (a config entry
+overrides an inherited variable of the same name), and **replaces itself** with
+the command via `exec(2)`. The command becomes the same process — signals, the
+PID, and the exit status all flow straight to it, which is the right shape under
+a process manager and the devcontainer CLI.
+
+## Inline scanning: `--scan`
+
+With `--scan`, postern also resolves **inherited** environment variables whose
+value is itself a secret reference, replacing each in place:
+
+```sh
+DATABASE_URL=op://Infra/droplet-db/url postern exec --scan -- node server.js
+```
+
+Only values whose scheme has a configured credstore are touched; everything else
+(`https://…` URLs, plain connection strings) passes through unchanged. A config
+`env:` entry of the same name always wins over a scanned value. `--scan` works
+with or without an `env:` block.
+
+## What it guarantees
+
+- **Fails closed.** If any secret fails to resolve, the command is **never
+  launched** — a partially-resolved environment is worse than not running. This
+  mirrors the proxy's fail-closed `502`.
+- **Rejects non-cacheable refs.** A short-lived reference (e.g. an OTP) can't
+  survive an exec-and-replace, so it's rejected up front. Use the proxy for those.
+- **Never logs secret values.** Resolved values appear in logs only as a masked
+  `first4…last4` fingerprint, never in the clear.
+- **Child-only.** The resolved values go to the launched process. Postern does
+  not export them to your shell, and never writes them to disk.
+
+## Deployment recipes
+
+No cluster required — these are single-host patterns (a droplet, a VM, a laptop).
+
+### systemd service
+
+Deliver the vault token with systemd's credential store, and resolve the
+workload's secrets fresh on every start:
+
+```ini
+[Service]
+ExecStart=/usr/local/bin/postern exec --config /etc/postern/config.yaml -- /usr/local/bin/myapp
+LoadCredential=op_token:/etc/postern/op_token
+```
+
+Set `token.source: file` and `token.file:
+/run/credentials/myapp.service/op_token` in the config. The service's main PID
+becomes `myapp`, so `systemctl status`, restarts, and signals all behave
+normally — and no plaintext `.env` file ever sits on disk.
+
+### Docker Compose
+
+Bake the postern binary into the image and make it the entrypoint:
+
+```yaml
+services:
+  app:
+    image: myapp
+    entrypoint: ["postern", "exec", "--", "myapp"]
+    volumes:
+      - ./config.yaml:/etc/postern/config.yaml:ro
+    secrets:
+      - op_token        # the vault token, the only secret on disk (0600)
+```
+
+### Dev container over SSH
+
+On the remote host, wrap the devcontainer CLI:
+
+```sh
+postern exec -- devcontainer up --workspace-folder .
+```
+
+postern resolves the `env:` block into the devcontainer CLI's environment; the
+CLI forwards those into the container through its normal env-forwarding, e.g. in
+`devcontainer.json`:
+
+```json
+{
+  "remoteEnv": { "DATABASE_URL": "${localEnv:DATABASE_URL}" }
+}
+```
+
+For the strongest posture, also run `postern server` inside the container and
+point `HTTPS_PROXY` at it, so HTTPS APIs stay brokered and `exec` only carries
+the non-HTTP residue.
+
+## Limitations
+
+- `postern exec` replaces the process with `exec(2)`, so it is supported on Linux
+  and macOS only. On other platforms, use a process manager to inject the
+  environment instead.
+- It does **not** broker the SSH protocol itself. It can place a credential a
+  tool reads from `$ENV`, but it cannot keep an SSH **private key** out of the
+  container — that would be a separate SSH-agent / certificate-signing feature.

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -1,0 +1,217 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mmartinez/postern/internal/broker"
+	"github.com/mmartinez/postern/internal/config"
+	"github.com/mmartinez/postern/internal/credstore"
+	"github.com/mmartinez/postern/internal/logging"
+	"github.com/mmartinez/postern/internal/token"
+)
+
+// execFn is the process-replacement seam. Production wires it to the
+// platform syscall.Exec wrapper (exec_unix.go); tests swap in a recorder so
+// they can assert what the child would launch with — including that it never
+// launches when resolution fails closed.
+var execFn = execProcess
+
+// NewExecCmd builds `postern exec`. It resolves the config's env: block through
+// the same credstore path the proxy uses and replaces the current process with
+// the given command, exporting the resolved values into the child's
+// environment. reg is the credstore provider registry; store is the OS keychain
+// wrapper feeding the token-resolution chain.
+//
+// Unlike the proxy — where the agent never holds the credential — env injection
+// hands the secret to the launched process. It is the fallback for tools and
+// protocols the proxy cannot intercept (a database driver, git over SSH, a CLI
+// that reads $ENV); prefer routing HTTPS traffic through `postern server`.
+func NewExecCmd(reg *credstore.Registry, store token.Store) *cobra.Command {
+	var (
+		configPath string
+		logFormat  string
+		logLevel   string
+		noColor    bool
+	)
+	cmd := &cobra.Command{
+		Use:   "exec [flags] -- command [args...]",
+		Short: "Resolve declared secrets into a child process's environment",
+		Long: "Resolve the config's env: block through the credential vendor and\n" +
+			"replace postern with the given command, exporting the resolved values\n" +
+			"into its environment. Use it for tools the proxy cannot intercept\n" +
+			"(database drivers, git over SSH, CLIs that read environment variables).\n" +
+			"\n" +
+			"The resolved secret lives in the child's environment for its lifetime —\n" +
+			"a weaker posture than the proxy, where the agent never holds the\n" +
+			"credential. Prefer `postern server` for anything that speaks HTTPS.\n" +
+			"\n" +
+			"  postern exec -- node server.js\n" +
+			"  postern exec --config ./postern.yaml -- devcontainer up --workspace-folder .",
+		// Everything after `--` is the child command; cobra stops flag parsing
+		// at the dash and hands the remainder through as args.
+		Args:                  cobra.MinimumNArgs(1),
+		DisableFlagsInUseLine: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			logger, err := logging.New(logging.Options{
+				Format:  logFormat,
+				Level:   logLevel,
+				NoColor: noColor,
+				Output:  cmd.ErrOrStderr(),
+			})
+			if err != nil {
+				return err
+			}
+
+			cfgPath := configPath
+			if cfgPath == "" {
+				cfgPath = config.DefaultPath()
+			}
+			// The env: block lives in the config, so unlike `server` there is no
+			// useful zero-config mode: a missing file is an error, not a silent
+			// no-op that would exec the child with nothing injected.
+			cfg, err := config.LoadForCLI(cfgPath, true)
+			if err != nil {
+				return err
+			}
+			if cfg == nil || len(cfg.Env) == 0 {
+				return fmt.Errorf("config %s declares no env: block; `postern exec` has nothing to inject", cfgPath)
+			}
+
+			ctx := cmd.Context()
+			if ctx == nil {
+				ctx = context.Background()
+			}
+
+			resolvers, err := buildCredStoreResolvers(ctx, reg, cfg.CredStores, store, logger)
+			if err != nil {
+				return err
+			}
+			if err := assertEnvRoutable(cfg.Env, resolvers); err != nil {
+				return err
+			}
+			router, err := credstore.NewSchemeRouter(resolvers)
+			if err != nil {
+				return fmt.Errorf("init credstore router: %w", err)
+			}
+
+			return runExec(ctx, router, cfg.Env, os.Environ(), newShouldCacheRef(reg), logger, execFn, args)
+		},
+	}
+	cmd.Flags().StringVar(&configPath, "config", "", "Config file path (default: ~/.postern/config.yaml)")
+	cmd.Flags().StringVar(&logFormat, "log-format", "text", "Log format: text|json")
+	cmd.Flags().StringVar(&logLevel, "log-level", "info", "Log level: quiet|info|debug")
+	cmd.Flags().BoolVar(&noColor, "no-color", false, "Disable ANSI colour (NO_COLOR env also honored)")
+	return cmd
+}
+
+// runExec resolves refs into the child environment and hands off to exec. It is
+// the testable core of `postern exec`: router and exec are injected so a test
+// can drive it with a fake resolver and assert the child is launched only when
+// every secret resolves. On any failure it returns before calling exec — fail
+// closed, mirroring the proxy's 502-on-resolver-error rule.
+func runExec(
+	ctx context.Context,
+	router broker.Resolver,
+	refs map[string]string,
+	inherited []string,
+	shouldCache func(string) bool,
+	logger *slog.Logger,
+	exec func(command string, argv, env []string) error,
+	args []string,
+) error {
+	if len(args) == 0 {
+		return errors.New("exec requires a command to run")
+	}
+	childEnv, err := resolveExecEnv(ctx, router, refs, inherited, shouldCache, logger)
+	if err != nil {
+		return err
+	}
+	return exec(args[0], args, childEnv)
+}
+
+// resolveExecEnv resolves every ref in refs and returns the child environment:
+// inherited overlaid with the resolved values. It fails closed — the first
+// resolve error aborts and returns it, so the caller never execs a child with a
+// half-populated secret set. A ref the owning provider marks non-cacheable
+// (e.g. an OTP) is rejected up front: an exec'd child cannot re-resolve a
+// short-lived secret. Resolved values are logged only as masked fingerprints.
+func resolveExecEnv(
+	ctx context.Context,
+	router broker.Resolver,
+	refs map[string]string,
+	inherited []string,
+	shouldCache func(string) bool,
+	logger *slog.Logger,
+) ([]string, error) {
+	resolved := make(map[string]string, len(refs))
+	for _, name := range sortedRefNames(refs) {
+		ref := refs[name]
+		if !shouldCache(ref) {
+			return nil, fmt.Errorf("env %s: secret_ref %q is non-cacheable (e.g. a one-time password) and cannot be injected as an environment variable; route it through the proxy instead", name, ref)
+		}
+		val, err := router.Resolve(ctx, "", ref)
+		if err != nil {
+			return nil, fmt.Errorf("env %s: resolve %s: %w", name, ref, err)
+		}
+		resolved[name] = val
+		logger.Info("env resolved",
+			slog.String("name", name),
+			slog.String("value", token.Fingerprint(val)),
+		)
+	}
+	return mergeEnv(inherited, resolved), nil
+}
+
+// mergeEnv overlays resolved onto inherited, dropping any inherited entry whose
+// name a resolved value replaces so the child sees exactly one binding per name.
+// Resolved entries are appended in sorted order for deterministic output.
+func mergeEnv(inherited []string, resolved map[string]string) []string {
+	out := make([]string, 0, len(inherited)+len(resolved))
+	for _, kv := range inherited {
+		name, _, _ := strings.Cut(kv, "=")
+		if _, overridden := resolved[name]; overridden {
+			continue
+		}
+		out = append(out, kv)
+	}
+	for _, name := range sortedRefNames(resolved) {
+		out = append(out, name+"="+resolved[name])
+	}
+	return out
+}
+
+// assertEnvRoutable fails closed if any env value's scheme has no resolver in
+// resolvers (keyed by scheme). It mirrors assertRulesRoutable so an unroutable
+// env ref errors before any resolve rather than mid-injection. Malformed refs
+// are left to the schema validator.
+func assertEnvRoutable(env map[string]string, resolvers map[string]broker.Resolver) error {
+	for _, name := range sortedRefNames(env) {
+		scheme, _, ok := strings.Cut(env[name], "://")
+		if !ok || scheme == "" {
+			continue
+		}
+		if _, ok := resolvers[scheme]; !ok {
+			return fmt.Errorf("env %s references secret_ref scheme %q but no credstore resolves it", name, scheme)
+		}
+	}
+	return nil
+}
+
+// sortedRefNames returns m's keys in lexical order so resolution, logging, and
+// the assembled environment are deterministic regardless of map iteration.
+func sortedRefNames(m map[string]string) []string {
+	names := make([]string, 0, len(m))
+	for k := range m {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -37,6 +37,7 @@ var execFn = execProcess
 func NewExecCmd(reg *credstore.Registry, store token.Store) *cobra.Command {
 	var (
 		configPath string
+		scan       bool
 		logFormat  string
 		logLevel   string
 		noColor    bool
@@ -54,7 +55,8 @@ func NewExecCmd(reg *credstore.Registry, store token.Store) *cobra.Command {
 			"credential. Prefer `postern server` for anything that speaks HTTPS.\n" +
 			"\n" +
 			"  postern exec -- node server.js\n" +
-			"  postern exec --config ./postern.yaml -- devcontainer up --workspace-folder .",
+			"  postern exec --config ./postern.yaml -- devcontainer up\n" +
+			"  postern exec --scan -- node server.js   # resolve op://-valued env vars",
 		// Everything after `--` is the child command; cobra stops flag parsing
 		// at the dash and hands the remainder through as args.
 		Args:                  cobra.MinimumNArgs(1),
@@ -81,8 +83,8 @@ func NewExecCmd(reg *credstore.Registry, store token.Store) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if cfg == nil || len(cfg.Env) == 0 {
-				return fmt.Errorf("config %s declares no env: block; `postern exec` has nothing to inject", cfgPath)
+			if len(cfg.Env) == 0 && !scan {
+				return fmt.Errorf("config %s declares no env: block and --scan was not set; `postern exec` has nothing to inject", cfgPath)
 			}
 
 			ctx := cmd.Context()
@@ -94,6 +96,13 @@ func NewExecCmd(reg *credstore.Registry, store token.Store) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if len(resolvers) == 0 {
+				// Reachable only in scan-only mode against a config that
+				// configures no credstore: nothing can be resolved, so run the
+				// command with the inherited environment unchanged.
+				logger.Warn("no credstores configured; running command with the inherited environment")
+				return execFn(args[0], args, os.Environ())
+			}
 			if err := assertEnvRoutable(cfg.Env, resolvers); err != nil {
 				return err
 			}
@@ -102,14 +111,37 @@ func NewExecCmd(reg *credstore.Registry, store token.Store) *cobra.Command {
 				return fmt.Errorf("init credstore router: %w", err)
 			}
 
-			return runExec(ctx, router, cfg.Env, os.Environ(), newShouldCacheRef(reg), logger, execFn, args)
+			opts := resolveOptions{
+				scan: scan,
+				isResolvable: func(scheme string) bool {
+					_, ok := resolvers[scheme]
+					return ok
+				},
+			}
+			return runExec(ctx, router, cfg.Env, os.Environ(), newShouldCacheRef(reg), logger, execFn, args, opts)
 		},
 	}
 	cmd.Flags().StringVar(&configPath, "config", "", "Config file path (default: ~/.postern/config.yaml)")
+	cmd.Flags().BoolVar(&scan, "scan", false, "Also resolve inherited secret-ref env values")
 	cmd.Flags().StringVar(&logFormat, "log-format", "text", "Log format: text|json")
 	cmd.Flags().StringVar(&logLevel, "log-level", "info", "Log level: quiet|info|debug")
 	cmd.Flags().BoolVar(&noColor, "no-color", false, "Disable ANSI colour (NO_COLOR env also honored)")
 	return cmd
+}
+
+// resolveOptions tunes how runExec assembles the child environment beyond the
+// config env: block.
+type resolveOptions struct {
+	// scan, when true, also resolves inherited environment values that are
+	// themselves secret_refs (berglas-style), replacing each in place. A config
+	// env: entry of the same name always wins, so an explicit declaration is
+	// never overridden by a scanned value.
+	scan bool
+	// isResolvable reports whether a scheme has a configured credstore, so scan
+	// only touches values postern can actually resolve and leaves everything
+	// else (https URLs, plain connection strings) untouched. Required when scan
+	// is true.
+	isResolvable func(scheme string) bool
 }
 
 // runExec resolves refs into the child environment and hands off to exec. It is
@@ -126,23 +158,26 @@ func runExec(
 	logger *slog.Logger,
 	exec func(command string, argv, env []string) error,
 	args []string,
+	opts resolveOptions,
 ) error {
 	if len(args) == 0 {
 		return errors.New("exec requires a command to run")
 	}
-	childEnv, err := resolveExecEnv(ctx, router, refs, inherited, shouldCache, logger)
+	childEnv, err := resolveExecEnv(ctx, router, refs, inherited, shouldCache, logger, opts)
 	if err != nil {
 		return err
 	}
 	return exec(args[0], args, childEnv)
 }
 
-// resolveExecEnv resolves every ref in refs and returns the child environment:
-// inherited overlaid with the resolved values. It fails closed — the first
-// resolve error aborts and returns it, so the caller never execs a child with a
-// half-populated secret set. A ref the owning provider marks non-cacheable
-// (e.g. an OTP) is rejected up front: an exec'd child cannot re-resolve a
-// short-lived secret. Resolved values are logged only as masked fingerprints.
+// resolveExecEnv resolves every ref in refs (and, when opts.scan is set, every
+// inherited value that is itself a routable secret_ref) and returns the child
+// environment: inherited overlaid with the resolved values. It fails closed —
+// the first resolve error aborts and returns it, so the caller never execs a
+// child with a half-populated secret set. A ref the owning provider marks
+// non-cacheable (e.g. an OTP) is rejected up front: an exec'd child cannot
+// re-resolve a short-lived secret. Resolved values are logged only as masked
+// fingerprints.
 func resolveExecEnv(
 	ctx context.Context,
 	router broker.Resolver,
@@ -150,23 +185,51 @@ func resolveExecEnv(
 	inherited []string,
 	shouldCache func(string) bool,
 	logger *slog.Logger,
+	opts resolveOptions,
 ) ([]string, error) {
 	resolved := make(map[string]string, len(refs))
-	for _, name := range sortedRefNames(refs) {
-		ref := refs[name]
+	resolve := func(name, ref string) error {
 		if !shouldCache(ref) {
-			return nil, fmt.Errorf("env %s: secret_ref %q is non-cacheable (e.g. a one-time password) and cannot be injected as an environment variable; route it through the proxy instead", name, ref)
+			return fmt.Errorf("env %s: secret_ref %q is non-cacheable (e.g. a one-time password) and cannot be injected as an environment variable; route it through the proxy instead", name, ref)
 		}
 		val, err := router.Resolve(ctx, "", ref)
 		if err != nil {
-			return nil, fmt.Errorf("env %s: resolve %s: %w", name, ref, err)
+			return fmt.Errorf("env %s: resolve %s: %w", name, ref, err)
 		}
 		resolved[name] = val
 		logger.Info("env resolved",
 			slog.String("name", name),
 			slog.String("value", token.Fingerprint(val)),
 		)
+		return nil
 	}
+
+	for _, name := range sortedRefNames(refs) {
+		if err := resolve(name, refs[name]); err != nil {
+			return nil, err
+		}
+	}
+
+	if opts.scan {
+		for _, kv := range inherited {
+			name, val, ok := strings.Cut(kv, "=")
+			if !ok {
+				continue
+			}
+			// A config env: entry of the same name has already resolved and wins.
+			if _, done := resolved[name]; done {
+				continue
+			}
+			scheme, _, ok := strings.Cut(val, "://")
+			if !ok || scheme == "" || opts.isResolvable == nil || !opts.isResolvable(scheme) {
+				continue
+			}
+			if err := resolve(name, val); err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	return mergeEnv(inherited, resolved), nil
 }
 

--- a/internal/cli/exec_integration_test.go
+++ b/internal/cli/exec_integration_test.go
@@ -36,6 +36,15 @@ func TestExec_ErrorPaths(t *testing.T) {
 		require.Error(t, err, "missing config must exit non-zero; output: %s", out)
 	})
 
+	t.Run("scan flag is registered", func(t *testing.T) {
+		t.Parallel()
+		cmd := exec.Command(bin, "exec", "--help") //nolint:gosec // test-built binary
+		cmd.Env = filteredEnv()
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "exec --help should succeed; output: %s", out)
+		require.Contains(t, string(out), "--scan", "the --scan flag must be wired onto the command")
+	})
+
 	t.Run("config without env block exits non-zero", func(t *testing.T) {
 		t.Parallel()
 		cfg := filepath.Join(t.TempDir(), "config.yaml")

--- a/internal/cli/exec_integration_test.go
+++ b/internal/cli/exec_integration_test.go
@@ -1,0 +1,55 @@
+package cli_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestExec_ErrorPaths drives the real binary through the `postern exec`
+// failure modes that need no credential vendor: a missing command, a missing
+// config, and a config with nothing to inject. The resolve-and-replace happy
+// path needs live vendor credentials, so it is covered in-process by the
+// runExec unit tests (exec_test.go) with a fake resolver instead.
+func TestExec_ErrorPaths(t *testing.T) {
+	// Not Parallel at the top level: go build dominates wall-clock. Build once,
+	// then fan the cheap subprocess cases out underneath it.
+	bin := buildPosternBinary(t)
+
+	t.Run("no command exits non-zero", func(t *testing.T) {
+		t.Parallel()
+		cmd := exec.Command(bin, "exec") //nolint:gosec // test-built binary
+		cmd.Env = filteredEnv()
+		out, err := cmd.CombinedOutput()
+		require.Error(t, err, "exec with no command must exit non-zero; output: %s", out)
+	})
+
+	t.Run("missing config exits non-zero", func(t *testing.T) {
+		t.Parallel()
+		missing := filepath.Join(t.TempDir(), "nope.yaml")
+		cmd := exec.Command(bin, "exec", "--config", missing, "--", "echo", "hi") //nolint:gosec // test-built binary
+		cmd.Env = filteredEnv()
+		out, err := cmd.CombinedOutput()
+		require.Error(t, err, "missing config must exit non-zero; output: %s", out)
+	})
+
+	t.Run("config without env block exits non-zero", func(t *testing.T) {
+		t.Parallel()
+		cfg := filepath.Join(t.TempDir(), "config.yaml")
+		require.NoError(t, os.WriteFile(cfg, []byte(`
+proxy:
+  listen: 127.0.0.1:1701
+  cache_ttl: 5m
+  on_no_match: passthrough
+rules: []
+`), 0o600))
+		cmd := exec.Command(bin, "exec", "--config", cfg, "--", "echo", "hi") //nolint:gosec // test-built binary
+		cmd.Env = filteredEnv()
+		out, err := cmd.CombinedOutput()
+		require.Error(t, err, "a config with no env: block must exit non-zero; output: %s", out)
+		require.Contains(t, string(out), "no env", "error should explain there is nothing to inject; output: %s", out)
+	})
+}

--- a/internal/cli/exec_other.go
+++ b/internal/cli/exec_other.go
@@ -1,0 +1,12 @@
+//go:build !linux && !darwin
+
+package cli
+
+import "errors"
+
+// execProcess fails on platforms without syscall.Exec. Postern targets Linux
+// (amd64/arm64) today; the build tag keeps a hypothetical Windows build
+// compiling even though `postern exec` cannot replace the process there.
+func execProcess(_ string, _, _ []string) error {
+	return errors.New("postern exec is not supported on this platform; use a process manager to inject the environment instead")
+}

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -51,6 +51,10 @@ func (r *recordingExec) run(command string, argv, env []string) error {
 
 func allCacheable(string) bool { return true }
 
+// opResolvable reports whether a scheme is the op scheme — the stand-in for "a
+// credstore is configured for this scheme" in scan-mode tests.
+func opResolvable(scheme string) bool { return scheme == "op" }
+
 // The happy path: every ref resolves, the resolved values land in the child
 // env, and a config entry overrides an inherited variable of the same name.
 func TestRunExec_ResolvesMergesAndExecs(t *testing.T) {
@@ -61,7 +65,7 @@ func TestRunExec_ResolvesMergesAndExecs(t *testing.T) {
 	inherited := []string{"PATH=/bin", "A_VAR=old"}
 	rec := &recordingExec{}
 
-	err := runExec(context.Background(), r, refs, inherited, allCacheable, discardLogger(), rec.run, []string{"printenv", "A_VAR"})
+	err := runExec(context.Background(), r, refs, inherited, allCacheable, discardLogger(), rec.run, []string{"printenv", "A_VAR"}, resolveOptions{})
 	require.NoError(t, err)
 
 	require.True(t, rec.called, "the child must be launched on success")
@@ -80,7 +84,7 @@ func TestRunExec_FailClosed_ResolveError_NoExec(t *testing.T) {
 
 	rec := &recordingExec{}
 	err := runExec(context.Background(), fakeResolver{err: errors.New("vault down")},
-		map[string]string{"A_VAR": "op://a"}, nil, allCacheable, discardLogger(), rec.run, []string{"true"})
+		map[string]string{"A_VAR": "op://a"}, nil, allCacheable, discardLogger(), rec.run, []string{"true"}, resolveOptions{})
 
 	require.Error(t, err)
 	require.False(t, rec.called, "must not exec the child when a secret fails to resolve (fail closed)")
@@ -94,7 +98,7 @@ func TestRunExec_RejectsNonCacheable_NoExec(t *testing.T) {
 	neverCacheable := func(string) bool { return false }
 	rec := &recordingExec{}
 	err := runExec(context.Background(), fakeResolver{values: map[string]string{"op://otp": "x"}},
-		map[string]string{"OTP": "op://otp"}, nil, neverCacheable, discardLogger(), rec.run, []string{"true"})
+		map[string]string{"OTP": "op://otp"}, nil, neverCacheable, discardLogger(), rec.run, []string{"true"}, resolveOptions{})
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "non-cacheable")
@@ -112,11 +116,64 @@ func TestRunExec_MasksSecretInLogs(t *testing.T) {
 	rec := &recordingExec{}
 
 	err := runExec(context.Background(), fakeResolver{values: map[string]string{"op://a": secret}},
-		map[string]string{"A_VAR": "op://a"}, nil, allCacheable, logger, rec.run, []string{"true"})
+		map[string]string{"A_VAR": "op://a"}, nil, allCacheable, logger, rec.run, []string{"true"}, resolveOptions{})
 	require.NoError(t, err)
 
 	require.NotContains(t, buf.String(), secret, "the raw secret must never appear in logs")
 	require.Contains(t, buf.String(), token.Fingerprint(secret), "logs should reference the masked fingerprint")
+}
+
+// In scan mode an inherited variable whose value is a routable secret_ref is
+// resolved in place; values with an unknown scheme (or none) pass through
+// untouched.
+func TestRunExec_Scan_ResolvesInheritedRefs(t *testing.T) {
+	t.Parallel()
+
+	r := fakeResolver{values: map[string]string{"op://foo": "FOOVAL"}}
+	inherited := []string{"FOO=op://foo", "BAR=plain", "URL=https://example.com"}
+	rec := &recordingExec{}
+
+	err := runExec(context.Background(), r, nil, inherited, allCacheable, discardLogger(), rec.run,
+		[]string{"true"}, resolveOptions{scan: true, isResolvable: opResolvable})
+	require.NoError(t, err)
+
+	require.True(t, rec.called)
+	require.Contains(t, rec.env, "FOO=FOOVAL", "an inherited op:// ref should be resolved in place")
+	require.Contains(t, rec.env, "BAR=plain", "a non-ref value passes through")
+	require.Contains(t, rec.env, "URL=https://example.com", "an unconfigured scheme passes through")
+	require.NotContains(t, rec.env, "FOO=op://foo", "the original ref must be replaced")
+}
+
+// A config env: entry takes precedence over an inherited ref of the same name:
+// the explicit declaration wins, the inherited ref is not resolved.
+func TestRunExec_Scan_ConfigOverridesScanned(t *testing.T) {
+	t.Parallel()
+
+	r := fakeResolver{values: map[string]string{"op://cfg": "CFGVAL", "op://inherited": "INHVAL"}}
+	refs := map[string]string{"FOO": "op://cfg"}
+	inherited := []string{"FOO=op://inherited"}
+	rec := &recordingExec{}
+
+	err := runExec(context.Background(), r, refs, inherited, allCacheable, discardLogger(), rec.run,
+		[]string{"true"}, resolveOptions{scan: true, isResolvable: opResolvable})
+	require.NoError(t, err)
+
+	require.Contains(t, rec.env, "FOO=CFGVAL", "the config env: entry must win over the inherited ref")
+	require.NotContains(t, rec.env, "FOO=INHVAL")
+}
+
+// Scan resolution fails closed just like the config block: an inherited ref
+// that won't resolve aborts before the child launches.
+func TestRunExec_Scan_FailClosedOnScannedRef_NoExec(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingExec{}
+	err := runExec(context.Background(), fakeResolver{err: errors.New("vault down")},
+		nil, []string{"FOO=op://foo"}, allCacheable, discardLogger(), rec.run,
+		[]string{"true"}, resolveOptions{scan: true, isResolvable: opResolvable})
+
+	require.Error(t, err)
+	require.False(t, rec.called)
 }
 
 // mergeEnv overlays resolved values onto the inherited environment, replacing

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -1,0 +1,146 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mmartinez/postern/internal/broker"
+	"github.com/mmartinez/postern/internal/token"
+)
+
+// fakeResolver resolves a ref from a fixed map; a configured err short-circuits
+// every call so a test can model a vault outage.
+type fakeResolver struct {
+	values map[string]string
+	err    error
+}
+
+func (f fakeResolver) Resolve(_ context.Context, _, ref string) (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	v, ok := f.values[ref]
+	if !ok {
+		return "", errors.New("no such ref: " + ref)
+	}
+	return v, nil
+}
+
+// recordingExec stands in for the real syscall.Exec seam so a test can assert
+// what the child WOULD be launched with — and, crucially, that it is never
+// launched at all when resolution fails closed.
+type recordingExec struct {
+	called  bool
+	command string
+	argv    []string
+	env     []string
+}
+
+func (r *recordingExec) run(command string, argv, env []string) error {
+	r.called = true
+	r.command = command
+	r.argv = argv
+	r.env = env
+	return nil
+}
+
+func allCacheable(string) bool { return true }
+
+// The happy path: every ref resolves, the resolved values land in the child
+// env, and a config entry overrides an inherited variable of the same name.
+func TestRunExec_ResolvesMergesAndExecs(t *testing.T) {
+	t.Parallel()
+
+	r := fakeResolver{values: map[string]string{"op://a": "AAA", "op://b": "BBB"}}
+	refs := map[string]string{"A_VAR": "op://a", "B_VAR": "op://b"}
+	inherited := []string{"PATH=/bin", "A_VAR=old"}
+	rec := &recordingExec{}
+
+	err := runExec(context.Background(), r, refs, inherited, allCacheable, discardLogger(), rec.run, []string{"printenv", "A_VAR"})
+	require.NoError(t, err)
+
+	require.True(t, rec.called, "the child must be launched on success")
+	require.Equal(t, "printenv", rec.command)
+	require.Equal(t, []string{"printenv", "A_VAR"}, rec.argv)
+	require.Contains(t, rec.env, "A_VAR=AAA")
+	require.Contains(t, rec.env, "B_VAR=BBB")
+	require.Contains(t, rec.env, "PATH=/bin")
+	require.NotContains(t, rec.env, "A_VAR=old", "a config env entry must override the inherited value")
+}
+
+// Fail closed: if any secret fails to resolve, the child is never launched —
+// a partially-resolved environment is worse than not running at all.
+func TestRunExec_FailClosed_ResolveError_NoExec(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingExec{}
+	err := runExec(context.Background(), fakeResolver{err: errors.New("vault down")},
+		map[string]string{"A_VAR": "op://a"}, nil, allCacheable, discardLogger(), rec.run, []string{"true"})
+
+	require.Error(t, err)
+	require.False(t, rec.called, "must not exec the child when a secret fails to resolve (fail closed)")
+}
+
+// A non-cacheable ref (e.g. an OTP) cannot survive an exec-and-replace, so it
+// is rejected before any child is launched.
+func TestRunExec_RejectsNonCacheable_NoExec(t *testing.T) {
+	t.Parallel()
+
+	neverCacheable := func(string) bool { return false }
+	rec := &recordingExec{}
+	err := runExec(context.Background(), fakeResolver{values: map[string]string{"op://otp": "x"}},
+		map[string]string{"OTP": "op://otp"}, nil, neverCacheable, discardLogger(), rec.run, []string{"true"})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "non-cacheable")
+	require.False(t, rec.called)
+}
+
+// Resolved secret values must never reach the logs; only the masked
+// fingerprint may appear.
+func TestRunExec_MasksSecretInLogs(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	const secret = "SUPERSECRETVALUE"
+	rec := &recordingExec{}
+
+	err := runExec(context.Background(), fakeResolver{values: map[string]string{"op://a": secret}},
+		map[string]string{"A_VAR": "op://a"}, nil, allCacheable, logger, rec.run, []string{"true"})
+	require.NoError(t, err)
+
+	require.NotContains(t, buf.String(), secret, "the raw secret must never appear in logs")
+	require.Contains(t, buf.String(), token.Fingerprint(secret), "logs should reference the masked fingerprint")
+}
+
+// mergeEnv overlays resolved values onto the inherited environment, replacing
+// (not duplicating) any inherited variable of the same name.
+func TestMergeEnv_OverridesInherited(t *testing.T) {
+	t.Parallel()
+
+	out := mergeEnv([]string{"PATH=/bin", "X=old"}, map[string]string{"X": "new", "Y": "y"})
+	require.Contains(t, out, "PATH=/bin")
+	require.Contains(t, out, "X=new")
+	require.Contains(t, out, "Y=y")
+	require.NotContains(t, out, "X=old")
+}
+
+// assertEnvRoutable is the boot-time guard mirroring assertRulesRoutable: an
+// env value whose scheme no configured credstore resolves must error before any
+// resolve, not mid-injection.
+func TestAssertEnvRoutable(t *testing.T) {
+	t.Parallel()
+
+	resolvers := map[string]broker.Resolver{"op": nil}
+	require.NoError(t, assertEnvRoutable(map[string]string{"A_VAR": "op://a"}, resolvers))
+
+	err := assertEnvRoutable(map[string]string{"A_VAR": "bw://a"}, resolvers)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bw")
+}

--- a/internal/cli/exec_unix.go
+++ b/internal/cli/exec_unix.go
@@ -1,0 +1,29 @@
+//go:build linux || darwin
+
+package cli
+
+import (
+	"fmt"
+	"os/exec"
+	"syscall"
+)
+
+// execProcess replaces the current process image with command (resolved
+// against PATH) and argv, using env as the child's environment. On success it
+// does not return: the kernel hands the process over to the child, so signals,
+// the PID, and exit status all flow to it directly — the right shape under a
+// process manager (systemd) and the devcontainer CLI. argv must include the
+// command name as argv[0]; callers pass the post-`--` args verbatim.
+func execProcess(command string, argv, env []string) error {
+	path, err := exec.LookPath(command)
+	if err != nil {
+		return fmt.Errorf("locate command %q: %w", command, err)
+	}
+	// Launching a user-named command with a user-built environment is the whole
+	// point of `postern exec`; the command and env come from the operator's
+	// config and argv, not an untrusted request path.
+	if err := syscall.Exec(path, argv, env); err != nil { //nolint:gosec // intentional exec wrapper; command + env are operator-supplied
+		return fmt.Errorf("exec %q: %w", command, err)
+	}
+	return nil // unreachable: a successful Exec never returns.
+}

--- a/internal/config/default.yaml
+++ b/internal/config/default.yaml
@@ -129,3 +129,19 @@ rules:
 #       consumer_secret_ref: op://Agents/app/consumer_secret
 #       token_ref: op://Agents/user/access_token
 #       token_secret_ref: op://Agents/user/access_token_secret
+
+# env: secrets for `postern exec`. Each value resolves through the same
+# credstore as the rules above, and `postern exec -- <command>` exports the
+# resolved values into the launched process before replacing itself with it:
+#
+#   postern exec -- node server.js
+#   postern exec -- devcontainer up --workspace-folder .
+#
+# Use this for tools the proxy cannot intercept — a database driver, git over
+# SSH, a CLI that reads its credential from the environment. Unlike the proxy,
+# the launched process DOES hold the secret, so prefer a rule above for anything
+# that speaks HTTPS. Keys must be valid environment-variable names.
+#
+# env:
+#   DATABASE_URL: op://Infra/droplet-db/url
+#   STRIPE_SECRET_KEY: op://Infra/stripe/secret_key

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -1,0 +1,153 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mmartinez/postern/internal/config"
+)
+
+// A routable env: block (every value resolves to a configured scheme) produces
+// no lints — the same brand-agnostic scheme check that guards rule secret_refs
+// applies to the values `postern exec` injects as environment variables.
+func TestValidate_EnvBlock_AcceptsRoutableRefs(t *testing.T) {
+	t.Parallel()
+
+	doc := `
+token:
+  source: env
+  env_var: OP_SERVICE_ACCOUNT_TOKEN
+proxy:
+  listen: 127.0.0.1:1701
+  cache_ttl: 5m
+  on_no_match: passthrough
+env:
+  DATABASE_URL: op://Infra/db/url
+  STRIPE_KEY: op://Infra/stripe/secret
+rules: []
+`
+	_, lints, err := config.LoadAndValidateWithProviders(strings.NewReader(doc), opOnlyFacts)
+	require.NoError(t, err)
+	require.Empty(t, lints, "routable env refs should produce no lints; got %v", lints)
+}
+
+// An env value whose scheme no configured credstore resolves can never be
+// injected; flag it at validate time with a line number rather than at exec.
+func TestValidate_EnvBlock_FlagsUnroutableScheme(t *testing.T) {
+	t.Parallel()
+
+	doc := `
+token:
+  source: env
+  env_var: OP_SERVICE_ACCOUNT_TOKEN
+proxy:
+  listen: 127.0.0.1:1701
+  cache_ttl: 5m
+  on_no_match: passthrough
+env:
+  DATABASE_URL: bw://Coll/db/url
+rules: []
+`
+	_, lints, err := config.LoadAndValidateWithProviders(strings.NewReader(doc), opOnlyFacts)
+	require.NoError(t, err)
+
+	var found *config.LintError
+	for i := range lints {
+		if strings.Contains(lints[i].Path, "env.DATABASE_URL") && strings.Contains(lints[i].Message, "bw") {
+			found = &lints[i]
+		}
+	}
+	require.NotNil(t, found, "want a lint flagging the unroutable bw scheme; got %v", lints)
+	require.Equal(t, config.SeverityError, found.Severity)
+	require.Greater(t, found.Line, 0, "registry-aware env lint must carry a line number")
+}
+
+// A value that isn't a <scheme>://<rest> URI is a schema error, surfaced
+// without needing the registry facts.
+func TestValidate_EnvBlock_FlagsMalformedRef(t *testing.T) {
+	t.Parallel()
+
+	doc := `
+token:
+  source: env
+  env_var: OP_SERVICE_ACCOUNT_TOKEN
+proxy:
+  listen: 127.0.0.1:1701
+  cache_ttl: 5m
+  on_no_match: passthrough
+env:
+  DATABASE_URL: not-a-uri
+rules: []
+`
+	_, lints, err := config.LoadAndValidate(strings.NewReader(doc))
+	require.NoError(t, err)
+
+	var found *config.LintError
+	for i := range lints {
+		if strings.Contains(lints[i].Path, "env.DATABASE_URL") && strings.Contains(lints[i].Message, "URI") {
+			found = &lints[i]
+		}
+	}
+	require.NotNil(t, found, "want a lint flagging the malformed env value; got %v", lints)
+	require.Equal(t, config.SeverityError, found.Severity)
+}
+
+// A key that isn't a valid environment-variable name is a schema error: it
+// could never be exported to the child process.
+func TestValidate_EnvBlock_FlagsInvalidVarName(t *testing.T) {
+	t.Parallel()
+
+	doc := `
+token:
+  source: env
+  env_var: OP_SERVICE_ACCOUNT_TOKEN
+proxy:
+  listen: 127.0.0.1:1701
+  cache_ttl: 5m
+  on_no_match: passthrough
+env:
+  "bad-name": op://Infra/db/url
+rules: []
+`
+	_, lints, err := config.LoadAndValidate(strings.NewReader(doc))
+	require.NoError(t, err)
+
+	var found *config.LintError
+	for i := range lints {
+		if strings.Contains(lints[i].Path, "env") && strings.Contains(lints[i].Message, "environment variable name") {
+			found = &lints[i]
+		}
+	}
+	require.NotNil(t, found, "want a lint flagging the invalid env var name; got %v", lints)
+	require.Equal(t, config.SeverityError, found.Severity)
+}
+
+// An env: block with no credstore to resolve against can never inject anything;
+// mirror the rules-need-a-credstore guard so the failure is a line-friendly
+// lint rather than a cryptic boot error.
+func TestValidate_EnvBlock_RequiresCredStore(t *testing.T) {
+	t.Parallel()
+
+	doc := `
+proxy:
+  listen: 127.0.0.1:1701
+  cache_ttl: 5m
+  on_no_match: passthrough
+env:
+  DATABASE_URL: op://Infra/db/url
+rules: []
+`
+	_, lints, err := config.LoadAndValidate(strings.NewReader(doc))
+	require.NoError(t, err)
+
+	var found *config.LintError
+	for i := range lints {
+		if strings.Contains(lints[i].Path, "credstores") && strings.Contains(lints[i].Message, "env") {
+			found = &lints[i]
+		}
+	}
+	require.NotNil(t, found, "want a lint requiring a credstore when env is set; got %v", lints)
+	require.Equal(t, config.SeverityError, found.Severity)
+}

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -95,6 +95,11 @@ func ValidateProviders(cfg *Config, root *yaml.Node, facts ProviderFacts) []Lint
 				v.checkRefScheme(fmt.Sprintf("rules[%d].inject.token_secret_ref", i), r.Inject.TokenSecretRef, facts)
 			}
 		}
+		// The `postern exec` env: values resolve through the same credstores; an
+		// unroutable scheme there is the same fail-at-validate condition as a rule.
+		for _, name := range sortedKeys(cfg.Env) {
+			v.checkRefScheme("env."+name, cfg.Env[name], facts)
+		}
 	}
 
 	return v.out

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -77,6 +77,14 @@ type Config struct {
 	CredStores []CredStore `yaml:"credstores,omitempty"`
 	Proxy      Proxy       `yaml:"proxy"`
 	Rules      []Rule      `yaml:"rules"`
+
+	// Env maps environment-variable names to secret references for the
+	// `postern exec` command, which resolves each value through the same
+	// credstore path the proxy uses and exports it into the launched child's
+	// environment. It is independent of the proxy's rules: a config may set
+	// env, rules, or both. Each value is a <scheme>://<rest> secret_ref whose
+	// scheme a configured credstore must resolve.
+	Env map[string]string `yaml:"env,omitempty"`
 }
 
 // CredStore declares a single credential vendor configuration the broker

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"net"
 	"regexp"
+	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -55,6 +56,11 @@ var secretRefPattern = regexp.MustCompile(`^[a-z][a-z0-9+.\-]*://.+$`)
 // for stable substitution outside header values.
 var unreservedTokenPattern = regexp.MustCompile(`^[A-Za-z0-9._~-]+$`)
 
+// envNamePattern is the POSIX-portable environment-variable name shape: a
+// letter or underscore followed by letters, digits, or underscores. A key
+// outside this set could never be exported to the launched child process.
+var envNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
 // Validate walks cfg and returns the slice of findings. Root is the AST from
 // Load and supplies line numbers; pass nil to skip location info.
 func Validate(cfg *Config, root *yaml.Node) []LintError {
@@ -74,11 +80,16 @@ func validateSkipping(cfg *Config, root *yaml.Node, skipRule map[int]struct{}) [
 	v.checkProxy(&cfg.Proxy)
 	v.checkCredStores(cfg.CredStores)
 	v.checkRulesSkipping(cfg.Rules, skipRule)
-	// Rules without any credstore can never be brokered. Flagging this at
-	// validate time turns the otherwise-cryptic boot error "scheme router
-	// requires at least one resolver" into a line-numbered lint.
-	if len(cfg.Rules) > 0 && len(cfg.CredStores) == 0 {
-		v.add("credstores", "at least one credstore is required when rules are non-empty (set top-level `token:` or `credstores:`)", SeverityError)
+	v.checkEnv(cfg.Env)
+	// Rules or env entries without any credstore can never be resolved.
+	// Flagging this at validate time turns the otherwise-cryptic boot error
+	// "scheme router requires at least one resolver" into a line-numbered lint.
+	if len(cfg.CredStores) == 0 {
+		if len(cfg.Rules) > 0 {
+			v.add("credstores", "at least one credstore is required when rules are non-empty (set top-level `token:` or `credstores:`)", SeverityError)
+		} else if len(cfg.Env) > 0 {
+			v.add("credstores", "at least one credstore is required when env is non-empty (set top-level `token:` or `credstores:`)", SeverityError)
+		}
 	}
 	return v.out
 }
@@ -228,6 +239,37 @@ func (v *validator) checkRulesSkipping(rules []Rule, skip map[int]struct{}) {
 			}
 		}
 	}
+}
+
+// checkEnv validates the env: block consumed by `postern exec`. Each key must
+// be a valid environment-variable name and each value a well-formed secret_ref;
+// the scheme-is-routable check lives in ValidateProviders alongside the rule
+// check, so it runs only on the registry-aware path. Keys are visited in sorted
+// order so the lint output is deterministic regardless of map iteration order.
+func (v *validator) checkEnv(env map[string]string) {
+	for _, name := range sortedKeys(env) {
+		base := "env." + name
+		if !envNamePattern.MatchString(name) {
+			v.add(base, fmt.Sprintf("%q is not a valid environment variable name (use letters, digits, and underscore; must not start with a digit)", name), SeverityError)
+		}
+		ref := env[name]
+		if ref == "" {
+			v.add(base, "secret_ref is required", SeverityError)
+		} else if !secretRefPattern.MatchString(ref) {
+			v.add(base, fmt.Sprintf("secret_ref %q must be a URI of the form <scheme>://<rest> (e.g., op://VAULT/ITEM/FIELD)", ref), SeverityError)
+		}
+	}
+}
+
+// sortedKeys returns the keys of m in lexical order. The validator iterates
+// maps through it so lints over the env: block come out in a stable order.
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func (v *validator) checkRule(base string, r Rule) {


### PR DESCRIPTION
Postern's job is to keep secrets out of an agent's hands: the agent makes its requests, and postern attaches the real credentials on the way out, so the secret never sits inside the agent. The catch is that not everything an agent does travels over the web in a way postern can step into — think of a program connecting to a database, copying code over an SSH connection, or a tool that simply expects its password to already be waiting in its environment when it starts. This change adds a new command, `postern exec`, to cover those cases. You tell postern which secrets a program needs, and it fetches them from your vault and places them into that program's environment as it launches it.

In your config file you add a short list under a new `env` section, pairing each secret in your vault with the name the program looks for. Then you start the program through postern, for example `postern exec -- node server.js`. Postern looks each secret up, hands them over, and steps out of the way so the program runs as itself. There is also an optional scan mode for a common setup where the environment already holds placeholders that point at the vault instead of the real values — postern swaps those placeholders for the real secrets at launch. The same command works for a long-running service managed by the operating system, a container, or a development environment brought up over SSH, and the documentation includes copy-and-paste setups for each.

It is worth being clear that this is intentionally a narrower, more cautious tool than the main proxy. Because the secret is placed into the program's environment, that program does hold it while it runs — unlike the proxy, where the secret never leaves postern. The guidance, spelled out in the new documentation, is to keep using the proxy for anything that talks to the web and to reach for this only where the proxy cannot help. By default the command errs on the side of safety: if any secret cannot be fetched it refuses to start the program rather than run it half-configured, it never prints secret values (only a masked hint), and it declines to inject short-lived one-time codes that would already be expired by the time the program needed them.

## Example

```yaml
env:
  DATABASE_URL: op://Infra/droplet-db/url
  STRIPE_SECRET_KEY: op://Infra/stripe/secret_key
```

```sh
postern exec -- node server.js
```

Full reference and the systemd, Docker Compose, and dev-container-over-SSH setups are in `docs/exec.md`.
