### PR TITLE
feat(oauth2): persist rotated refresh tokens across restarts

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -282,9 +282,16 @@ The OAuth2 grant type decides how many secrets the credstore needs:
   long-lived **refresh token** (`refresh_token:`, the same source grammar as
   `token:`). Both resolve through the normal token chain (env/file/keychain).
 
-A rotated refresh token (some servers issue a new one on each refresh) is held in
-memory for the life of the process; persisting it across restarts is not yet
-supported, so a rotating server must be re-provisioned after a restart.
+Some servers issue a **single-use refresh token**: every refresh returns a new
+refresh token and invalidates the previous one (e.g. X, Marktplaats). The rotated
+token is always kept in memory for the life of the process. To also survive a
+restart, set **`refresh_token_path`** to a writable, durable file: the resolver
+writes each rotated token there atomically and prefers it over the configured
+`refresh_token:` seed on the next boot. Without it, a restart falls back to the
+seed — which a rotating server has already invalidated — so the credstore must be
+re-provisioned. The `refresh_token:` block is still required as the first-boot
+seed; `refresh_token_path` only needs a durable mount (a hostPath/PVC, not an
+`emptyDir`, which a rotating server would outlive).
 
 ### Settings keys
 
@@ -295,6 +302,7 @@ supported, so a rotating server must be re-provisioned after a restart.
 | `grant_type` | yes | `client_credentials` or `refresh_token`. Explicit, never inferred. A `refresh_token:` block is required for — and only for — `refresh_token`. |
 | `scope` | no | Space-separated scopes requested at the token endpoint. |
 | `auth_style` | no | How client credentials are sent: `basic` (HTTP Basic header, the default) or `post` (form body). Some endpoints require one or the other. |
+| `refresh_token_path` | no | Absolute path to a writable, durable file where a rotated refresh token is persisted and re-read across restarts. `refresh_token` grant only. Omit to keep the in-memory-only behavior. |
 
 ### Config example
 
@@ -325,6 +333,7 @@ credstores:
       client_id: postern-agent
       grant_type: refresh_token
       auth_style: post
+      refresh_token_path: /var/lib/postern/feed-refresh-token  # survives restarts on rotating servers
 
 proxy:
   listen: 127.0.0.1:1701

--- a/internal/credstore/oauth2/provider.go
+++ b/internal/credstore/oauth2/provider.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -134,35 +135,53 @@ func (p *Provider) buildResolver(clientSecret, refreshToken string, settings map
 		}
 	}
 
+	// With persistence enabled, a refresh token rotated by a prior process run
+	// lives in refresh_token_path and supersedes the configured seed (which a
+	// rotating server has already invalidated). On first boot the file is absent
+	// and the seed is used; the resolver writes the file on the first rotation.
+	effectiveRefresh := refreshToken
+	if s.refreshTokenPath != "" {
+		persisted, err := readPersistedRefreshToken(s.refreshTokenPath)
+		if err != nil {
+			return nil, err
+		}
+		if persisted != "" {
+			effectiveRefresh = persisted
+		}
+	}
+
 	return newResolver(oauthConfig{
-		tokenURL:     s.tokenURL,
-		clientID:     s.clientID,
-		clientSecret: clientSecret,
-		grantType:    s.grantType,
-		refreshToken: refreshToken,
-		scopes:       s.scopes,
-		authStyle:    s.authStyle,
-		httpClient:   client,
+		tokenURL:         s.tokenURL,
+		clientID:         s.clientID,
+		clientSecret:     clientSecret,
+		grantType:        s.grantType,
+		refreshToken:     effectiveRefresh,
+		scopes:           s.scopes,
+		authStyle:        s.authStyle,
+		refreshTokenPath: s.refreshTokenPath,
+		httpClient:       client,
 	})
 }
 
 // settings is the parsed, validated token-endpoint configuration.
 type settings struct {
-	tokenURL  string
-	clientID  string
-	grantType string
-	scopes    []string
-	authStyle xoauth2.AuthStyle
+	tokenURL         string
+	clientID         string
+	grantType        string
+	scopes           []string
+	authStyle        xoauth2.AuthStyle
+	refreshTokenPath string
 }
 
 // knownSettingKeys is the closed set of recognized settings keys; any other key
 // is a config error so a typo never silently no-ops.
 var knownSettingKeys = map[string]bool{
-	"token_url":  true,
-	"client_id":  true,
-	"grant_type": true,
-	"scope":      true,
-	"auth_style": true,
+	"token_url":          true,
+	"client_id":          true,
+	"grant_type":         true,
+	"scope":              true,
+	"auth_style":         true,
+	"refresh_token_path": true,
 }
 
 // parseSettings validates and parses the provider settings map. grant_type is
@@ -210,6 +229,20 @@ func parseSettings(m map[string]string) (settings, error) {
 
 	if sc := strings.TrimSpace(m["scope"]); sc != "" {
 		s.scopes = strings.Fields(sc)
+	}
+
+	if p := strings.TrimSpace(m["refresh_token_path"]); p != "" {
+		// Persisting a rotated refresh token only makes sense for the refresh_token
+		// grant; client_credentials never receives one.
+		if s.grantType != grantRefreshToken {
+			return s, errors.New("oauth2: refresh_token_path requires grant_type: refresh_token")
+		}
+		// An absolute path keeps persistence independent of the proxy's working
+		// directory and makes the durable-mount requirement explicit.
+		if !filepath.IsAbs(p) {
+			return s, fmt.Errorf("oauth2: refresh_token_path must be an absolute path: %q", p)
+		}
+		s.refreshTokenPath = p
 	}
 	return s, nil
 }

--- a/internal/credstore/oauth2/refresh_persist_test.go
+++ b/internal/credstore/oauth2/refresh_persist_test.go
@@ -1,0 +1,167 @@
+package oauth2
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// rotatingIDP is a token endpoint with single-use refresh tokens: every
+// refresh_token exchange issues a new access AND refresh token and invalidates
+// the previous refresh token (the X / Marktplaats behavior). A stale refresh
+// token is rejected with invalid_grant. expires_in is 1s so x/oauth2 treats each
+// issued access token as immediately stale and refreshes on the next call.
+type rotatingIDP struct {
+	srv     *httptest.Server
+	mu      sync.Mutex
+	current string // the only currently-valid refresh token
+	issued  int
+}
+
+func newRotatingIDP(t *testing.T, seed string) *rotatingIDP {
+	t.Helper()
+	idp := &rotatingIDP{current: seed}
+	idp.srv = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		idp.mu.Lock()
+		defer idp.mu.Unlock()
+		if r.PostForm.Get("grant_type") != "refresh_token" {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"unsupported_grant_type"}`))
+			return
+		}
+		if r.PostForm.Get("refresh_token") != idp.current {
+			// Rotated-away / stale token: single-use semantics reject it.
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+			return
+		}
+		idp.issued++
+		next := fmt.Sprintf("rt-%d", idp.issued)
+		idp.current = next
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  fmt.Sprintf("at-%d", idp.issued),
+			"refresh_token": next,
+			"token_type":    "Bearer",
+			"expires_in":    1,
+		})
+	}))
+	t.Cleanup(idp.srv.Close)
+	return idp
+}
+
+func readFileTrimmed(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// TestRefreshTokenRotationPersistedAndSurvivesRestart is the core of the feature:
+// a rotated refresh token is written back to refresh_token_path, and a fresh
+// resolver built from the original (now-invalid) seed picks up the persisted
+// token instead — proving persistence survives a process restart.
+func TestRefreshTokenRotationPersistedAndSurvivesRestart(t *testing.T) {
+	t.Parallel()
+	const seed = "rt-0"
+	idp := newRotatingIDP(t, seed)
+	path := filepath.Join(t.TempDir(), "refresh-token")
+	p := &Provider{httpClient: idp.srv.Client()}
+	settings := rtSettings(idp.srv.URL)
+	settings["refresh_token_path"] = path
+
+	res, err := p.NewResolverWithSecondary(context.Background(), "csecret", seed, settings)
+	require.NoError(t, err)
+
+	// First exchange rotates rt-0 -> rt-1 and must persist rt-1.
+	at, err := res.Resolve(context.Background(), "", "oauth2://mp")
+	require.NoError(t, err)
+	require.Equal(t, "at-1", at)
+	require.Equal(t, "rt-1", readFileTrimmed(t, path), "rotated refresh token must be persisted")
+
+	// Second exchange (token already stale at 1s) rotates rt-1 -> rt-2.
+	at, err = res.Resolve(context.Background(), "", "oauth2://mp")
+	require.NoError(t, err)
+	require.Equal(t, "at-2", at)
+	require.Equal(t, "rt-2", readFileTrimmed(t, path))
+
+	// Simulate a restart: a brand-new resolver is constructed from the ORIGINAL
+	// seed (as a SealedSecret/env seed would supply), but the persisted file holds
+	// rt-2. The server has long invalidated rt-0, so success proves the resolver
+	// used the persisted token, not the seed.
+	res2, err := p.NewResolverWithSecondary(context.Background(), "csecret", seed, settings)
+	require.NoError(t, err)
+	at, err = res2.Resolve(context.Background(), "", "oauth2://mp")
+	require.NoError(t, err, "post-restart resolver must use the persisted (rotated) refresh token, not the stale seed")
+	require.Equal(t, "at-3", at)
+	require.Equal(t, "rt-3", readFileTrimmed(t, path))
+}
+
+// TestRefreshTokenSeedUsedWhenNoPersistFileYet covers first boot: with the path
+// set but no file yet, the configured seed is used and then persisted.
+func TestRefreshTokenSeedUsedWhenNoPersistFileYet(t *testing.T) {
+	t.Parallel()
+	idp := newRotatingIDP(t, "seed-0")
+	path := filepath.Join(t.TempDir(), "nested", "refresh-token")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+	p := &Provider{httpClient: idp.srv.Client()}
+	settings := rtSettings(idp.srv.URL)
+	settings["refresh_token_path"] = path
+
+	res, err := p.NewResolverWithSecondary(context.Background(), "csecret", "seed-0", settings)
+	require.NoError(t, err)
+	_, err = res.Resolve(context.Background(), "", "oauth2://mp")
+	require.NoError(t, err)
+	require.Equal(t, "rt-1", readFileTrimmed(t, path), "first rotation must seed the persist file")
+}
+
+// TestParseSettingsRefreshTokenPath validates the new setting: accepted for the
+// refresh grant, rejected for client_credentials, rejected when relative.
+func TestParseSettingsRefreshTokenPath(t *testing.T) {
+	t.Parallel()
+	base := func() map[string]string {
+		return map[string]string{"token_url": "https://idp.example.com/token", "client_id": "cid", "grant_type": "refresh_token"}
+	}
+
+	t.Run("accepted for refresh grant", func(t *testing.T) {
+		t.Parallel()
+		m := base()
+		m["refresh_token_path"] = "/var/lib/postern/rt"
+		s, err := parseSettings(m)
+		require.NoError(t, err)
+		require.Equal(t, "/var/lib/postern/rt", s.refreshTokenPath)
+	})
+
+	t.Run("rejected for client_credentials", func(t *testing.T) {
+		t.Parallel()
+		m := base()
+		m["grant_type"] = "client_credentials"
+		m["refresh_token_path"] = "/var/lib/postern/rt"
+		_, err := parseSettings(m)
+		require.Error(t, err)
+	})
+
+	t.Run("rejected when relative", func(t *testing.T) {
+		t.Parallel()
+		m := base()
+		m["refresh_token_path"] = "relative/rt"
+		_, err := parseSettings(m)
+		require.Error(t, err)
+	})
+
+	t.Run("unset leaves persistence disabled", func(t *testing.T) {
+		t.Parallel()
+		s, err := parseSettings(base())
+		require.NoError(t, err)
+		require.Empty(t, s.refreshTokenPath)
+	})
+}

--- a/internal/credstore/oauth2/refresh_persist_test.go
+++ b/internal/credstore/oauth2/refresh_persist_test.go
@@ -59,6 +59,12 @@ func newRotatingIDP(t *testing.T, seed string) *rotatingIDP {
 	return idp
 }
 
+func (idp *rotatingIDP) latest() string {
+	idp.mu.Lock()
+	defer idp.mu.Unlock()
+	return idp.current
+}
+
 func readFileTrimmed(t *testing.T, path string) string {
 	t.Helper()
 	b, err := os.ReadFile(path)
@@ -122,6 +128,43 @@ func TestRefreshTokenSeedUsedWhenNoPersistFileYet(t *testing.T) {
 	_, err = res.Resolve(context.Background(), "", "oauth2://mp")
 	require.NoError(t, err)
 	require.Equal(t, "rt-1", readFileTrimmed(t, path), "first rotation must seed the persist file")
+}
+
+// TestRefreshTokenPersistConcurrent hammers Resolve from many goroutines against
+// a rotating IdP. Under -race it guards the fetch+persist critical section, and
+// the final assertion checks that the persisted file holds the latest issued
+// refresh token — never a stale value rolled back by a preempted goroutine.
+func TestRefreshTokenPersistConcurrent(t *testing.T) {
+	t.Parallel()
+	idp := newRotatingIDP(t, "rt-0")
+	path := filepath.Join(t.TempDir(), "refresh-token")
+	p := &Provider{httpClient: idp.srv.Client()}
+	settings := rtSettings(idp.srv.URL)
+	settings["refresh_token_path"] = path
+	res, err := p.NewResolverWithSecondary(context.Background(), "csecret", "rt-0", settings)
+	require.NoError(t, err)
+
+	const workers, iters = 24, 25
+	var wg sync.WaitGroup
+	errs := make(chan error, workers*iters)
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iters {
+				if _, err := res.Resolve(context.Background(), "", "oauth2://mp"); err != nil {
+					errs <- err
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.Equal(t, idp.latest(), readFileTrimmed(t, path),
+		"persisted token must equal the latest issued, never a stale rollback")
 }
 
 // TestParseSettingsRefreshTokenPath validates the new setting: accepted for the

--- a/internal/credstore/oauth2/resolver.go
+++ b/internal/credstore/oauth2/resolver.go
@@ -15,7 +15,10 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 
 	xoauth2 "golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
@@ -49,6 +52,10 @@ type oauthConfig struct {
 	refreshToken string
 	scopes       []string
 	authStyle    xoauth2.AuthStyle
+	// refreshTokenPath, when non-empty, is a writable file where a rotated
+	// refresh token is persisted so it survives a process restart. Empty
+	// disables persistence (the in-memory-only legacy behavior).
+	refreshTokenPath string
 	// httpClient governs the token-endpoint calls (timeout, test transport).
 	// nil uses http.DefaultClient via x/oauth2.
 	httpClient *http.Client
@@ -56,8 +63,20 @@ type oauthConfig struct {
 
 // resolver adapts an x/oauth2 TokenSource to broker.Resolver. The TokenSource is
 // thread-safe and caches/refreshes the token internally.
+//
+// When persistPath is set (refresh_token grant only), the resolver watches each
+// minted token for a rotated refresh token and writes the new value back to
+// persistPath atomically. Servers that issue single-use refresh tokens (X,
+// Marktplaats, …) invalidate the previous refresh token on every refresh; without
+// persistence the rotated token lives only in the TokenSource's memory and is lost
+// on restart, leaving the on-disk seed permanently invalid. mu guards lastRefresh
+// and the write so concurrent Resolve calls persist at most once per rotation.
 type resolver struct {
 	ts xoauth2.TokenSource
+
+	persistPath string
+	mu          sync.Mutex
+	lastRefresh string
 }
 
 // newResolver builds a resolver whose TokenSource implements cfg.grantType. The
@@ -96,7 +115,9 @@ func newResolver(cfg oauthConfig) (*resolver, error) {
 		return nil, fmt.Errorf("oauth2: unsupported grant_type %q", cfg.grantType)
 	}
 
-	return &resolver{ts: ts}, nil
+	// lastRefresh seeds the rotation watermark with the refresh token the
+	// TokenSource starts from, so only a genuine rotation triggers a write.
+	return &resolver{ts: ts, persistPath: cfg.refreshTokenPath, lastRefresh: cfg.refreshToken}, nil
 }
 
 // Resolve returns the access token for secretRef. vaultID is unused (single
@@ -114,7 +135,82 @@ func (r *resolver) Resolve(_ context.Context, _, secretRef string) (string, erro
 	if tok.AccessToken == "" {
 		return "", errors.New("oauth2: token endpoint returned an empty access_token")
 	}
+	if err := r.persistRotatedRefreshToken(tok.RefreshToken); err != nil {
+		// Fail closed: the server has already invalidated the previous refresh
+		// token, so a token we cannot record will brick the next restart. Surface
+		// it now (502) rather than silently degrade. The access token returned by
+		// this same exchange stays valid in the TokenSource cache, so a transient
+		// write error recovers on the next attempt once the path is writable.
+		return "", err
+	}
 	return tok.AccessToken, nil
+}
+
+// persistRotatedRefreshToken writes refreshToken back to persistPath when it has
+// rotated since the last persisted value. It is a no-op when persistence is
+// disabled (persistPath empty), the server did not return a refresh token, or the
+// value is unchanged — so a cached (non-refreshing) Token() call writes nothing.
+func (r *resolver) persistRotatedRefreshToken(refreshToken string) error {
+	if r.persistPath == "" || refreshToken == "" {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if refreshToken == r.lastRefresh {
+		return nil
+	}
+	if err := writeRefreshTokenFile(r.persistPath, refreshToken); err != nil {
+		return fmt.Errorf("oauth2: persist rotated refresh token: %w", err)
+	}
+	r.lastRefresh = refreshToken
+	return nil
+}
+
+// writeRefreshTokenFile atomically replaces path with token (no trailing
+// newline; readers trim). It writes a sibling temp file at 0600 and renames it
+// over path, so a crash mid-write never leaves a truncated refresh token that
+// would brick the next restart. The temp file shares path's directory so the
+// rename is a same-filesystem atomic operation.
+func writeRefreshTokenFile(path, token string) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".refresh-token-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }() // no-op once the rename succeeds
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.WriteString(token); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+// readPersistedRefreshToken returns the trimmed contents of a previously
+// persisted refresh-token file. A missing file returns "" with no error (first
+// boot, before any rotation) so the caller falls back to the configured seed;
+// any other read error is surfaced so a non-writable/unreadable mount fails the
+// resolver build loudly rather than silently dropping persistence.
+func readPersistedRefreshToken(path string) (string, error) {
+	b, err := os.ReadFile(path) //nolint:gosec // operator-supplied refresh-token path is intentional
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("oauth2: read persisted refresh token: %w", err)
+	}
+	return strings.TrimSpace(string(b)), nil
 }
 
 // sanitizeTokenError strips the token-endpoint response body from an x/oauth2

--- a/internal/credstore/oauth2/resolver.go
+++ b/internal/credstore/oauth2/resolver.go
@@ -69,8 +69,10 @@ type oauthConfig struct {
 // persistPath atomically. Servers that issue single-use refresh tokens (X,
 // Marktplaats, …) invalidate the previous refresh token on every refresh; without
 // persistence the rotated token lives only in the TokenSource's memory and is lost
-// on restart, leaving the on-disk seed permanently invalid. mu guards lastRefresh
-// and the write so concurrent Resolve calls persist at most once per rotation.
+// on restart, leaving the on-disk seed permanently invalid. mu serializes the
+// token fetch together with the rotation write (persistence path only), so a
+// goroutine cannot fetch a token, stall, and later overwrite a newer refresh
+// token a concurrent rotation already persisted.
 type resolver struct {
 	ts xoauth2.TokenSource
 
@@ -128,6 +130,25 @@ func (r *resolver) Resolve(_ context.Context, _, secretRef string) (string, erro
 		return "", fmt.Errorf("%w: %q", errNotOAuth2Ref, secretRef)
 	}
 
+	// Persistence-disabled resolvers take the lock-free fast path. When
+	// persistence is on, the token fetch and the rotation write happen under a
+	// single lock: a goroutine preempted between fetch and write must not resume
+	// and overwrite a refresh token a concurrent rotation already persisted —
+	// the server has invalidated the older value, so that would brick the next
+	// restart. Holding r.mu across r.ts.Token() makes fetch+persist atomic.
+	if r.persistPath == "" {
+		tok, err := r.ts.Token()
+		if err != nil {
+			return "", sanitizeTokenError(err)
+		}
+		if tok.AccessToken == "" {
+			return "", errors.New("oauth2: token endpoint returned an empty access_token")
+		}
+		return tok.AccessToken, nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	tok, err := r.ts.Token()
 	if err != nil {
 		return "", sanitizeTokenError(err)
@@ -135,42 +156,29 @@ func (r *resolver) Resolve(_ context.Context, _, secretRef string) (string, erro
 	if tok.AccessToken == "" {
 		return "", errors.New("oauth2: token endpoint returned an empty access_token")
 	}
-	if err := r.persistRotatedRefreshToken(tok.RefreshToken); err != nil {
+	// A rotated refresh token is persisted before the access token is handed out.
+	// A cached (non-refreshing) Token() call leaves RefreshToken unchanged, so it
+	// writes nothing.
+	if rt := tok.RefreshToken; rt != "" && rt != r.lastRefresh {
 		// Fail closed: the server has already invalidated the previous refresh
-		// token, so a token we cannot record will brick the next restart. Surface
-		// it now (502) rather than silently degrade. The access token returned by
-		// this same exchange stays valid in the TokenSource cache, so a transient
-		// write error recovers on the next attempt once the path is writable.
-		return "", err
+		// token, so a value we cannot record will brick the next restart. Surface
+		// it now (502) rather than silently degrade. The access token from this
+		// same exchange stays valid in the TokenSource cache, so a transient write
+		// error recovers on the next attempt once the path is writable.
+		if err := writeRefreshTokenFile(r.persistPath, rt); err != nil {
+			return "", fmt.Errorf("oauth2: persist rotated refresh token: %w", err)
+		}
+		r.lastRefresh = rt
 	}
 	return tok.AccessToken, nil
 }
 
-// persistRotatedRefreshToken writes refreshToken back to persistPath when it has
-// rotated since the last persisted value. It is a no-op when persistence is
-// disabled (persistPath empty), the server did not return a refresh token, or the
-// value is unchanged — so a cached (non-refreshing) Token() call writes nothing.
-func (r *resolver) persistRotatedRefreshToken(refreshToken string) error {
-	if r.persistPath == "" || refreshToken == "" {
-		return nil
-	}
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if refreshToken == r.lastRefresh {
-		return nil
-	}
-	if err := writeRefreshTokenFile(r.persistPath, refreshToken); err != nil {
-		return fmt.Errorf("oauth2: persist rotated refresh token: %w", err)
-	}
-	r.lastRefresh = refreshToken
-	return nil
-}
-
 // writeRefreshTokenFile atomically replaces path with token (no trailing
-// newline; readers trim). It writes a sibling temp file at 0600 and renames it
-// over path, so a crash mid-write never leaves a truncated refresh token that
-// would brick the next restart. The temp file shares path's directory so the
-// rename is a same-filesystem atomic operation.
+// newline; readers trim). It writes a sibling temp file and renames it over
+// path, so a crash mid-write never leaves a truncated refresh token that would
+// brick the next restart. The temp file shares path's directory so the rename is
+// a same-filesystem atomic operation. os.CreateTemp opens with O_EXCL at mode
+// 0600, so the refresh token is never briefly world-readable.
 func writeRefreshTokenFile(path, token string) error {
 	dir := filepath.Dir(path)
 	tmp, err := os.CreateTemp(dir, ".refresh-token-*")
@@ -179,10 +187,6 @@ func writeRefreshTokenFile(path, token string) error {
 	}
 	tmpName := tmp.Name()
 	defer func() { _ = os.Remove(tmpName) }() // no-op once the rename succeeds
-	if err := tmp.Chmod(0o600); err != nil {
-		_ = tmp.Close()
-		return err
-	}
 	if _, err := tmp.WriteString(token); err != nil {
 		_ = tmp.Close()
 		return err


### PR DESCRIPTION
## Problem

Servers that issue **single-use / rotating refresh tokens** (X, Marktplaats, and others) return a *new* refresh token on every refresh and invalidate the previous one. Postern's `oauth2` credstore keeps the rotated token only in `x/oauth2`'s in-memory `TokenSource`, so on a process restart it re-reads the configured `refresh_token:` seed — which the server has already invalidated — and the credstore is bricked until manually re-provisioned.

The provider docs already call this out:

> "A rotated refresh token … is held in memory for the life of the process; persisting it across restarts is not yet supported."

For an access token with a short lifetime (X ≈ 2h, Marktplaats access tokens 24h) and a proxy that restarts on any redeploy/node move, this means refresh-token auth effectively can't survive normal operation.

## Change

Add an optional **`refresh_token_path`** setting on the `oauth2` credstore (`refresh_token` grant only):

- The resolver watches each minted token and, when the refresh token has **rotated**, writes the new value back to `refresh_token_path` **atomically** (temp file + `rename`, mode `0600`).
- On the next boot, `buildResolver` reads `refresh_token_path` and **prefers it over the configured seed** (the seed is only the first-boot bootstrap).
- Omitting the setting preserves the **exact prior in-memory-only behavior** — zero change for `client_credentials` or seed-only refresh setups.
- A cached (non-refreshing) `Token()` call writes nothing (guarded by a rotation watermark under a mutex, so concurrent `Resolve` calls persist at most once per rotation).
- **Fails closed** if the rotated token can't be persisted: the server has already invalidated the prior token, so a value we can't record would brick the next restart — better surfaced now than silently later.

Validation: `refresh_token_path` is rejected for `client_credentials` and when not absolute.

## Tests

- `TestRefreshTokenRotationPersistedAndSurvivesRestart` — a rotating IdP (single-use refresh tokens); asserts each rotation is persisted and that a **freshly built resolver seeded with the original (now-invalid) seed** picks up the persisted token and keeps working.
- `TestRefreshTokenSeedUsedWhenNoPersistFileYet` — first boot uses the seed, then seeds the file.
- `TestParseSettingsRefreshTokenPath` — accepted for refresh grant; rejected for client_credentials / relative path / leaves persistence off when unset.

`go vet ./...`, `go build ./...`, and `go test -race ./...` pass; `gofmt`/`gofumpt` clean. Docs updated in `docs/providers.md` (settings table, secrets section, config example, and the durable-mount caveat — hostPath/PVC, not emptyDir).

🤖 Generated with [Claude Code](https://claude.com/claude-code)