### PR TITLE
feat(proxy): selective MITM — tunnel non-brokered hosts

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,17 +35,23 @@ agent                     postern (127.0.0.1:1701)                 upstream
   │  ◀──── response (streamed) ──┤                                     │
 ```
 
-1. **CONNECT + MITM.** The agent points `HTTPS_PROXY` at postern. For each
-   `CONNECT`, postern mints a short-lived leaf certificate for the target host,
-   signed by a CA it generated locally and that the agent's trust store has been
-   told to trust (`postern ca install`). The agent completes a normal TLS
-   handshake; postern is the other end.
+1. **CONNECT + selective MITM.** The agent points `HTTPS_PROXY` at postern. For
+   each `CONNECT`, postern matches the target host against the rules and
+   intercepts only brokered hosts: it mints a short-lived leaf certificate for
+   the host, signed by a CA it generated locally and that the agent's trust
+   store has been told to trust (`postern ca install`), and completes the TLS
+   handshake as the other end. A host that matches no rule is tunneled untouched
+   — postern relays the encrypted bytes without terminating TLS, so the agent
+   reaches the real upstream with the real certificate and only needs to trust
+   the postern CA for hosts it actually brokers. (When no broker is configured
+   at all, postern falls back to intercepting every host.)
 
-2. **Match.** The decrypted request's host (with any `:port` stripped) is
-   matched against the YAML-declared rules — first match wins. Host patterns are
-   either a literal hostname or a single-`*` glob (`*.example.com`, matching one
-   label like a TLS wildcard). No match means the request is forwarded unchanged
-   (the default `passthrough` behavior).
+2. **Match.** For an intercepted host the decrypted request's host (with any
+   `:port` stripped) is matched against the YAML-declared rules — first match
+   wins. Host patterns are either a literal hostname or a single-`*` glob
+   (`*.example.com`, matching one label like a TLS wildcard). A host that
+   matches no rule is tunneled at `CONNECT` without decryption (the default
+   `passthrough` behavior); `block` rejects the `CONNECT` instead.
 
 3. **Resolve.** The matched rule's `secret_ref` (e.g. `op://Vault/Item/field`)
    is handed to the credstore provider registered for that URI scheme. Resolved

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,7 +77,7 @@ proxy:
     ttl: 1h                   # nominal freshness window
     refresh_ahead: 45m        # refresh asynchronously once a value reaches this age
     max_stale: 24h            # keep serving a cached value this long if refreshes fail
-  on_no_match: passthrough    # passthrough | block
+  on_no_match: passthrough    # passthrough (tunnel, no MITM) | block (reject the CONNECT)
   max_body_bytes: 1048576     # body buffering cap for body substitution (1 MiB)
 ```
 
@@ -86,7 +86,7 @@ proxy:
 | `listen` | yes | `host:port` the proxy binds. Point your agent's `HTTPS_PROXY` at this. |
 | `cache` | no | Credential cache settings (see below). |
 | `cache_ttl` | no | **Legacy alias for `cache.ttl`.** Go duration (`5m`, `30s`). Accepted for backward compatibility; prefer the `cache` block. Setting both `cache_ttl` and `cache.ttl` to different values is a config error. |
-| `on_no_match` | no | What to do when no rule matches. `passthrough` (default) forwards the request unchanged; `block` denies it with a `502` and never contacts the upstream (allowlist-only egress for proxied traffic). See [security.md](security.md#egress-containment-with-on_no_match). |
+| `on_no_match` | no | What to do with a `CONNECT` to a host that matches no rule. `passthrough` (default) tunnels the connection untouched — postern does **not** terminate TLS, so the agent reaches the real upstream with the real certificate and only needs to trust the postern CA for brokered hosts. `block` rejects the `CONNECT` with a `502` and never contacts the upstream (allowlist-only egress for proxied traffic). See [security.md](security.md#egress-containment-with-on_no_match). |
 | `max_body_bytes` | no | Cap (in bytes) on how much of a request body postern buffers when a rule rewrites the body (`inject.in` includes `body`). Default 1 MiB when unset or `0`. A larger body is rejected with `413 Request Entity Too Large` and never reaches the upstream. Bound at startup; a hot-reload edit warns and does not take effect (a per-rule `inject.max_body_bytes` override does hot-reload). |
 
 ### `proxy.cache`

--- a/docs/security.md
+++ b/docs/security.md
@@ -126,14 +126,36 @@ request.
 
 ## Egress containment with `on_no_match`
 
-`proxy.on_no_match` controls what happens to a proxied request whose host
-matches no broker rule:
+`proxy.on_no_match` controls what happens to a `CONNECT` whose host matches no
+broker rule:
 
-- `passthrough` (the default) forwards the request unchanged.
-- `block` denies it with a `502` and never contacts the upstream — an
-  allowlist-only egress policy for traffic flowing through the proxy.
+- `passthrough` (the default) tunnels the connection untouched — postern does
+  not terminate TLS for it. The agent reaches the real upstream with the real
+  certificate, and clients only need to trust the postern CA for hosts that are
+  actually brokered.
+- `block` rejects the `CONNECT` with a `502` and never contacts the upstream —
+  an allowlist-only egress policy for traffic flowing through the proxy.
 
 `block` governs only requests that reach the proxy. It is not a substitute for a
 network-level egress policy: anything that bypasses the proxy (raw sockets,
 misconfigured `HTTPS_PROXY`, non-HTTP protocols) is unaffected. Use a firewall
 when you need to contain egress the process cannot route around.
+
+## Selective interception
+
+Postern terminates TLS only for hosts that match a broker rule; everything else
+is tunneled byte-for-byte (or rejected under `block`). This shrinks the blast
+radius — postern decrypts only what it brokers — and lets protocol upgrades
+(e.g. WebSockets) and TLS-fingerprinting upstreams work end to end for
+non-brokered hosts, since those connections carry the agent's own handshake to
+the real server. Two boundaries follow from this:
+
+- **The interception decision uses the outer `CONNECT` host (the SNI/authority
+  the agent dials), not an inner request header.** A request that reaches a
+  brokered host by fronting it behind a different, non-brokered `CONNECT` host
+  would be tunneled, not brokered. This matters only under deliberate
+  domain-fronting; for the intended use (an agent dialing an API directly) the
+  `CONNECT` host and the request host are the same.
+- **Brokered hosts that also need a WebSocket upgrade are still MITM'd**, and
+  that upgrade path is not yet handled. Selective interception fixes upgrades
+  for non-brokered hosts only.

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -100,6 +100,8 @@ func NewServerCmd(caDir string, reg *credstore.Registry, store token.Store) *cob
 				Addr:               addr,
 				Logger:             logger,
 				PreUpstreamHandler: bundle.hook,
+				ShouldIntercept:    bundle.shouldIntercept,
+				BlockNonBrokered:   bundle.blockNonBrokered,
 			})
 			if err != nil {
 				return fmt.Errorf("init runtime: %w", err)
@@ -163,6 +165,15 @@ type brokerBundle struct {
 	cfgPath  string
 	listen   string
 	baseline *broker.Baseline
+
+	// shouldIntercept reports whether a host is brokered, so the proxy MITMs
+	// only those and tunnels the rest. nil (the no-broker bundle) leaves the
+	// proxy intercepting every host, unchanged from before selective MITM.
+	shouldIntercept func(string) bool
+
+	// blockNonBrokered mirrors on_no_match: block — reject non-brokered
+	// CONNECTs instead of tunneling them.
+	blockNonBrokered bool
 }
 
 // resolveListenAddr applies the listen-address precedence for `postern
@@ -267,6 +278,11 @@ func buildBrokerHook(ctx context.Context, reg *credstore.Registry, cfgPath strin
 			Proxy:      cfg.Proxy,
 			CredStores: cfg.CredStores,
 		},
+		shouldIntercept: func(host string) bool { _, ok := engine.Match(host); return ok },
+		// on_no_match is captured here and in broker.Hook above; both bind it at
+		// startup. A hot-reload edit does not take effect until restart — the
+		// reloader's baseline comparison warns when on_no_match changes.
+		blockNonBrokered: cfg.Proxy.OnNoMatch == config.OnNoMatchBlock,
 	}, nil
 }
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -19,9 +19,10 @@ const (
 	TokenSourceFile     TokenSource = "file"
 )
 
-// OnNoMatch is the proxy behavior when an outbound request doesn't match any
-// rule. The conservative default is passthrough (forward unchanged); "block"
-// is for paranoid deployments that want allowlist-only egress.
+// OnNoMatch is the proxy behavior for a CONNECT whose host matches no rule.
+// The conservative default is passthrough: the connection is tunneled untouched
+// (no TLS termination), so postern decrypts only the hosts it brokers. "block"
+// rejects the CONNECT for allowlist-only egress in paranoid deployments.
 type OnNoMatch string
 
 // On-no-match behavior values accepted in YAML.

--- a/internal/proxy/decision.go
+++ b/internal/proxy/decision.go
@@ -1,0 +1,27 @@
+package proxy
+
+// connectMode is the interception decision for a single CONNECT: terminate TLS
+// and broker the request (modeMITM), relay the encrypted bytes untouched
+// (modeTunnel), or refuse the tunnel at connect time (modeReject).
+type connectMode int
+
+const (
+	modeMITM connectMode = iota
+	modeTunnel
+	modeReject
+)
+
+// decideConnect chooses how to handle a CONNECT to host (a host:port target).
+// shouldIntercept reports whether the bare host is brokered; a nil func means
+// intercept every host, preserving the pre-selective-MITM behavior for callers
+// that do not opt in. A non-brokered host is tunneled unless blockNonBrokered
+// is set, in which case its CONNECT is rejected.
+func decideConnect(host string, shouldIntercept func(string) bool, blockNonBrokered bool) connectMode {
+	if shouldIntercept == nil || shouldIntercept(stripPort(host)) {
+		return modeMITM
+	}
+	if blockNonBrokered {
+		return modeReject
+	}
+	return modeTunnel
+}

--- a/internal/proxy/decision_test.go
+++ b/internal/proxy/decision_test.go
@@ -1,0 +1,68 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecideConnect(t *testing.T) {
+	t.Parallel()
+
+	matchAnthropic := func(host string) bool { return host == "api.anthropic.com" }
+
+	tests := []struct {
+		name             string
+		host             string
+		shouldIntercept  func(string) bool
+		blockNonBrokered bool
+		want             connectMode
+	}{
+		{
+			name:            "brokered host is intercepted",
+			host:            "api.anthropic.com:443",
+			shouldIntercept: matchAnthropic,
+			want:            modeMITM,
+		},
+		{
+			name:            "brokered match strips the port before matching",
+			host:            "api.anthropic.com:8443",
+			shouldIntercept: matchAnthropic,
+			want:            modeMITM,
+		},
+		{
+			name:            "non-brokered host tunnels by default",
+			host:            "example.com:443",
+			shouldIntercept: matchAnthropic,
+			want:            modeTunnel,
+		},
+		{
+			name:             "non-brokered host is rejected when blocking",
+			host:             "example.com:443",
+			shouldIntercept:  matchAnthropic,
+			blockNonBrokered: true,
+			want:             modeReject,
+		},
+		{
+			name:            "nil shouldIntercept intercepts everything (back-compat)",
+			host:            "example.com:443",
+			shouldIntercept: nil,
+			want:            modeMITM,
+		},
+		{
+			name:             "nil shouldIntercept intercepts even when blocking is set",
+			host:             "example.com:443",
+			shouldIntercept:  nil,
+			blockNonBrokered: true,
+			want:             modeMITM,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := decideConnect(tc.host, tc.shouldIntercept, tc.blockNonBrokered)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -50,6 +50,19 @@ type Config struct {
 	//
 	// The broker plugs into this slot to perform match → resolve → inject.
 	PreUpstreamHandler func(req *http.Request) *http.Response
+
+	// ShouldIntercept reports whether a host (port already stripped) is
+	// brokered and therefore must be MITM'd. Hosts it declines are tunneled
+	// (raw CONNECT relay, no TLS termination) or, when BlockNonBrokered is
+	// set, rejected at connect time. A nil func intercepts every host,
+	// preserving the original always-MITM behavior for callers that construct
+	// a Config directly (notably tests).
+	ShouldIntercept func(host string) bool
+
+	// BlockNonBrokered rejects the CONNECT for hosts ShouldIntercept declines
+	// instead of tunneling them — the connect-time form of on_no_match: block.
+	// It is ignored when ShouldIntercept is nil (every host is intercepted).
+	BlockNonBrokered bool
 }
 
 // Proxy is the postern HTTPS proxy. Construct one with New; expose its
@@ -93,14 +106,28 @@ func New(cfg Config) (*Proxy, error) {
 	}
 
 	tlsConfig := mitmTLSConfig(cfg.Minter)
-	gp.OnRequest().HandleConnect(goproxy.FuncHttpsHandler(func(host string, _ *goproxy.ProxyCtx) (*goproxy.ConnectAction, string) {
+	gp.OnRequest().HandleConnect(goproxy.FuncHttpsHandler(func(host string, ctx *goproxy.ProxyCtx) (*goproxy.ConnectAction, string) {
 		// Returning host (not "") preserves the destination so goproxy's
 		// downstream dial uses the correct target — the second return is
 		// the upstream connect address, not a label.
-		return &goproxy.ConnectAction{
-			Action:    goproxy.ConnectMitm,
-			TLSConfig: tlsConfig,
-		}, host
+		switch decideConnect(host, cfg.ShouldIntercept, cfg.BlockNonBrokered) {
+		case modeReject:
+			// Refuse the tunnel at connect time: no leaf minted, no upstream
+			// contact. Hand the agent a 502 so the block is legible rather
+			// than a bare socket close.
+			ctx.Resp = goproxy.NewResponse(ctx.Req, goproxy.ContentTypeText, http.StatusBadGateway, "blocked by postern: host not brokered\n") //nolint:bodyclose // synthetic 502; goproxy owns and writes this response, there is no body to close
+			return goproxy.RejectConnect, host
+		case modeTunnel:
+			// Non-brokered host: relay the encrypted bytes untouched so the
+			// client reaches the real upstream with its real certificate and
+			// TLS fingerprint. postern never decrypts what it does not broker.
+			return goproxy.OkConnect, host
+		default:
+			return &goproxy.ConnectAction{
+				Action:    goproxy.ConnectMitm,
+				TLSConfig: tlsConfig,
+			}, host
+		}
 	}))
 
 	installHandlers(gp, cfg.Logger)

--- a/internal/proxy/selective_test.go
+++ b/internal/proxy/selective_test.go
@@ -1,0 +1,154 @@
+package proxy_test
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mmartinez/postern/internal/proxy"
+)
+
+// clientTrustingUpstreamOnly routes HTTPS through the proxy while trusting only
+// the upstream's real certificate — NOT the postern CA. A tunneled CONNECT
+// therefore succeeds (the client validates the genuine upstream cert), while an
+// intercepted CONNECT fails (the client rejects postern's minted leaf). That
+// asymmetry is what proves whether interception happened. ServerName is pinned
+// to example.com because httptest's testcert carries no 127.0.0.1 IP SAN.
+func clientTrustingUpstreamOnly(t *testing.T, proxyURL string, upstream *httptest.Server) *http.Client {
+	t.Helper()
+	u, err := url.Parse(proxyURL)
+	require.NoError(t, err)
+
+	pool := x509.NewCertPool()
+	pool.AddCert(upstream.Certificate())
+
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyURL(u),
+			TLSClientConfig: &tls.Config{
+				RootCAs:    pool,
+				ServerName: "example.com",
+				MinVersion: tls.VersionTLS12,
+			},
+		},
+		Timeout: 5 * time.Second,
+	}
+}
+
+// A non-brokered host must be tunneled, not MITM'd: the client reaches the real
+// upstream and validates the upstream's own certificate. The client trusts only
+// the upstream cert (not the postern CA), so success here is positive proof
+// that postern minted no leaf and terminated no TLS.
+func TestProxy_SelectiveMITM_NonBrokeredHostIsTunneled(t *testing.T) {
+	t.Parallel()
+
+	var hits atomic.Int64
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = io.WriteString(w, "hello from real upstream")
+	}))
+	t.Cleanup(upstream.Close)
+
+	root := fixtureCA(t)
+	p, err := proxy.New(proxy.Config{
+		CA:              root,
+		Minter:          fixtureMinter(t, root),
+		Logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ShouldIntercept: func(string) bool { return false }, // nothing is brokered
+	})
+	require.NoError(t, err)
+
+	proxyURL := startProxy(t, p)
+	client := clientTrustingUpstreamOnly(t, proxyURL, upstream)
+
+	resp, err := client.Get(upstream.URL)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "hello from real upstream", string(body))
+	require.Equal(t, int64(1), hits.Load())
+}
+
+// The mirror of the tunnel test: when the host IS brokered, postern terminates
+// TLS with a leaf the upstream-only client does not trust, so the request
+// fails before any upstream contact. This proves flipping ShouldIntercept
+// actually flips TLS termination.
+func TestProxy_SelectiveMITM_BrokeredHostIsIntercepted(t *testing.T) {
+	t.Parallel()
+
+	var hits atomic.Int64
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = io.WriteString(w, "should not be reached by an upstream-only client")
+	}))
+	t.Cleanup(upstream.Close)
+
+	root := fixtureCA(t)
+	p, err := proxy.New(proxy.Config{
+		CA:              root,
+		Minter:          fixtureMinter(t, root),
+		Logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+		UpstreamTLS:     upstreamTLS(t, upstream),
+		ShouldIntercept: func(string) bool { return true }, // every host brokered
+	})
+	require.NoError(t, err)
+
+	proxyURL := startProxy(t, p)
+	client := clientTrustingUpstreamOnly(t, proxyURL, upstream)
+
+	resp, err := client.Get(upstream.URL)
+	// An upstream-only client MUST get a TLS handshake error: postern terminated
+	// the connection with a leaf signed by a CA the client does not trust.
+	require.Error(t, err, "upstream-only client must reject postern's MITM leaf")
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	require.Zero(t, hits.Load(), "upstream must not be reached when the client rejects the MITM leaf")
+}
+
+// on_no_match: block, expressed at connect time: a non-brokered host with
+// BlockNonBrokered set has its CONNECT rejected before any tunnel or MITM, so
+// the upstream is never contacted (fail-closed invariant).
+func TestProxy_SelectiveMITM_BlockRejectsNonBrokeredAtConnect(t *testing.T) {
+	t.Parallel()
+
+	var hits atomic.Int64
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = io.WriteString(w, "blocked host must never be reached")
+	}))
+	t.Cleanup(upstream.Close)
+
+	root := fixtureCA(t)
+	p, err := proxy.New(proxy.Config{
+		CA:               root,
+		Minter:           fixtureMinter(t, root),
+		Logger:           slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ShouldIntercept:  func(string) bool { return false }, // not brokered
+		BlockNonBrokered: true,
+	})
+	require.NoError(t, err)
+
+	proxyURL := startProxy(t, p)
+	client := clientThroughProxy(t, proxyURL, root)
+
+	resp, err := client.Get(upstream.URL)
+	if err == nil {
+		defer func() { _ = resp.Body.Close() }()
+		require.NotEqual(t, http.StatusOK, resp.StatusCode,
+			"a blocked CONNECT must not yield a 200")
+	}
+	require.Zero(t, hits.Load(), "CRITICAL: blocked host was contacted upstream")
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -48,6 +48,15 @@ type Options struct {
 	// PreUpstreamHandler is the broker insertion point. nil keeps
 	// the proxy in passthrough mode.
 	PreUpstreamHandler func(req *http.Request) *http.Response
+
+	// ShouldIntercept reports whether a host is brokered and must be MITM'd;
+	// hosts it declines are tunneled (or blocked). nil intercepts every host,
+	// matching the always-MITM behavior used when no broker is active.
+	ShouldIntercept func(host string) bool
+
+	// BlockNonBrokered rejects the CONNECT for non-brokered hosts instead of
+	// tunneling them — the connect-time form of on_no_match: block.
+	BlockNonBrokered bool
 }
 
 // Runtime is the constructed-but-not-yet-running postern server. Build it
@@ -86,6 +95,8 @@ func New(opts Options) (*Runtime, error) {
 		Logger:             opts.Logger,
 		UpstreamTLS:        opts.UpstreamTLS,
 		PreUpstreamHandler: opts.PreUpstreamHandler,
+		ShouldIntercept:    opts.ShouldIntercept,
+		BlockNonBrokered:   opts.BlockNonBrokered,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("init proxy: %w", err)


### PR DESCRIPTION
## Problem

Postern terminated and re-originated TLS for every `CONNECT`, regardless of whether the target host matched an injection rule. Hosts with no rule were still decrypted and re-encrypted with the proxy's own leaf and TLS stack. That breaks protocol upgrades (WebSockets) and TLS-fingerprinting upstreams for traffic postern adds nothing to, forces clients to trust the postern CA for hosts that are never brokered, and leaves no clean place to enforce egress policy.

## Change

Interception is now a per-`CONNECT` decision driven by the rule set:

| Case | Behavior |
|------|----------|
| Host matches a rule | MITM + inject (unchanged) |
| No match, `on_no_match: passthrough` (default) | Transparent CONNECT tunnel — no TLS termination, no leaf minted |
| No match, `on_no_match: block` | Reject the CONNECT with a `502`; upstream never contacted |

Non-brokered hosts now reach the real upstream with the real certificate and real client TLS fingerprint, so upgrades and fingerprinting edges work end to end, and clients only need to trust the postern CA for hosts actually brokered. The decision reuses the existing broker rule engine (`engine.Match`). When no broker is configured at all, postern falls back to intercepting every host, so existing no-broker deployments are unchanged.

No config schema change: `on_no_match` keeps `passthrough`/`block`; only the runtime effect for non-matched HTTPS changes.

## Implementation

- `internal/proxy`: `decideConnect` chooses MITM / tunnel / reject; `Config` gains `ShouldIntercept` and `BlockNonBrokered`. A nil `ShouldIntercept` intercepts everything (back-compat default).
- `internal/runtime`, `internal/cli`: thread the `engine.Match`-backed predicate and `on_no_match` through to the proxy.
- Docs updated (`architecture`, `configuration`, `security`).

## Testing

- Decision-table unit test over all branches incl. port-stripping and the nil-default.
- Integration: a non-brokered host is tunneled (client trusts only the real upstream cert and still succeeds — positive proof no leaf was minted); the mirror case proves interception flips TLS termination; a blocked non-brokered host is rejected at CONNECT with the upstream counter at zero.
- `make ci` green locally (lint, `-race` suite, govulncheck, license check). proxy coverage 89.7%.

## Out of scope

- Brokered hosts that also need a WebSocket upgrade remain MITM'd (upgrade path unhandled); this fixes upgrades for non-brokered hosts only.
- The interception decision follows the outer `CONNECT` host, not an inner request header (matters only under deliberate domain-fronting).

Closes #55
