### PR TITLE
feat: multi-header credential injection

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -197,8 +197,8 @@ rules:
 - **One resolve per request.** The rule's `secret_ref` is read once no matter how
   many headers it feeds, so a multi-header host costs the same vault quota as a
   single-header one.
-- **Header mode only.** Every entry takes `type: header`, a `name`, and a
-  `template` carrying `{{ CREDENTIAL }}`. `placeholder` and `oauth1` rules still
+- **Header mode only.** Every entry takes `type: header`, a `name` that is a
+  valid HTTP field name, and a `template` carrying `{{ CREDENTIAL }}`. `placeholder` and `oauth1` rules still
   use the single `inject` block, and the placeholder-only fields (`in`,
   `max_body_bytes`) are rejected inside an entry.
 - **Mutually exclusive** with `inject`, `routes`, and a preset `template` — each
@@ -376,7 +376,9 @@ Errors block startup. Common errors:
   missing or not of the form `<scheme>://<rest>`. (The `*_ref` fields are valid
   only with `type: oauth1`.)
 - `inject.in` set with `type: header`; an invalid surface name; a `placeholder`
-  token with reserved characters when a non-header surface is declared.
+  token with reserved characters when a non-header surface is declared; a
+  header `name` outside the RFC 9110 token grammar (net/http would refuse to
+  send it).
 - `routes` combined with a rule-level `secret_ref` or `inject.name`; `routes`
   without `type: placeholder`; a route missing `name`, `token`, or a well-formed
   `secret_ref`; duplicate or overlapping route tokens.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,6 +146,7 @@ rules:
 | `host` | yes* | A literal hostname (`api.example.com`) or a single-`*` glob (`*.example.com`, matching exactly one label). **Do not use a wildcard on a multi-tenant or shared-suffix domain** (e.g. `*.s3.amazonaws.com`, `*.blob.core.windows.net`): any host an attacker can register under that suffix would also match the rule and receive the injected credential. Reserve wildcards for single-tenant domains you control. |
 | `secret_ref` | yes | A `<scheme>://<rest>` URI the matching provider resolves (e.g. `op://VAULT/ITEM/FIELD`). Omit when using `routes` (each route carries its own). |
 | `inject` | yes* | How to attach the resolved credential — see below. |
+| `injects` | no | Several header injections fed by the rule's one `secret_ref`, for a host that authenticates the same credential through two different headers. Mutually exclusive with `inject`, `routes`, and `template`; see below. |
 | `routes` | no | Placeholder-routing entries: per-token secret selection for a shared host. Mutually exclusive with `secret_ref`/`inject.name`; see below. |
 | `template` | no | Name of a built-in preset (see below) that fills in `host` and `inject` defaults. |
 
@@ -168,6 +169,48 @@ inject:
 | `template` | The rendered credential string. `{{ CREDENTIAL }}` is replaced with the resolved value. Omitting the placeholder is a **fatal error**: the credential would be discarded and the request forwarded unauthenticated, so postern refuses to start. |
 | `in` | (`placeholder` only) The request surfaces to substitute, any subset of `header`, `body`, `path`, `query`. Defaults to `[header]`. |
 | `max_body_bytes` | (`placeholder` with `in` including `body`) Per-rule override of `proxy.max_body_bytes`. `0` (or unset) inherits the proxy-wide cap. |
+
+### Multi-header injection (`injects`)
+
+Some upstreams authenticate the *same* credential through *different* headers
+depending on the endpoint. OpenCode Zen is the canonical case: its OpenAI-shaped
+endpoint wants `Authorization: Bearer <key>` while its Anthropic-shaped endpoint
+wants `x-api-key: <key>`, both on `opencode.ai`. Host matching is first-match, so
+a single rule has to cover both.
+
+An `injects` list replaces the single `inject` block with several header
+injections, all fed by the rule's one `secret_ref`:
+
+```yaml
+rules:
+  - host: opencode.ai
+    secret_ref: op://Agents/opencode/api_key
+    injects:
+      - type: header
+        name: authorization
+        template: "Bearer {{ CREDENTIAL }}"
+      - type: header
+        name: x-api-key
+        template: "{{ CREDENTIAL }}"
+```
+
+- **One resolve per request.** The rule's `secret_ref` is read once no matter how
+  many headers it feeds, so a multi-header host costs the same vault quota as a
+  single-header one.
+- **Header mode only.** Every entry takes `type: header`, a `name`, and a
+  `template` carrying `{{ CREDENTIAL }}`. `placeholder` and `oauth1` rules still
+  use the single `inject` block, and the placeholder-only fields (`in`,
+  `max_body_bytes`) are rejected inside an entry.
+- **Mutually exclusive** with `inject`, `routes`, and a preset `template` — each
+  of those would supply a second, conflicting injection. Header names must not
+  repeat within a rule (compared case-insensitively, since injection *sets* the
+  header rather than appending).
+- **Fail closed as a unit.** Every entry is validated and rendered before the
+  first header is set, so one unusable entry (no `{{ CREDENTIAL }}`, a CR/LF in
+  the rendered value) returns `502` with no header injected at all — never a
+  half-authenticated request.
+- **Each `Set` overrides** whatever the agent sent under that name, exactly as
+  single-header mode does.
 
 ### Substitution surfaces (`placeholder` mode)
 
@@ -337,6 +380,9 @@ Errors block startup. Common errors:
 - `routes` combined with a rule-level `secret_ref` or `inject.name`; `routes`
   without `type: placeholder`; a route missing `name`, `token`, or a well-formed
   `secret_ref`; duplicate or overlapping route tokens.
+- `injects` combined with `inject`, `routes`, or `template`; an empty `injects`
+  list; an entry that is not `type: header`, is missing `name` or `template`, or
+  carries `in`/`max_body_bytes`; duplicate header names within one rule.
 
 Warnings (reported, non-fatal): a route `token` with low estimated entropy
 (below ~64 bits) — a guessability hint, not a hard failure.

--- a/internal/broker/from_config.go
+++ b/internal/broker/from_config.go
@@ -21,6 +21,14 @@ func FromConfigRules(in []config.Rule) ([]Rule, error) {
 	out := make([]Rule, len(in))
 	for i := range in {
 		src := in[i]
+		if len(src.Injects) > 0 {
+			specs, err := injectionsFromConfig(src.Injects)
+			if err != nil {
+				return nil, fmt.Errorf("rules[%d] (%s): %w", i, src.Host, err)
+			}
+			out[i] = Rule{Host: src.Host, SecretRef: src.SecretRef, Injections: specs}
+			continue
+		}
 		t, err := injectTypeFromConfig(src.Inject.Type)
 		if err != nil {
 			// A template-only rule has no Host yet; fall back to the template
@@ -53,6 +61,23 @@ func FromConfigRules(in []config.Rule) ([]Rule, error) {
 			},
 			Routes: routesFromConfig(src.Routes),
 		}
+	}
+	return out, nil
+}
+
+// injectionsFromConfig translates a multi-header rule's inject list into
+// runtime specs. Every entry shares the rule's secret_ref, so an entry carries
+// only the header name and its template. Header mode is the only type the
+// list supports; the validator rejects anything else, and so does this rather
+// than translate a spec Inject could not apply.
+func injectionsFromConfig(in []config.Inject) ([]InjectSpec, error) {
+	out := make([]InjectSpec, len(in))
+	for i := range in {
+		e := &in[i]
+		if e.Type != config.InjectTypeHeader {
+			return nil, fmt.Errorf("injects[%d]: unsupported inject.type %q (header mode only)", i, e.Type)
+		}
+		out[i] = InjectSpec{Type: InjectHeader, Name: e.Name, Template: e.Template}
 	}
 	return out, nil
 }

--- a/internal/broker/from_config_test.go
+++ b/internal/broker/from_config_test.go
@@ -93,6 +93,53 @@ func TestFromConfigRules_TranslatesSurfacesAndCap(t *testing.T) {
 	}
 }
 
+// A rule's injects list becomes the runtime Injections slice, in order, with
+// the single rule-level secret_ref carried through unchanged.
+func TestFromConfigRules_TranslatesInjects(t *testing.T) {
+	t.Parallel()
+
+	in := []config.Rule{{
+		Host:      "api.example.com",
+		SecretRef: "op://Agents/example/api_key",
+		Injects: []config.Inject{
+			{Type: config.InjectTypeHeader, Name: "authorization", Template: "Bearer {{ CREDENTIAL }}"},
+			{Type: config.InjectTypeHeader, Name: "x-api-key", Template: "{{ CREDENTIAL }}"},
+		},
+	}}
+
+	got, err := broker.FromConfigRules(in)
+	if err != nil {
+		t.Fatalf("FromConfigRules: %v", err)
+	}
+
+	want := []broker.Rule{{
+		Host:      "api.example.com",
+		SecretRef: "op://Agents/example/api_key",
+		Injections: []broker.InjectSpec{
+			{Type: broker.InjectHeader, Name: "authorization", Template: "Bearer {{ CREDENTIAL }}"},
+			{Type: broker.InjectHeader, Name: "x-api-key", Template: "{{ CREDENTIAL }}"},
+		},
+	}}
+	if diff := cmp.Diff(want, got, cmpopts.EquateEmpty()); diff != "" {
+		t.Fatalf("rules diff (-want +got):\n%s", diff)
+	}
+}
+
+func TestFromConfigRules_RejectsNonHeaderInjectsEntry(t *testing.T) {
+	t.Parallel()
+
+	_, err := broker.FromConfigRules([]config.Rule{{
+		Host:      "api.example.com",
+		SecretRef: "op://V/I/f",
+		Injects: []config.Inject{
+			{Type: config.InjectTypePlaceholder, Name: "__tok__", Template: "{{ CREDENTIAL }}"},
+		},
+	}})
+	if err == nil {
+		t.Fatalf("FromConfigRules with a non-header injects entry: want error, got nil")
+	}
+}
+
 func TestFromConfigRules_RejectsUnknownSurface(t *testing.T) {
 	t.Parallel()
 

--- a/internal/broker/hook_test.go
+++ b/internal/broker/hook_test.go
@@ -241,6 +241,71 @@ func TestHook_NilLoggerDefaultsToNoop(t *testing.T) {
 	}
 }
 
+// A multi-header rule injects every declared header from ONE resolve: the
+// rule's secret_ref is read exactly once per request no matter how many headers
+// it feeds, which is what keeps a two-header host off the vendor's read quota
+// twice over.
+func TestHook_MultiHeaderInjectsBothFromOneResolve(t *testing.T) {
+	t.Parallel()
+
+	res := &fakeResolver{value: "sk-secret"}
+	hook := newHookFixture(t, broker.Rule{
+		Host:      "api.example.com",
+		SecretRef: "op://Agents/example/api_key",
+		Injections: []broker.InjectSpec{
+			{Type: broker.InjectHeader, Name: "authorization", Template: "Bearer {{ CREDENTIAL }}"},
+			{Type: broker.InjectHeader, Name: "x-api-key", Template: "{{ CREDENTIAL }}"},
+		},
+	}, res)
+
+	req, _ := http.NewRequest(http.MethodPost, "https://api.example.com/v1/messages", http.NoBody)
+	resp := hook(req) //nolint:bodyclose // closeIfNonNil below handles the non-nil branch
+
+	defer closeIfNonNil(t, resp)
+	if resp != nil {
+		t.Fatalf("hook returned response on match: %+v, want nil (forward to upstream)", resp)
+	}
+	if got := req.Header.Get("authorization"); got != "Bearer sk-secret" {
+		t.Fatalf("authorization = %q, want %q", got, "Bearer sk-secret")
+	}
+	if got := req.Header.Get("x-api-key"); got != "sk-secret" {
+		t.Fatalf("x-api-key = %q, want %q", got, "sk-secret")
+	}
+	if got := res.calls.Load(); got != 1 {
+		t.Fatalf("resolver.calls = %d, want 1 (one secret_ref, one read per request)", got)
+	}
+}
+
+// A multi-header rule fails closed as a unit: one unusable entry means no
+// header is injected and the request never reaches the upstream.
+func TestHook_MultiHeaderBadEntryFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	res := &fakeResolver{value: "sk-secret"}
+	hook := newHookFixture(t, broker.Rule{
+		Host:      "api.example.com",
+		SecretRef: "op://Agents/example/api_key",
+		Injections: []broker.InjectSpec{
+			{Type: broker.InjectHeader, Name: "authorization", Template: "Bearer {{ CREDENTIAL }}"},
+			{Type: broker.InjectHeader, Name: "x-api-key", Template: "no placeholder"},
+		},
+	}, res)
+
+	req, _ := http.NewRequest(http.MethodPost, "https://api.example.com/v1/messages", http.NoBody)
+	resp := hook(req) //nolint:bodyclose // closeIfNonNil below handles the non-nil branch
+
+	defer closeIfNonNil(t, resp)
+	if resp == nil {
+		t.Fatalf("unusable injects entry: want non-nil 502, got nil (would forward half-injected)")
+	}
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", resp.StatusCode)
+	}
+	if _, ok := req.Header["Authorization"]; ok {
+		t.Fatalf("authorization set on a fail-closed inject; request must not carry partial credential state")
+	}
+}
+
 // A placeholder rule that matches the host but whose placeholder token is
 // absent from the request must fail closed (502), not forward the request to
 // the authenticated upstream with no credential attached.

--- a/internal/broker/inject.go
+++ b/internal/broker/inject.go
@@ -142,17 +142,24 @@ func hasCRLF(s string) bool {
 }
 
 // Inject applies the rule's injection spec to req using credential as the
-// secret value. Header mode sets a single header. Placeholder mode rewrites
-// the token across every declared surface (header, body, path, query) with
-// per-surface encoding, and returns ErrNoPlaceholder when the token is absent
-// from every eligible surface so the proxy fails closed instead of forwarding
-// the request unauthenticated. An unknown InjectType is treated as a
-// configuration error: Inject returns an error so the proxy can fail closed.
+// secret value. Header mode sets a single header; a rule carrying Injections
+// sets each of those headers instead, all from the same credential.
+// Placeholder mode rewrites the token across every declared surface (header,
+// body, path, query) with per-surface encoding, and returns ErrNoPlaceholder
+// when the token is absent from every eligible surface so the proxy fails
+// closed instead of forwarding the request unauthenticated. An unknown
+// InjectType is treated as a configuration error: Inject returns an error so
+// the proxy can fail closed.
 //
 // In placeholder mode body substitution reads req.Body; callers that declare
 // the body surface (Hook) must materialize req.Body into an in-memory,
 // size-bounded reader before calling Inject.
 func (r Rule) Inject(req *http.Request, credential string) error {
+	// A multi-header rule carries its entries in Injections and leaves
+	// Injection zero, so it branches before the single-injection guards.
+	if len(r.Injections) > 0 {
+		return r.injectHeaders(req, credential)
+	}
 	// Guard before mutating anything: a template with no placeholder would
 	// render to a constant and forward the request without the credential.
 	// Reject it so both inject modes fail closed rather than fail open.
@@ -172,6 +179,36 @@ func (r Rule) Inject(req *http.Request, credential string) error {
 	default:
 		return fmt.Errorf("broker: unsupported inject type %d", r.Injection.Type)
 	}
+}
+
+// injectHeaders applies every entry of a multi-header rule, in list order, from
+// the single credential the caller already resolved — a rule reads its
+// secret_ref once per request no matter how many headers it feeds. Every entry
+// carries the same fail-closed guards as single-header mode, and all of them run
+// before the first header is set, so a rejected entry leaves the request
+// untouched instead of forwarding it half-injected.
+func (r Rule) injectHeaders(req *http.Request, credential string) error {
+	values := make([]string, len(r.Injections))
+	for i := range r.Injections {
+		in := &r.Injections[i]
+		if in.Type != InjectHeader {
+			return fmt.Errorf("broker: injections[%d]: unsupported inject type %d (header mode only)", i, in.Type)
+		}
+		if in.Name == "" {
+			return fmt.Errorf("broker: injections[%d]: empty header name", i)
+		}
+		if !hasCredentialPlaceholder(in.Template) {
+			return ErrNoCredentialPlaceholder
+		}
+		values[i] = Render(in.Template, credential)
+		if hasCRLF(values[i]) {
+			return ErrHeaderInjection
+		}
+	}
+	for i := range r.Injections {
+		req.Header.Set(r.Injections[i].Name, values[i])
+	}
+	return nil
 }
 
 // injectPlaceholder rewrites the placeholder token across the rule's declared

--- a/internal/broker/inject_test.go
+++ b/internal/broker/inject_test.go
@@ -179,6 +179,141 @@ func TestInjectPlaceholder_EmptyTokenFailsClosed(t *testing.T) {
 	}
 }
 
+// A multi-header rule feeds every declared header from the one credential the
+// caller resolved. Both headers must carry the rendered template, and Set must
+// override whatever the agent supplied.
+func TestInject_MultiHeader_SetsEveryHeader(t *testing.T) {
+	t.Parallel()
+
+	r := broker.Rule{
+		Host: "api.example.com",
+		Injections: []broker.InjectSpec{
+			{Type: broker.InjectHeader, Name: "authorization", Template: "Bearer {{ CREDENTIAL }}"},
+			{Type: broker.InjectHeader, Name: "x-api-key", Template: "{{ CREDENTIAL }}"},
+		},
+	}
+	req, _ := http.NewRequest(http.MethodPost, "https://api.example.com/v1/messages", http.NoBody)
+	req.Header.Set("authorization", "Bearer placeholder")
+
+	if err := r.Inject(req, "sk-real"); err != nil {
+		t.Fatalf("Inject: %v", err)
+	}
+
+	got := map[string]string{
+		"authorization": req.Header.Get("authorization"),
+		"x-api-key":     req.Header.Get("x-api-key"),
+	}
+	want := map[string]string{
+		"authorization": "Bearer sk-real",
+		"x-api-key":     "sk-real",
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("headers diff (-want +got):\n%s", diff)
+	}
+}
+
+// Entries are applied in list order, so a repeated header name resolves to the
+// last entry. The config validator rejects such a rule; this pins the runtime
+// behavior for anything that reaches Inject without that check.
+func TestInject_MultiHeader_PreservesListOrder(t *testing.T) {
+	t.Parallel()
+
+	r := broker.Rule{
+		Host: "api.example.com",
+		Injections: []broker.InjectSpec{
+			{Type: broker.InjectHeader, Name: "authorization", Template: "first {{ CREDENTIAL }}"},
+			{Type: broker.InjectHeader, Name: "authorization", Template: "last {{ CREDENTIAL }}"},
+		},
+	}
+	req, _ := http.NewRequest(http.MethodGet, "https://api.example.com/", http.NoBody)
+
+	if err := r.Inject(req, "sk-real"); err != nil {
+		t.Fatalf("Inject: %v", err)
+	}
+	if got := req.Header.Get("authorization"); got != "last sk-real" {
+		t.Fatalf("authorization = %q, want %q (later entry wins)", got, "last sk-real")
+	}
+}
+
+// Every fail-closed guard applies per entry, and nothing is written until all
+// entries pass: a bad second entry must leave the first header unset rather
+// than forward a half-injected request.
+func TestInject_MultiHeader_PerEntryGuardsFailClosed(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		second  broker.InjectSpec
+		wantErr error
+	}{
+		{
+			name:    "CRLF in the rendered value",
+			second:  broker.InjectSpec{Type: broker.InjectHeader, Name: "x-api-key", Template: "{{ CREDENTIAL }}\r\nx-evil: 1"},
+			wantErr: broker.ErrHeaderInjection,
+		},
+		{
+			name:    "template without the CREDENTIAL placeholder",
+			second:  broker.InjectSpec{Type: broker.InjectHeader, Name: "x-api-key", Template: "static"},
+			wantErr: broker.ErrNoCredentialPlaceholder,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := broker.Rule{
+				Host: "api.example.com",
+				Injections: []broker.InjectSpec{
+					{Type: broker.InjectHeader, Name: "authorization", Template: "Bearer {{ CREDENTIAL }}"},
+					tc.second,
+				},
+			}
+			req, _ := http.NewRequest(http.MethodGet, "https://api.example.com/", http.NoBody)
+
+			err := r.Inject(req, "sk-real")
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("Inject: got %v, want %v", err, tc.wantErr)
+			}
+			if _, ok := req.Header["Authorization"]; ok {
+				t.Fatalf("authorization set despite a failing entry; a fail-closed inject must not partially mutate the request")
+			}
+			if _, ok := req.Header["X-Api-Key"]; ok {
+				t.Fatalf("x-api-key set from a failing entry")
+			}
+		})
+	}
+}
+
+// Non-header entries and empty header names never reach a validated config;
+// Inject rejects them anyway rather than write a credential somewhere the
+// caller did not intend.
+func TestInject_MultiHeader_RejectsUnusableEntry(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		entry broker.InjectSpec
+	}{
+		{"non-header type", broker.InjectSpec{Type: broker.InjectPlaceholder, Name: "__tok__", Template: "{{ CREDENTIAL }}"}},
+		{"empty header name", broker.InjectSpec{Type: broker.InjectHeader, Name: "", Template: "{{ CREDENTIAL }}"}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := broker.Rule{Host: "api.example.com", Injections: []broker.InjectSpec{tc.entry}}
+			req, _ := http.NewRequest(http.MethodGet, "https://api.example.com/", http.NoBody)
+
+			if err := r.Inject(req, "sk-real"); err == nil {
+				t.Fatalf("Inject with %s: want error, got nil", tc.name)
+			}
+			if len(req.Header) != 0 {
+				t.Fatalf("headers mutated to %v; nothing must be injected when failing closed", req.Header)
+			}
+		})
+	}
+}
+
 func TestInject_UnknownTypeReturnsError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/broker/integration_test.go
+++ b/internal/broker/integration_test.go
@@ -78,6 +78,60 @@ func TestE2E_BrokerInjectsHeaderThroughMITMProxy(t *testing.T) {
 	require.Equal(t, int64(1), res.calls.Load())
 }
 
+// TestE2E_BrokerInjectsMultipleHeadersThroughMITMProxy is the multi-header
+// counterpart: one rule, one secret_ref, two headers. The upstream asserts both
+// arrive with the resolver-supplied value, and the resolver counter proves the
+// secret was read exactly once for the request — the whole point of feeding both
+// headers from one rule instead of two.
+func TestE2E_BrokerInjectsMultipleHeadersThroughMITMProxy(t *testing.T) {
+	t.Parallel()
+
+	var upstreamHits atomic.Int64
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		upstreamHits.Add(1)
+		if got := req.Header.Get("authorization"); got != "Bearer sk-from-resolver" {
+			t.Errorf("upstream saw authorization=%q, want %q", got, "Bearer sk-from-resolver")
+		}
+		if got := req.Header.Get("x-api-key"); got != "sk-from-resolver" {
+			t.Errorf("upstream saw x-api-key=%q, want %q", got, "sk-from-resolver")
+		}
+		_, _ = io.WriteString(w, "ok")
+	}))
+	t.Cleanup(upstream.Close)
+
+	root := fixtureCA(t)
+	minter := fixtureMinter(t, root)
+
+	engine := broker.NewEngine([]broker.Rule{{
+		Host:      "127.0.0.1",
+		SecretRef: "op://Agents/example/api_key",
+		Injections: []broker.InjectSpec{
+			{Type: broker.InjectHeader, Name: "authorization", Template: "Bearer {{ CREDENTIAL }}"},
+			{Type: broker.InjectHeader, Name: "x-api-key", Template: "{{ CREDENTIAL }}"},
+		},
+	}})
+	res := &fakeResolver{value: "sk-from-resolver"}
+	hook := broker.Hook(engine, res, config.OnNoMatchPassthrough, 0, slog.New(slog.NewTextHandler(io.Discard, nil))) //nolint:bodyclose // synthetic body; goproxy closes it after writing to the client
+
+	p, err := proxy.New(proxy.Config{
+		CA:                 root,
+		Minter:             minter,
+		Logger:             slog.New(slog.NewTextHandler(io.Discard, nil)),
+		UpstreamTLS:        upstreamTLS(t, upstream),
+		PreUpstreamHandler: hook,
+	})
+	require.NoError(t, err)
+
+	client := clientThroughProxy(t, startProxy(t, p), root)
+	resp, err := client.Get(upstream.URL)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, int64(1), upstreamHits.Load())
+	require.Equal(t, int64(1), res.calls.Load(), "one secret_ref must be resolved once, however many headers it feeds")
+}
+
 // TestE2E_ResolverErrorReturns502_UpstreamNotContacted verifies the
 // fail-closed invariant: on resolver error the proxy returns 502 *and*
 // the upstream counter stays at zero. A regression

--- a/internal/broker/rule.go
+++ b/internal/broker/rule.go
@@ -30,6 +30,11 @@ type Rule struct {
 	// outbound request. See InjectSpec and Rule.Inject.
 	Injection InjectSpec
 
+	// Injections, when non-empty, makes this a multi-header rule: every entry
+	// is a header injection applied with the same credential, resolved once
+	// from SecretRef. It replaces Injection, which is then the zero value.
+	Injections []InjectSpec
+
 	// Routes, when non-empty, makes this a placeholder-routing rule: the token
 	// an agent presents on a declared surface selects (and is replaced by) the
 	// route's secret. See SelectRoute and InjectRoute.

--- a/internal/config/injects_test.go
+++ b/internal/config/injects_test.go
@@ -1,0 +1,184 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mmartinez/postern/internal/config"
+)
+
+// baseInjectsConfig is a valid multi-header config: one host, one secret_ref,
+// two header injections fed by that single secret. It mirrors an upstream that
+// authenticates the same key through two different headers depending on which
+// endpoint the agent calls. Cases below mutate it.
+const baseInjectsConfig = `
+token:
+  source: auto
+  env_var: OP_SERVICE_ACCOUNT_TOKEN
+  keychain_account: default
+proxy:
+  listen: 127.0.0.1:1701
+  cache_ttl: 5m
+  on_no_match: passthrough
+rules:
+  - host: api.example.com
+    secret_ref: op://Agents/example/api_key
+    injects:
+      - type: header
+        name: authorization
+        template: "Bearer {{ CREDENTIAL }}"
+      - type: header
+        name: x-api-key
+        template: "{{ CREDENTIAL }}"
+`
+
+func TestValidateInjects(t *testing.T) {
+	t.Parallel()
+
+	cases := []validateCase{
+		{
+			name: "valid injects",
+			yaml: baseInjectsConfig,
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				require.Empty(t, lints, "a valid injects block should produce no lints")
+			},
+		},
+		{
+			name: "injects and inject are mutually exclusive",
+			yaml: strings.Replace(baseInjectsConfig,
+				"    injects:\n",
+				"    inject:\n      type: header\n      name: x-api-key\n      template: \"{{ CREDENTIAL }}\"\n    injects:\n",
+				1),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "mutually exclusive")
+			},
+		},
+		{
+			name: "injects and routes are mutually exclusive",
+			yaml: baseInjectsConfig + `    routes:
+      - name: max
+        token: tg_max_8Kq2Lp9wZ
+        secret_ref: op://Agents/example-max/token
+`,
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "mutually exclusive")
+			},
+		},
+		{
+			name: "injects and a preset template are mutually exclusive",
+			yaml: strings.Replace(baseInjectsConfig,
+				"  - host: api.example.com\n",
+				"  - template: anthropic\n    host: api.example.com\n",
+				1),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "template")
+			},
+		},
+		{
+			name: "injects requires a rule-level secret_ref",
+			yaml: strings.Replace(baseInjectsConfig,
+				"    secret_ref: op://Agents/example/api_key\n", "", 1),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "secret_ref is required")
+			},
+		},
+		{
+			name: "injects rejects a malformed secret_ref",
+			yaml: strings.Replace(baseInjectsConfig,
+				"op://Agents/example/api_key", "not-a-secret-ref", 1),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "secret_ref")
+			},
+		},
+		{
+			name: "injects entry must be type header",
+			yaml: strings.Replace(baseInjectsConfig,
+				"      - type: header\n        name: x-api-key\n",
+				"      - type: placeholder\n        name: __tok__\n",
+				1),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "type: header")
+			},
+		},
+		{
+			name: "injects entry with an empty name",
+			yaml: strings.Replace(baseInjectsConfig,
+				"        name: x-api-key\n", "        name: \"\"\n", 1),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "name is required")
+			},
+		},
+		{
+			name: "injects entry with an empty template",
+			yaml: strings.Replace(baseInjectsConfig,
+				"        template: \"{{ CREDENTIAL }}\"\n", "        template: \"\"\n", 1),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "template is required")
+			},
+		},
+		{
+			name: "injects entry template without the CREDENTIAL placeholder",
+			yaml: strings.Replace(baseInjectsConfig,
+				"        template: \"{{ CREDENTIAL }}\"\n", "        template: \"static\"\n", 1),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "{{ CREDENTIAL }}")
+			},
+		},
+		{
+			name: "duplicate header names, differing only in case",
+			yaml: strings.Replace(baseInjectsConfig,
+				"        name: x-api-key\n", "        name: Authorization\n", 1),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "duplicate header name")
+			},
+		},
+		{
+			name: "injects entry carrying a placeholder-only field",
+			yaml: strings.Replace(baseInjectsConfig,
+				"        template: \"{{ CREDENTIAL }}\"\n",
+				"        template: \"{{ CREDENTIAL }}\"\n        in: [body]\n", 1),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "only type, name, and template")
+			},
+		},
+		{
+			name: "empty injects list",
+			yaml: strings.Replace(baseInjectsConfig,
+				`    injects:
+      - type: header
+        name: authorization
+        template: "Bearer {{ CREDENTIAL }}"
+      - type: header
+        name: x-api-key
+        template: "{{ CREDENTIAL }}"
+`,
+				"    injects: []\n", 1),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "at least one entry")
+			},
+		},
+		{
+			name: "unknown field inside an injects entry",
+			yaml: strings.Replace(baseInjectsConfig,
+				"        name: x-api-key\n", "        nope: x-api-key\n", 1),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, lints, err := config.LoadAndValidate(strings.NewReader(tc.yaml))
+			if tc.wantErr {
+				require.Error(t, err, "expected a parse-level error")
+				return
+			}
+			require.NoError(t, err, "unexpected parse-level error")
+			if tc.wantLints != nil {
+				tc.wantLints(t, lints)
+			}
+		})
+	}
+}

--- a/internal/config/injects_test.go
+++ b/internal/config/injects_test.go
@@ -127,6 +127,24 @@ func TestValidateInjects(t *testing.T) {
 			},
 		},
 		{
+			name: "injects entry with an invalid header name",
+			yaml: strings.Replace(baseInjectsConfig,
+				"        name: x-api-key\n", "        name: \"x api key\"\n", 1),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "valid HTTP header name")
+			},
+		},
+		{
+			// Underscores are legal token characters, so a header name carrying
+			// one must not trip the charset check.
+			name: "injects entry with an underscore in the header name",
+			yaml: strings.Replace(baseInjectsConfig,
+				"        name: x-api-key\n", "        name: x_api_key\n", 1),
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				require.Empty(t, lints, "an underscore is a valid HTTP header name character")
+			},
+		},
+		{
 			name: "duplicate header names, differing only in case",
 			yaml: strings.Replace(baseInjectsConfig,
 				"        name: x-api-key\n", "        name: Authorization\n", 1),

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -261,6 +261,14 @@ type Rule struct {
 	SecretRef string `yaml:"secret_ref"`
 	Inject    Inject `yaml:"inject,omitempty"`
 
+	// Injects turns a single host rule into a multi-header rule: every entry is
+	// a header injection fed by the rule's one SecretRef, which is still
+	// resolved exactly once per request. It replaces the single Inject block
+	// outright and is mutually exclusive with Inject, Routes, and Template.
+	// Serves upstreams that authenticate the same credential through two
+	// different headers depending on the endpoint the agent calls.
+	Injects []Inject `yaml:"injects,omitempty"`
+
 	// Routes turns a single host rule into a placeholder-routing rule: each
 	// entry's token both selects, and is replaced by, its own secret. Mutually
 	// exclusive with the rule-level SecretRef and inject.name, and valid only
@@ -304,4 +312,13 @@ type Inject struct {
 	ConsumerSecretRef string `yaml:"consumer_secret_ref,omitempty"`
 	TokenRef          string `yaml:"token_ref,omitempty"`
 	TokenSecretRef    string `yaml:"token_secret_ref,omitempty"`
+}
+
+// IsZero reports whether the inject block is absent (the YAML zero value). The
+// validator uses it to enforce that a rule declares either a single `inject:`
+// or an `injects:` list, never both.
+func (i Inject) IsZero() bool {
+	return i.Type == "" && i.Name == "" && i.Template == "" && len(i.In) == 0 &&
+		i.MaxBodyBytes == nil && i.ConsumerKeyRef == "" && i.ConsumerSecretRef == "" &&
+		i.TokenRef == "" && i.TokenSecretRef == ""
 }

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -55,6 +55,13 @@ var secretRefPattern = regexp.MustCompile(`^[a-z][a-z0-9+.\-]*://.+$`)
 // for stable substitution outside header values.
 var unreservedTokenPattern = regexp.MustCompile(`^[A-Za-z0-9._~-]+$`)
 
+// headerNamePattern matches the RFC 9110 token grammar every HTTP field name
+// must obey. net/http rejects anything else when it writes the request, so a
+// header rule naming (say) "x api key" could never reach the upstream — catch
+// it as a line-numbered lint at validate time rather than as an opaque
+// transport error on the first matching request.
+var headerNamePattern = regexp.MustCompile("^[!#$%&'*+.^_`|~0-9A-Za-z-]+$")
+
 // Validate walks cfg and returns the slice of findings. Root is the AST from
 // Load and supplies line numbers; pass nil to skip location info.
 func Validate(cfg *Config, root *yaml.Node) []LintError {
@@ -305,6 +312,8 @@ func (v *validator) checkInjects(base string, r Rule) {
 		}
 		if in.Name == "" {
 			v.add(eb+".name", "name is required", SeverityError)
+		} else if !headerNamePattern.MatchString(in.Name) {
+			v.add(eb+".name", fmt.Sprintf("name %q is not a valid HTTP header name (RFC 9110 token characters)", in.Name), SeverityError)
 		} else if prev, dup := seenName[strings.ToLower(in.Name)]; dup {
 			// Header names are case-insensitive on the wire and injection is a
 			// Set, so a case-variant duplicate would silently overwrite the
@@ -521,6 +530,8 @@ func (v *validator) checkInject(base string, in Inject) {
 	case InjectTypeHeader:
 		if in.Name == "" {
 			v.add(base+".name", "name is required when inject.type=header", SeverityError)
+		} else if !headerNamePattern.MatchString(in.Name) {
+			v.add(base+".name", fmt.Sprintf("name %q is not a valid HTTP header name (RFC 9110 token characters)", in.Name), SeverityError)
 		}
 	case InjectTypePlaceholder:
 		if in.Name == "" {

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -237,6 +237,11 @@ func (v *validator) checkRule(base string, r Rule) {
 		v.add(base+".host", fmt.Sprintf("host %q must be a literal hostname or a single-* glob (e.g. *.example.com)", r.Host), SeverityError)
 	}
 
+	if r.Injects != nil {
+		v.checkInjects(base, r)
+		return
+	}
+
 	if len(r.Routes) > 0 {
 		v.checkRoutes(base, r)
 		return
@@ -254,6 +259,62 @@ func (v *validator) checkRule(base string, r Rule) {
 	}
 
 	v.checkInject(base+".inject", r.Inject)
+}
+
+// checkInjects validates a multi-header rule. Every entry is a header injection
+// fed by the rule's single secret_ref (resolved once per request), so entries
+// carry only type/name/template while the rule keeps the usual secret_ref
+// requirement. `injects` replaces the single `inject` block outright, so
+// combining it with `inject`, `routes`, or a preset `template` — each of which
+// would supply a second, conflicting injection — is rejected rather than
+// silently resolved in favor of one of them.
+func (v *validator) checkInjects(base string, r Rule) {
+	if len(r.Injects) == 0 {
+		v.add(base+".injects", "injects must declare at least one entry", SeverityError)
+		return
+	}
+	switch {
+	case r.Template != "":
+		// Template expansion has already poured the preset's header name and
+		// template into the (otherwise empty) inject block, so report the
+		// preset rather than the inject block it filled.
+		v.add(base+".injects", "injects and template are mutually exclusive; a template preset fills the single inject block", SeverityError)
+	case !r.Inject.IsZero():
+		v.add(base+".injects", "injects and inject are mutually exclusive; declare every header under injects", SeverityError)
+	}
+	if len(r.Routes) > 0 {
+		v.add(base+".injects", "injects and routes are mutually exclusive; routes requires inject.type=placeholder", SeverityError)
+	}
+
+	if r.SecretRef == "" {
+		v.add(base+".secret_ref", "secret_ref is required", SeverityError)
+	} else if !secretRefPattern.MatchString(r.SecretRef) {
+		v.add(base+".secret_ref", fmt.Sprintf("secret_ref %q must be a URI of the form <scheme>://<rest> (e.g., op://VAULT/ITEM/FIELD)", r.SecretRef), SeverityError)
+	}
+
+	seenName := make(map[string]int, len(r.Injects))
+	for i := range r.Injects {
+		in := &r.Injects[i]
+		eb := fmt.Sprintf("%s.injects[%d]", base, i)
+		if in.Type != InjectTypeHeader {
+			v.add(eb+".type", fmt.Sprintf("injects entries must be type: header (got %q); placeholder and oauth1 rules carry a single inject block", in.Type), SeverityError)
+		}
+		if len(in.In) > 0 || in.MaxBodyBytes != nil || in.ConsumerKeyRef != "" ||
+			in.ConsumerSecretRef != "" || in.TokenRef != "" || in.TokenSecretRef != "" {
+			v.add(eb, "only type, name, and template are valid in an injects entry", SeverityError)
+		}
+		if in.Name == "" {
+			v.add(eb+".name", "name is required", SeverityError)
+		} else if prev, dup := seenName[strings.ToLower(in.Name)]; dup {
+			// Header names are case-insensitive on the wire and injection is a
+			// Set, so a case-variant duplicate would silently overwrite the
+			// earlier entry instead of adding a header.
+			v.add(eb+".name", fmt.Sprintf("duplicate header name %q (first declared at %s.injects[%d]); header names are case-insensitive", in.Name, base, prev), SeverityError)
+		} else {
+			seenName[strings.ToLower(in.Name)] = i
+		}
+		v.checkCredentialTemplate(eb+".template", in.Template)
+	}
 }
 
 // checkOAuth1Rule validates an OAuth 1.0a signing rule. The request is signed,
@@ -305,11 +366,7 @@ func (v *validator) checkRoutes(base string, r Rule) {
 	if in.Name != "" {
 		v.add(base+".inject.name", "inject.name must be empty when routes is set; each route's token is the placeholder", SeverityError)
 	}
-	if in.Template == "" {
-		v.add(base+".inject.template", "template is required", SeverityError)
-	} else if !strings.Contains(in.Template, "{{ CREDENTIAL }}") && !strings.Contains(in.Template, "{{CREDENTIAL}}") {
-		v.add(base+".inject.template", "template must contain a {{ CREDENTIAL }} placeholder; without it the resolved credential is discarded and the request is forwarded unauthenticated", SeverityError)
-	}
+	v.checkCredentialTemplate(base+".inject.template", in.Template)
 
 	v.checkInjectSurfaces(base+".inject", in)
 	v.checkRouteEntries(base, r.Routes, surfacesHaveNonHeader(in.In))
@@ -480,17 +537,25 @@ func (v *validator) checkInject(base string, in Inject) {
 	if in.ConsumerKeyRef != "" || in.ConsumerSecretRef != "" || in.TokenRef != "" || in.TokenSecretRef != "" {
 		v.add(base, "the oauth1 *_ref fields (consumer_key_ref, consumer_secret_ref, token_ref, token_secret_ref) are valid only with inject.type=oauth1", SeverityError)
 	}
-	if in.Template == "" {
-		v.add(base+".template", "template is required", SeverityError)
-	} else if !strings.Contains(in.Template, "{{ CREDENTIAL }}") && !strings.Contains(in.Template, "{{CREDENTIAL}}") {
-		// Fatal, not a warning: a template with no placeholder discards the
-		// resolved credential, so the request would be forwarded to the upstream
-		// unauthenticated — a silent fail-open. Reject it at validate time so the
-		// proxy never boots (or hot-reloads) into that state.
-		v.add(base+".template", "template must contain a {{ CREDENTIAL }} placeholder; without it the resolved credential is discarded and the request is forwarded unauthenticated", SeverityError)
-	}
+	v.checkCredentialTemplate(base+".template", in.Template)
 
 	v.checkInjectSurfaces(base, in)
+}
+
+// checkCredentialTemplate requires a credential template that actually carries
+// the {{ CREDENTIAL }} placeholder. A missing placeholder is fatal, not a
+// warning: the template would render to a constant, discarding the resolved
+// credential and forwarding the request to the upstream unauthenticated — a
+// silent fail-open. Rejecting it at validate time keeps the proxy from booting
+// (or hot-reloading) into that state.
+func (v *validator) checkCredentialTemplate(path, tmpl string) {
+	if tmpl == "" {
+		v.add(path, "template is required", SeverityError)
+		return
+	}
+	if !strings.Contains(tmpl, "{{ CREDENTIAL }}") && !strings.Contains(tmpl, "{{CREDENTIAL}}") {
+		v.add(path, "template must contain a {{ CREDENTIAL }} placeholder; without it the resolved credential is discarded and the request is forwarded unauthenticated", SeverityError)
+	}
 }
 
 // checkInjectSurfaces validates the per-rule substitution surface list and its

--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -204,6 +204,28 @@ rules:
 			},
 		},
 		{
+			// net/http refuses to write a field name outside the RFC 9110 token
+			// grammar, so such a rule could never reach the upstream. Catch it as
+			// a lint instead of an opaque transport error at request time.
+			name: "header inject with an invalid header name",
+			yaml: `
+proxy:
+  listen: 127.0.0.1:1701
+  cache_ttl: 5m
+  on_no_match: passthrough
+rules:
+  - host: api.example.com
+    secret_ref: op://Vault/Item/field
+    inject:
+      type: header
+      name: "x api key"
+      template: "{{ CREDENTIAL }}"
+`,
+			wantLints: func(t *testing.T, lints []config.LintError) {
+				requireLintContains(t, lints, "valid HTTP header name")
+			},
+		},
+		{
 			name: "placeholder inject missing name is fatal",
 			yaml: `
 proxy:


### PR DESCRIPTION
## What

Lets a single rule inject the resolved credential into **multiple headers**, all fed by the rule's one `secret_ref`.

```yaml
rules:
  - host: opencode.ai
    secret_ref: op://Agents/opencode/api_key
    injects:
      - type: header
        name: authorization
        template: "Bearer {{ CREDENTIAL }}"
      - type: header
        name: x-api-key
        template: "{{ CREDENTIAL }}"
```

## Why

postern matches one rule per host (`broker.Engine.Match` returns the first match) and each rule injects exactly one header (`Rule.Inject` does a single `Header.Set`). That blocks any upstream that authenticates the *same* credential through *different* headers on the same host.

The motivating case is OpenCode Zen on `opencode.ai`: its OpenAI-shaped endpoint (`/zen/go/v1`) wants `Authorization: Bearer <key>`, its Anthropic-shaped endpoint (`/zen/go`) wants `x-api-key: <key>`. With one header per rule, requests to the other endpoint went out unauthenticated and 401'd.

## Config surface

`injects:` is an optional rule-level list, mutually exclusive with `inject:`, `routes:`, and a preset `template:`. Every entry is a header-mode injection sharing the rule's `secret_ref`.

Validation (line-numbered, like the rest of the schema):

- mutually exclusive with `inject`, `routes`, `template`; at least one entry
- rule-level `secret_ref` required and shape-checked
- every entry must be `type: header` — `placeholder`/`oauth1` still use the single `inject` block
- every entry needs a non-empty `name` and a `template` containing `{{ CREDENTIAL }}` (spaced or unspaced)
- no duplicate header names within a rule, compared case-insensitively (injection is a `Set` on a case-insensitive name, so a case variant would silently overwrite rather than add)
- placeholder-only fields (`in`, `max_body_bytes`) and the oauth1 `*_ref` fields are rejected inside an entry rather than silently ignored
- a `name` outside the RFC 9110 token grammar is rejected. net/http refuses to write such a field name, so the rule could never reach the upstream; it is now a lint instead of an opaque transport error on the first matching request. The same check now covers the single `inject.name` in header mode, which had the identical gap.

## Guarantees

**Backward compatible.** The single-`Injection` path is untouched; existing `inject:` and `routes:` rules take the same code path they did before. Full existing suite stays green.

**One resolve per request.** `hook.go` is unchanged: the rule's `secret_ref` is resolved once and the shared credential is handed to `Inject`, so a two-header host costs the same vault read quota as a one-header host. The E2E and hook tests assert `resolver.calls == 1`.

**Fails closed per entry, as a unit.** Each entry keeps the existing guards (`ErrNoCredentialPlaceholder` for a template without `{{ CREDENTIAL }}`, `ErrHeaderInjection` for CR/LF in the rendered value), plus rejection of a non-header type or an empty header name. All entries are validated and rendered *before* the first header is set, so one bad entry means a 502 with no header injected at all — never a half-authenticated request reaching the upstream.

**No behavior change elsewhere.** Host matching stays first-match, no path/prefix matching, no per-entry `secret_ref`. Hot-reload picks the new form up for free (`reloader.go` already routes through `FromConfigRules`).

## Tests

- `internal/config/injects_test.go` — 16 cases: accepted form, each exclusivity conflict, non-header entry, empty name/template, missing placeholder, duplicate names, invalid and valid-with-underscore header names, empty list, unknown field under strict mode.
- `internal/broker/inject_test.go` — both headers set from one credential, `Set` overrides an agent-supplied value, list order, per-entry CRLF and missing-placeholder fail-closed with no partial mutation, unusable-entry rejection.
- `internal/broker/from_config_test.go` — `config.Rule.Injects` → `broker.Rule.Injections`.
- `internal/broker/hook_test.go` — both headers injected from a single resolve; a bad entry 502s with nothing injected.
- `internal/broker/integration_test.go` — E2E through real goproxy + real local CA where the upstream asserts both headers arrive and the resolver counter stays at 1.

Coverage: broker 90.8%, config 91.7%. `golangci-lint run ./...` → 0 issues.

## Follow-up, not in this PR

`postern rules list` prints blank INJECT/NAME/TEMPLATE columns for an `injects` rule — the same shallowness `routes` rules already have. Worth a separate pass over the listing.
