### PR TITLE
build(deps): bump Go to 1.26.6 for stdlib advisories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: "1.26.5"
+  GO_VERSION: "1.26.6"
   GOLANGCI_VERSION: "v2.12.2"
   GITLEAKS_VERSION: "8.21.4"
   GOFUMPT_VERSION: "v0.7.0"
@@ -76,7 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.26.5"]
+        go: ["1.26.6"]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ permissions:
   id-token: write # goreleaser: keyless cosign signing via GitHub OIDC
 
 env:
-  GO_VERSION: "1.26.5"
+  GO_VERSION: "1.26.6"
   # Kept in lockstep with .github/workflows/ci.yml and .mise.toml.
   GORELEASER_VERSION: "v2.16.0"
   ZIG_VERSION: "0.14.0"

--- a/.mise.toml
+++ b/.mise.toml
@@ -2,7 +2,7 @@
 # Bump versions deliberately; lockstep with .github/workflows/ci.yml matrix.
 
 [tools]
-go             = "1.26.5"
+go             = "1.26.6"
 golangci-lint  = "2.12"
 gofumpt        = "0.7"
 lefthook       = "1.10"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mmartinez/postern
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/1password/onepassword-sdk-go v0.4.1


### PR DESCRIPTION
`govulncheck` fails on Go 1.26.5 with five reachable standard-library advisories, all fixed in 1.26.6. This is what turns the `vuln` check red on the open release PR (#67).

| Advisory | Package | Reached from |
|---|---|---|
| GO-2026-6218 | `net/url` | |
| GO-2026-6090 | `crypto/tls` | |
| GO-2026-6089 | `net/http` | |
| GO-2026-5972 | `encoding/asn1` | `internal/ca/gen.go:169` — `ca.Load` → `x509.ParseECPrivateKey` |
| GO-2026-5026 | `net/http` (idna) | `internal/runtime/runtime.go:144`, `internal/credstore/oauth2/resolver.go:140` |

## Change

Bumps the pin in lockstep across all four places that carry it:

- `.mise.toml`
- `go.mod`
- `.github/workflows/ci.yml` (`GO_VERSION` and the typecheck matrix)
- `.github/workflows/release.yml` (`GO_VERSION`)

No dependency changes, so `THIRD_PARTY_NOTICES.md` is untouched.

## Verification

- `govulncheck ./...` → `No vulnerabilities found.`
- `go build ./...` and `go test -race ./...` green on 1.26.6 (15 packages)