### PR TITLE
fix(proxy): bound outbound transport, tunnel dials, inbound idle conns; sanitize connection errors

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -12,7 +12,10 @@ a missing token, a vendor outage, a malformed reference, or a panic anywhere in
 the hook chain — results in a generic `502 Bad Gateway` to the agent, and the
 upstream is **not contacted**. The error reason returned to the client is
 deliberately generic ("credential resolution failed") so the agent cannot tell
-a missing token from a network blip from a misconfigured rule.
+a missing token from a network blip from a misconfigured rule. Connection-level
+failures — a tunnel that cannot dial, or a mid-tunnel copy error — return the
+same generic `502` body rather than the underlying error text, so a hostile
+agent cannot use postern's errors to probe internal network topology.
 
 This is an enforced invariant, not a convention: integration tests assert that
 on a resolver error the upstream-side request counter stays at zero.

--- a/internal/proxy/connerr_test.go
+++ b/internal/proxy/connerr_test.go
@@ -1,0 +1,93 @@
+package proxy
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/elazarl/goproxy"
+	"github.com/stretchr/testify/require"
+)
+
+// errMintFailure is representative of the error goproxy's httpError would
+// leak: a MITM leaf-signing failure naming the CA path and internal detail.
+var errMintFailure = errors.New("mint leaf for internal-vault.corp: open /home/dev/.postern/ca.key: permission denied")
+
+// errDialFailure is representative of a tunnel-dial error: OS error text
+// plus an internal address — a network-topology oracle if echoed to the client.
+var errDialFailure = errors.New("dial tcp 10.42.0.7:8443: connect: connection refused")
+
+// newConnErrProxy builds a proxy server with the sanitized connection error
+// handler installed, for direct invocation of gp.ConnectionErrHandler.
+func newConnErrProxy(t *testing.T) *goproxy.ProxyHttpServer {
+	t.Helper()
+	gp := goproxy.NewProxyHttpServer()
+	installConnectionErrHandler(gp, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	require.NotNil(t, gp.ConnectionErrHandler)
+	return gp
+}
+
+// TestConnectionErrHandler_HTTPResponseWriter covers the branch where
+// goproxy hands us a real http.ResponseWriter (e.g. the plain-HTTP error
+// path): the client must see exactly the constant bad-gateway body with a
+// 502 status and none of the underlying error text.
+func TestConnectionErrHandler_HTTPResponseWriter(t *testing.T) {
+	t.Parallel()
+
+	for name, err := range map[string]error{"mint": errMintFailure, "dial": errDialFailure} {
+		t.Run(name, func(t *testing.T) {
+			gp := newConnErrProxy(t)
+			rec := httptest.NewRecorder()
+
+			gp.ConnectionErrHandler(rec, &goproxy.ProxyCtx{}, err)
+
+			require.Equal(t, 502, rec.Code)
+			require.Equal(t, badGatewayBody, rec.Body.String())
+			require.NotContains(t, rec.Body.String(), "mint")
+			require.NotContains(t, rec.Body.String(), "ca.key")
+			require.NotContains(t, rec.Body.String(), "10.42.0.7")
+			require.NotContains(t, rec.Body.String(), "connection refused")
+		})
+	}
+}
+
+// TestConnectionErrHandler_RawWriter covers the hijacked-stream branch:
+// tunnel dial failures and mid-tunnel copy errors arrive on a bare
+// io.Writer after the 200 Connection established frame may already be out.
+// The response must mirror goproxy's raw HTTP/1.1 frame shape but carry the
+// constant body.
+func TestConnectionErrHandler_RawWriter(t *testing.T) {
+	t.Parallel()
+
+	gp := newConnErrProxy(t)
+	var buf bytes.Buffer
+
+	gp.ConnectionErrHandler(&buf, &goproxy.ProxyCtx{}, errDialFailure)
+
+	out := buf.String()
+	require.True(t, strings.HasPrefix(out, "HTTP/1.1 502 Bad Gateway\r\n"), "raw branch must emit a parseable 502 status line, got %q", out)
+	require.Contains(t, out, "Content-Length: "+strconv.Itoa(len(badGatewayBody))+"\r\n")
+	require.True(t, strings.HasSuffix(out, "\r\n\r\n"+badGatewayBody), "body must be exactly the constant bad-gateway body")
+	require.NotContains(t, out, "10.42.0.7")
+	require.NotContains(t, out, "connection refused")
+}
+
+// TestConnectionErrHandler_DeadPeerDoesNotPanic proves the mid-tunnel path
+// tolerates a peer that has already hung up: writing to a closed pipe must
+// be ignored, never panic.
+func TestConnectionErrHandler_DeadPeerDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	gp := newConnErrProxy(t)
+	client, server := net.Pipe()
+	require.NoError(t, server.Close()) // peer gone mid-tunnel
+	defer func() { _ = client.Close() }()
+
+	gp.ConnectionErrHandler(client, &goproxy.ProxyCtx{}, errDialFailure)
+}

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -75,6 +76,52 @@ func installInnerGuard(gp *goproxy.ProxyHttpServer, logger *slog.Logger) {
 		}
 		return req, nil
 	})
+}
+
+// installConnectionErrHandler wires goproxy's ConnectionErrHandler so every
+// connection-level failure surfaces the constant anti-oracle body. Without
+// it goproxy's httpError writes the raw err.Error() to the client socket —
+// for a tunnel-dial failure that is a parseable 502 whose body names
+// internal addresses and OS error text: a network-topology oracle for a
+// hostile agent.
+//
+// goproxy also invokes the handler mid-tunnel on hijacked byte streams
+// (copy errors after the 200 Connection established frame is out), so the
+// hijacked branch mirrors goproxy's raw HTTP/1.1 frame shape with the
+// constant body, ignores write errors, and never assumes the peer still
+// speaks HTTP.
+func installConnectionErrHandler(gp *goproxy.ProxyHttpServer, logger *slog.Logger) {
+	gp.ConnectionErrHandler = func(w io.Writer, ctx *goproxy.ProxyCtx, err error) {
+		host := ""
+		if ctx != nil && ctx.Req != nil && ctx.Req.URL != nil {
+			host = ctx.Req.URL.Host
+		}
+		logger.Debug("upstream connection error",
+			slog.String("host", host),
+			slog.Any("err", err),
+		)
+		switch rw := w.(type) {
+		case http.ResponseWriter:
+			// Same shape http.Error produces, minus the extra newline —
+			// the body must stay byte-identical to badGatewayBody.
+			rw.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			rw.Header().Set("X-Content-Type-Options", "nosniff")
+			rw.WriteHeader(http.StatusBadGateway)
+			_, _ = io.WriteString(rw, badGatewayBody)
+		case interface{ ResponseWriter() http.ResponseWriter }:
+			// goproxy's HTTP/2 tunnel path wraps the stream; unwrap it so
+			// the client still gets a real HTTP response object.
+			http.Error(rw.ResponseWriter(), badGatewayBody, http.StatusBadGateway)
+		default:
+			// Hijacked raw stream (tunnel dial failure, mid-tunnel copy
+			// error). Same frame goproxy's httpError raw branch emits, but
+			// with the constant body.
+			frame := fmt.Sprintf(
+				"HTTP/1.1 502 Bad Gateway\r\nContent-Type: text/plain\r\nContent-Length: %d\r\n\r\n%s",
+				len(badGatewayBody), badGatewayBody)
+			_, _ = io.WriteString(w, frame)
+		}
+	}
 }
 
 // installPreUpstream wires the user-supplied PreUpstreamHandler into the

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -15,6 +15,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/elazarl/goproxy"
 
@@ -64,6 +65,17 @@ type Config struct {
 	// instead of tunneling them — the connect-time form of on_no_match: block.
 	// It is ignored when ShouldIntercept is nil (every host is intercepted).
 	BlockNonBrokered bool
+
+	// TestDialTimeout overrides the outbound dialer's 10s connect timeout
+	// for tests that cannot wait out the production default. Zero keeps
+	// the default. Test-only: production wiring never sets it and it is
+	// deliberately not exposed through YAML configuration.
+	TestDialTimeout time.Duration
+
+	// TestResponseHeaderTimeout overrides the outbound transport's 30s
+	// response-header timeout for the same reason. Zero keeps the default.
+	// Test-only, like TestDialTimeout.
+	TestResponseHeaderTimeout time.Duration
 }
 
 // Proxy is the postern HTTPS proxy. Construct one with New; expose its
@@ -92,10 +104,11 @@ func New(cfg Config) (*Proxy, error) {
 	// goproxy's default logger writes to stderr; mute it — we log via slog.
 	gp.Logger = mutedLogger{}
 
+	tr := newUpstreamTransport(cfg)
 	if cfg.UpstreamTLS != nil {
-		// goproxy reuses its Tr for upstream dials, so cloning preserves
-		// any other defaults (proxy chain, MaxIdleConns) the package set.
-		gp.Tr.TLSClientConfig = cfg.UpstreamTLS.Clone()
+		// Cloning preserves any other defaults (proxy chain, MaxIdleConns)
+		// the caller set on its config.
+		tr.TLSClientConfig = cfg.UpstreamTLS.Clone()
 	} else {
 		// Production path: dial upstreams with system trust. Set the verifying
 		// config explicitly rather than inheriting goproxy's transport default
@@ -103,8 +116,9 @@ func New(cfg Config) (*Proxy, error) {
 		// certificate verification is a load-bearing security invariant and
 		// must not silently depend on a library default that a future version
 		// could flip. InsecureSkipVerify stays false (the zero value).
-		gp.Tr.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+		tr.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12}
 	}
+	gp.Tr = tr
 
 	tlsConfig := mitmTLSConfig(cfg.Minter)
 	gp.OnRequest().HandleConnect(goproxy.FuncHttpsHandler(func(host string, ctx *goproxy.ProxyCtx) (*goproxy.ConnectAction, string) {
@@ -145,8 +159,64 @@ func New(cfg Config) (*Proxy, error) {
 	installInnerGuard(gp, cfg.Logger)
 	installHandlers(gp, cfg.Logger)
 	installPreUpstream(gp, cfg.Logger, cfg.PreUpstreamHandler)
+	installConnectionErrHandler(gp, cfg.Logger)
 
 	return &Proxy{cfg: cfg, server: gp}, nil
+}
+
+// Outbound timeout budget. goproxy's default transport sets zero timeouts,
+// so an upstream that accepts TCP but never responds would pin a goroutine
+// and a file descriptor forever. These constants bound each phase of the
+// upstream exchange; they are deliberately not configurable via YAML — a
+// knob can be added later if an operator ever needs one.
+const (
+	// upstreamDialTimeout bounds the TCP connect for upstream requests and
+	// CONNECT tunnels alike: goproxy dials tunnels through Tr.DialContext.
+	upstreamDialTimeout = 10 * time.Second
+
+	// upstreamKeepAlive is the TCP keep-alive period for upstream conns.
+	upstreamKeepAlive = 30 * time.Second
+
+	// upstreamTLSHandshakeTimeout bounds the upstream TLS handshake.
+	upstreamTLSHandshakeTimeout = 10 * time.Second
+
+	// upstreamResponseHeaderTimeout bounds how long postern waits for an
+	// upstream to start responding. It does not bound the body: streaming
+	// (SSE) responses may legitimately run for minutes.
+	upstreamResponseHeaderTimeout = 30 * time.Second
+
+	// upstreamIdleConnTimeout reaps pooled-but-silent upstream conns.
+	upstreamIdleConnTimeout = 90 * time.Second
+
+	// upstreamExpectContinueTimeout bounds the wait for an upstream's
+	// 100-continue reply.
+	upstreamExpectContinueTimeout = 1 * time.Second
+)
+
+// newUpstreamTransport builds the transport goproxy uses for ALL upstream
+// traffic: plain proxied requests, MITM'd inner requests (ctx.RoundTrip),
+// and CONNECT tunnel dials (goproxy prefers Tr.DialContext when set).
+func newUpstreamTransport(cfg Config) *http.Transport {
+	dialTimeout := upstreamDialTimeout
+	if cfg.TestDialTimeout > 0 {
+		dialTimeout = cfg.TestDialTimeout
+	}
+	headerTimeout := upstreamResponseHeaderTimeout
+	if cfg.TestResponseHeaderTimeout > 0 {
+		headerTimeout = cfg.TestResponseHeaderTimeout
+	}
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   dialTimeout,
+			KeepAlive: upstreamKeepAlive,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		TLSHandshakeTimeout:   upstreamTLSHandshakeTimeout,
+		ResponseHeaderTimeout: headerTimeout,
+		IdleConnTimeout:       upstreamIdleConnTimeout,
+		ExpectContinueTimeout: upstreamExpectContinueTimeout,
+	}
 }
 
 // Handler returns the proxy's net/http handler. Mount it on any http.Server

--- a/internal/proxy/timeout_test.go
+++ b/internal/proxy/timeout_test.go
@@ -1,0 +1,124 @@
+package proxy_test
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mmartinez/postern/internal/proxy"
+)
+
+// TestProxy_StalledUpstream_FailsWithinBound pins the response-header
+// timeout: an upstream that accepts TCP but never responds must not pin a
+// proxy goroutine and file descriptor forever. With a short injected
+// timeout the client's request fails within the bound and the goroutine
+// count returns to baseline once everything is torn down.
+func TestProxy_StalledUpstream_FailsWithinBound(t *testing.T) {
+	t.Parallel()
+
+	baseline := runtime.NumGoroutine()
+
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		// Block until the client (here: the proxy) goes away — the stalled
+		// upstream of the bug report, minus the forever.
+		<-r.Context().Done()
+	}))
+	t.Cleanup(upstream.Close)
+
+	root := fixtureCA(t)
+	p, err := proxy.New(proxy.Config{
+		CA:                        root,
+		Minter:                    fixtureMinter(t, root),
+		Logger:                    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		UpstreamTLS:               upstreamTLS(t, upstream),
+		TestResponseHeaderTimeout: 250 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	proxyURL := startProxy(t, p)
+	client := clientThroughProxy(t, proxyURL, root)
+
+	start := time.Now()
+	resp, err := client.Get(upstream.URL + "/stall")
+	elapsed := time.Since(start)
+	require.Error(t, err, "stalled upstream must fail, not hang")
+	require.Less(t, elapsed, 2*time.Second,
+		"request took %v — response-header timeout not in effect", elapsed)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+
+	// The bound is only useful if it releases resources: after the failure
+	// and teardown, goroutines must drain back to baseline.
+	t.Cleanup(func() {
+		require.Eventually(t, func() bool {
+			return runtime.NumGoroutine() <= baseline+5
+		}, 5*time.Second, 100*time.Millisecond,
+			"goroutines did not return to baseline (%d now vs %d before) — stalled-upstream goroutine leaked",
+			runtime.NumGoroutine(), baseline)
+	})
+}
+
+// TestProxy_TunnelDial_FailsWithinBound_ConstantBody pins both halves of
+// the tunnel-dial fix: the CONNECT dial for a tunneled (non-brokered) host
+// is bounded by Tr.DialContext, and the resulting 502 carries the constant
+// anti-oracle body instead of the raw dial error.
+func TestProxy_TunnelDial_FailsWithinBound_ConstantBody(t *testing.T) {
+	t.Parallel()
+
+	root := fixtureCA(t)
+	p, err := proxy.New(proxy.Config{
+		CA:              root,
+		Minter:          fixtureMinter(t, root),
+		Logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ShouldIntercept: func(string) bool { return false }, // tunnel everything
+		TestDialTimeout: 250 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	proxyAddr := strings.TrimPrefix(startProxy(t, p), "http://")
+
+	// RFC 5737 TEST-NET-1: guaranteed non-routable. Networks that reject it
+	// immediately (EHOSTUNREACH/ENETUNREACH) still exercise the sanitized
+	// 502; networks that blackhole it exercise the dial timeout.
+	const blackhole = "192.0.2.1:81"
+
+	conn, err := net.DialTimeout("tcp", proxyAddr, 2*time.Second)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	start := time.Now()
+	_, err = fmtFprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", blackhole, blackhole)
+	require.NoError(t, err)
+
+	reader := bufio.NewReader(conn)
+	status, err := reader.ReadString('\n')
+	require.NoError(t, err, "no reply from proxy within read deadline")
+	require.Contains(t, status, "502 Bad Gateway",
+		"tunnel dial failure must surface as 502, got %q", status)
+	require.Less(t, time.Since(start), 3*time.Second,
+		"CONNECT to non-routable address took %v — tunnel dial is unbounded", time.Since(start))
+
+	body, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NotEmpty(t, body)
+	require.NotContains(t, string(body), "192.0.2.1")
+	require.NotContains(t, string(body), "timeout")
+	require.NotContains(t, string(body), "unreachable")
+	require.NotContains(t, string(body), "refused")
+}
+
+// fmtFprintf writes formatted bytes to conn with a deadline so a broken
+// proxy fails the test instead of hanging it.
+func fmtFprintf(conn net.Conn, format string, args ...any) (int, error) {
+	_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+	return fmt.Fprintf(conn, format, args...)
+}

--- a/internal/proxy/transport_test.go
+++ b/internal/proxy/transport_test.go
@@ -1,0 +1,45 @@
+package proxy
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewUpstreamTransport_DefaultTimeouts pins the outbound transport's
+// timeout budget exactly. goproxy's own default transport sets none of
+// these, so a regression here silently re-opens the "stalled upstream pins
+// a goroutine and an fd forever" hole.
+func TestNewUpstreamTransport_DefaultTimeouts(t *testing.T) {
+	t.Parallel()
+
+	tr := newUpstreamTransport(Config{})
+
+	require.NotNil(t, tr.DialContext, "upstream dials (requests AND CONNECT tunnels) must go through the bounded dialer")
+	require.True(t, reflect.ValueOf(tr.Proxy).Pointer() == reflect.ValueOf(http.ProxyFromEnvironment).Pointer(),
+		"proxy-from-environment must be preserved")
+	require.Equal(t, 10*time.Second, tr.TLSHandshakeTimeout)
+	require.Equal(t, 30*time.Second, tr.ResponseHeaderTimeout)
+	require.Equal(t, 90*time.Second, tr.IdleConnTimeout)
+	require.Equal(t, 1*time.Second, tr.ExpectContinueTimeout)
+	require.True(t, tr.ForceAttemptHTTP2)
+	require.Nil(t, tr.TLSClientConfig, "TLS config is applied by New, not the transport constructor")
+}
+
+// TestNewUpstreamTransport_TestSeams proves the test-only overrides reach
+// the transport so timeout tests do not sleep through production values.
+func TestNewUpstreamTransport_TestSeams(t *testing.T) {
+	t.Parallel()
+
+	tr := newUpstreamTransport(Config{
+		TestDialTimeout:           100 * time.Millisecond,
+		TestResponseHeaderTimeout: 50 * time.Millisecond,
+	})
+
+	require.Equal(t, 50*time.Millisecond, tr.ResponseHeaderTimeout)
+	// The dial timeout lives inside the DialContext closure; it is asserted
+	// behaviorally by the tunnel-dial-bound e2e test.
+}

--- a/internal/runtime/idlereap_test.go
+++ b/internal/runtime/idlereap_test.go
@@ -1,0 +1,83 @@
+package runtime_test
+
+import (
+	"bufio"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mmartinez/postern/internal/runtime"
+)
+
+// TestRuntime_IdleKeepAliveConnReaped proves the inbound server closes a
+// silent keep-alive connection within the (test-injected) idle bound
+// instead of holding it forever.
+func TestRuntime_IdleKeepAliveConnReaped(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	}))
+	t.Cleanup(upstream.Close)
+
+	root := fixtureCA(t)
+	rt, err := runtime.New(runtime.Options{
+		CA:              root,
+		Addr:            "127.0.0.1:0",
+		Logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+		TestIdleTimeout: 300 * time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	done := make(chan error, 1)
+	go func() { done <- rt.Run(ctx) }()
+	require.NoError(t, waitForListening(rt, 2*time.Second))
+	t.Cleanup(func() {
+		<-done
+	})
+
+	conn, err := net.DialTimeout("tcp", rt.Addr(), 2*time.Second)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+
+	// One absolute-form request over the connection, then go silent — the
+	// keep-alive conn is now idle from the server's perspective.
+	req := "GET " + upstream.URL + "/ HTTP/1.1\r\nHost: " + hostOnly(t, upstream.URL) + "\r\n\r\n"
+	_, err = conn.Write([]byte(req))
+	require.NoError(t, err)
+	fakeReq, err := http.NewRequest(http.MethodGet, upstream.URL, http.NoBody)
+	require.NoError(t, err)
+	reader := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(reader, fakeReq)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	_, err = io.Copy(io.Discard, resp.Body)
+	require.NoError(t, err)
+
+	// The server must close the idle conn well inside a generous bound.
+	idleStart := time.Now()
+	_ = conn.SetDeadline(idleStart.Add(5 * time.Second))
+	_, err = reader.ReadByte()
+	require.Error(t, err, "idle keep-alive connection was never closed")
+	require.Less(t, time.Since(idleStart), 3*time.Second,
+		"idle conn closed after %v — IdleTimeout not in effect", time.Since(idleStart))
+}
+
+// hostOnly strips the scheme and port from an httptest URL for the Host
+// header of a hand-rolled request.
+func hostOnly(t *testing.T, raw string) string {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return u.Hostname()
+}

--- a/internal/runtime/idletimeout_test.go
+++ b/internal/runtime/idletimeout_test.go
@@ -1,0 +1,30 @@
+package runtime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mmartinez/postern/internal/ca"
+)
+
+// TestNew_ServerIdleTimeoutDefault pins the inbound server's IdleTimeout:
+// without it net/http never reaps silent keep-alive connections (ReadTimeout
+// is deliberately unset so streaming responses are never cut), and idle
+// agent connections accumulate goroutines forever.
+func TestNew_ServerIdleTimeoutDefault(t *testing.T) {
+	t.Parallel()
+
+	root, err := ca.Generate(time.Now())
+	require.NoError(t, err)
+	rt, err := New(Options{CA: root, Addr: "127.0.0.1:0"})
+	require.NoError(t, err)
+
+	require.Equal(t, 120*time.Second, rt.srv.IdleTimeout)
+	// Streaming guard: Read/WriteTimeout must stay zero or SSE responses
+	// would be cut mid-stream (docs/architecture.md promises incremental
+	// delivery).
+	require.Zero(t, rt.srv.ReadTimeout)
+	require.Zero(t, rt.srv.WriteTimeout)
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -27,6 +27,13 @@ import (
 // budget gets a 504 from the http.Server.
 const shutdownBudget = 10 * time.Second
 
+// idleTimeout reaps silent keep-alive connections on the inbound server.
+// With IdleTimeout unset net/http never closes an idle conn (ReadTimeout is
+// deliberately unset so streaming responses are never cut), so agents that
+// hold connections open would accumulate server goroutines forever. Not
+// configurable via YAML; a knob can be added later if ever needed.
+const idleTimeout = 2 * time.Minute
+
 // Options carries the resolved configuration runtime needs. CLI populates
 // it from cobra flags and config files; tests construct it inline.
 type Options struct {
@@ -57,6 +64,12 @@ type Options struct {
 	// BlockNonBrokered rejects the CONNECT for non-brokered hosts instead of
 	// tunneling them — the connect-time form of on_no_match: block.
 	BlockNonBrokered bool
+
+	// TestIdleTimeout overrides the inbound server's 2m IdleTimeout for
+	// tests that cannot wait out the production default. Zero keeps the
+	// default. Test-only: production wiring never sets it and it is not
+	// exposed through YAML configuration.
+	TestIdleTimeout time.Duration
 }
 
 // Runtime is the constructed-but-not-yet-running postern server. Build it
@@ -102,6 +115,11 @@ func New(opts Options) (*Runtime, error) {
 		return nil, fmt.Errorf("init proxy: %w", err)
 	}
 
+	idle := idleTimeout
+	if opts.TestIdleTimeout > 0 {
+		idle = opts.TestIdleTimeout
+	}
+
 	return &Runtime{
 		opts:   opts,
 		proxy:  p,
@@ -110,6 +128,7 @@ func New(opts Options) (*Runtime, error) {
 			Addr:              opts.Addr,
 			Handler:           p.Handler(),
 			ReadHeaderTimeout: 30 * time.Second,
+			IdleTimeout:       idle,
 		},
 	}, nil
 }


### PR DESCRIPTION
## Problem

All upstream traffic in goproxy v1.9.0 flows through `gp.Tr`, whose default transport sets zero timeouts (proxy.go:176), and CONNECT dials for tunneled hosts fall back to a zero-value `net.Dialer` (https.go:164-165). An upstream that accepts TCP but never responds pins a proxy goroutine and file descriptor indefinitely. On the inbound side, postern's `http.Server` set only `ReadHeaderTimeout`, so silent keep-alive connections were never reaped. Finally, with no `ConnectionErrHandler` set, goproxy's `httpError` (https.go:594-616) writes raw `err.Error()` to the client socket: a tunnel-dial failure yields a parseable 502 whose body is the dial error — an internal-network topology oracle for a hostile agent, violating postern's constant-body anti-oracle invariant.

## Evidence

- goproxy v1.9.0 proxy.go:176: `Tr: &http.Transport{TLSClientConfig: tlsClientSkipVerify, Proxy: http.ProxyFromEnvironment}` — no dial, TLS-handshake, response-header, or idle-conn timeouts.
- goproxy v1.9.0 https.go:158-165: `dial()` prefers `Tr.DialContext`, else zero-value `net.Dialer`; setting `DialContext` bounds both request and tunnel dials with one change.
- goproxy v1.9.0 https.go:594-616: `httpError` falls back to `http.Error(rw, err.Error(), 502)` or a raw-framed 502 with `err.Error()` as the body when `ConnectionErrHandler` is nil; also invoked mid-tunnel on hijacked streams (https.go:311-312, 364-365).
- go1.26.5 net/http: `IdleTimeout` zero falls back to zero `ReadTimeout`, i.e. no idle reap.

## Changes

- `internal/proxy/proxy.go`: stop poking `gp.Tr` fields; assign a fully specified `*http.Transport` via `newUpstreamTransport`: `net.Dialer{Timeout: 10s, KeepAlive: 30s}` as `DialContext`, `TLSHandshakeTimeout: 10s`, `ResponseHeaderTimeout: 30s`, `IdleConnTimeout: 90s`, `ExpectContinueTimeout: 1s`, `ForceAttemptHTTP2: true`, preserving `Proxy: http.ProxyFromEnvironment` and the existing two-branch `TLSClientConfig` logic. Package-level constants with doc comments; deliberately not YAML-configurable (a knob can be added later if wanted).
- `internal/runtime/runtime.go`: `IdleTimeout: 120s` on the `http.Server`. `ReadTimeout`/`WriteTimeout` intentionally stay zero so SSE/streaming (docs/architecture.md "Forward" step) keeps working.
- `internal/proxy/handler.go`: `installConnectionErrHandler` emits the constant `badGatewayBody` on every connection-level failure — `http.Error`-shaped 502 for real `http.ResponseWriter`s, goproxy's raw HTTP/1.1 frame shape (constant body) for hijacked byte streams; write errors ignored, cause logged at Debug.

**Deliberate behavior change:** tunnel-dial-failure 502 bodies are now the constant `postern: bad gateway\n` instead of the raw dial error. Documented in docs/security.md (Fail-closed section).

**Known adjacent gap, out of scope:** goproxy's plain-HTTP (non-CONNECT) upstream-failure path (http.go `handleHttp`) writes `ctx.Error.Error()` with a 500 directly, bypassing `httpError`/`ConnectionErrHandler`; goproxy v1.9.0 exposes no hook there. Not fixed in this PR.

## Acceptance criteria demonstrated by tests

- `TestNewUpstreamTransport_DefaultTimeouts` asserts every transport field exactly (dialer present, proxy-from-env preserved, 10s/30s/90s/1s, ForceAttemptHTTP2).
- `TestProxy_StalledUpstream_FailsWithinBound`: never-responding upstream fails within the injected bound and goroutine count returns to baseline.
- `TestProxy_TunnelDial_FailsWithinBound_ConstantBody`: CONNECT to a non-routable TEST-NET address fails within the injected dial timeout (observed 0.25s = injected timeout) and the 502 body contains no address/error text.
- `TestNew_ServerIdleTimeoutDefault` pins `IdleTimeout: 120s` and zero `Read/WriteTimeout`; `TestRuntime_IdleKeepAliveConnReaped` proves an idle keep-alive conn closes within the injected bound.
- `TestConnectionErrHandler_*`: simulated mint failure and tunnel-dial failure produce the constant body (HTTP-writer and raw-writer branches), no internal-detail substrings; dead-peer invocation does not panic.
- Streaming regression: pre-existing `TestProxy_StreamingNotBuffered` (SSE, per-chunk timing) passes unmodified.
- All pre-existing tests pass unmodified; `make ci` (golangci-lint 0 issues, go test -race ./..., govulncheck, licenses) green.