### PR TITLE
fix(proxy): bind inner MITM requests to the CONNECT authority

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,6 +45,8 @@ agent                     postern (127.0.0.1:1701)                 upstream
    reaches the real upstream with the real certificate and only needs to trust
    the postern CA for hosts it actually brokers. (When no broker is configured
    at all, postern falls back to intercepting every host.)
+   Inner requests on an intercepted tunnel are bound to the CONNECT
+   authority; a decrypted request naming any other host fails closed with a 502.
 
 2. **Match.** For an intercepted host the decrypted request's host (with any
    `:port` stripped) is matched against the YAML-declared rules — first match

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -37,14 +37,14 @@ func bad502(req *http.Request) *http.Response {
 	}
 }
 
-// installInnerGuard binds every inner MITM request to the CONNECT authority
-// stashed by the CONNECT handler in ctx.UserData (goproxy copies that slot
-// onto each inner request's fresh ProxyCtx). goproxy rebuilds only
-// relative-form inner URLs against the tunnel host; an absolute-form inner
-// request keeps its own URL host, and a cross-scheme one makes goproxy's
-// unchecked re-parse fail, leaving req.URL nil. Without this guard the first
-// case would be forwarded under passthrough policy and the second would
-// panic the logging handler, so both fail closed with the generic 502.
+// installInnerGuard binds every inner MITM request to the full CONNECT
+// authority (host AND port) stashed by the CONNECT handler in ctx.UserData
+// (goproxy copies that slot onto each inner request's fresh ProxyCtx).
+// goproxy rebuilds only relative-form inner URLs against the tunnel
+// authority; an absolute-form inner request keeps its own URL host, and a
+// cross-scheme one can leave req.URL nil. Without this guard such requests
+// would be forwarded under passthrough policy or panic the logging handler,
+// so both fail closed with the generic 502.
 func installInnerGuard(gp *goproxy.ProxyHttpServer, logger *slog.Logger) {
 	gp.OnRequest().DoFunc(func(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 		authority, ok := ctx.UserData.(string)
@@ -61,11 +61,14 @@ func installInnerGuard(gp *goproxy.ProxyHttpServer, logger *slog.Logger) {
 			)
 			return req, bad502(req) //nolint:bodyclose // goproxy owns the synthetic body
 		}
-		if host := strings.ToLower(stripPort(req.URL.Host)); host != authority {
+		// Full-authority comparison (host AND port): a port-stripped match
+		// would let an absolute-form inner request for api.example:8443 ride
+		// an api.example:443 tunnel and collect its credential.
+		if reqHost := strings.ToLower(req.URL.Host); reqHost != authority {
 			logger.Info("rejecting non-brokered inner host",
 				slog.Int64("session", ctx.Session),
 				slog.String("method", req.Method),
-				slog.String("host", host),
+				slog.String("host", reqHost),
 				slog.String("authority", authority),
 			)
 			return req, bad502(req) //nolint:bodyclose // goproxy owns the synthetic body

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -37,6 +37,43 @@ func bad502(req *http.Request) *http.Response {
 	}
 }
 
+// installInnerGuard binds every inner MITM request to the CONNECT authority
+// stashed by the CONNECT handler in ctx.UserData (goproxy copies that slot
+// onto each inner request's fresh ProxyCtx). goproxy rebuilds only
+// relative-form inner URLs against the tunnel host; an absolute-form inner
+// request keeps its own URL host, and a cross-scheme one makes goproxy's
+// unchecked re-parse fail, leaving req.URL nil. Without this guard the first
+// case would be forwarded under passthrough policy and the second would
+// panic the logging handler, so both fail closed with the generic 502.
+func installInnerGuard(gp *goproxy.ProxyHttpServer, logger *slog.Logger) {
+	gp.OnRequest().DoFunc(func(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+		authority, ok := ctx.UserData.(string)
+		if !ok || authority == "" {
+			// Not an intercepted tunnel (plain HTTP proxying leaves UserData
+			// unset); nothing to bind.
+			return req, nil
+		}
+		if req.URL == nil {
+			logger.Info("rejecting malformed inner request",
+				slog.Int64("session", ctx.Session),
+				slog.String("method", req.Method),
+				slog.String("authority", authority),
+			)
+			return req, bad502(req) //nolint:bodyclose // goproxy owns the synthetic body
+		}
+		if host := strings.ToLower(stripPort(req.URL.Host)); host != authority {
+			logger.Info("rejecting non-brokered inner host",
+				slog.Int64("session", ctx.Session),
+				slog.String("method", req.Method),
+				slog.String("host", host),
+				slog.String("authority", authority),
+			)
+			return req, bad502(req) //nolint:bodyclose // goproxy owns the synthetic body
+		}
+		return req, nil
+	})
+}
+
 // installPreUpstream wires the user-supplied PreUpstreamHandler into the
 // goproxy request chain. A nil hook installs nothing (passthrough). A
 // non-nil hook runs under a recover() so a bug or attacker-induced panic

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -14,6 +14,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strings"
 
 	"github.com/elazarl/goproxy"
 
@@ -123,6 +124,11 @@ func New(cfg Config) (*Proxy, error) {
 			// TLS fingerprint. postern never decrypts what it does not broker.
 			return goproxy.OkConnect, host
 		default:
+			// Bind every inner request on this tunnel to the CONNECT
+			// authority: goproxy copies ctx.UserData onto each MITM'd
+			// request's fresh ProxyCtx, where the inner-request guard
+			// uses it to reject anything naming another host.
+			ctx.UserData = strings.ToLower(stripPort(host))
 			return &goproxy.ConnectAction{
 				Action:    goproxy.ConnectMitm,
 				TLSConfig: tlsConfig,
@@ -130,6 +136,10 @@ func New(cfg Config) (*Proxy, error) {
 		}
 	}))
 
+	// Registered before the logging/pre-upstream handlers so a malformed
+	// or non-brokered inner request is rejected before anything
+	// dereferences req.URL.
+	installInnerGuard(gp, cfg.Logger)
 	installHandlers(gp, cfg.Logger)
 	installPreUpstream(gp, cfg.Logger, cfg.PreUpstreamHandler)
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -124,11 +124,14 @@ func New(cfg Config) (*Proxy, error) {
 			// TLS fingerprint. postern never decrypts what it does not broker.
 			return goproxy.OkConnect, host
 		default:
-			// Bind every inner request on this tunnel to the CONNECT
-			// authority: goproxy copies ctx.UserData onto each MITM'd
-			// request's fresh ProxyCtx, where the inner-request guard
-			// uses it to reject anything naming another host.
-			ctx.UserData = strings.ToLower(stripPort(host))
+			// Bind every inner request on this tunnel to the full CONNECT
+			// authority (host AND port): goproxy copies ctx.UserData onto
+			// each MITM'd request's fresh ProxyCtx, where the inner-request
+			// guard compares it against req.URL.Host. The port must be kept,
+			// or an inner request for api.example:8443 inside an
+			// api.example:443 tunnel would pass the guard and receive the
+			// brokered credential.
+			ctx.UserData = strings.ToLower(host)
 			return &goproxy.ConnectAction{
 				Action:    goproxy.ConnectMitm,
 				TLSConfig: tlsConfig,

--- a/internal/proxy/redteam_inner_request_test.go
+++ b/internal/proxy/redteam_inner_request_test.go
@@ -188,6 +188,33 @@ func TestRedTeam_InnerRequest_SameHostAbsoluteForm_Forwards(t *testing.T) {
 	require.Equal(t, int64(1), hits.Load(), "same-host inner request must reach the upstream")
 }
 
+// TestRedTeam_InnerRequest_CrossPortAbsoluteForm_FailsClosed pins the
+// full-authority binding: an absolute-form inner request whose HOST matches
+// the tunnel but whose PORT differs must be rejected — the credential is
+// brokered for one origin:port, not for every port on the host.
+func TestRedTeam_InnerRequest_CrossPortAbsoluteForm_FailsClosed(t *testing.T) {
+	t.Parallel()
+
+	var hits atomic.Int64
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+	}))
+	t.Cleanup(upstream.Close)
+
+	logBuf := &lockedBuffer{}
+	proxyURL, root := startGuardProxy(t, upstream, logBuf)
+
+	target := strings.TrimPrefix(upstream.URL, "https://")
+	host, _, err := net.SplitHostPort(target)
+	require.NoError(t, err)
+	tn := openMITMTunnel(t, proxyURL, target, root)
+
+	status, body := tn.roundTrip(t, "GET https://"+host+":1/v1/steal HTTP/1.1\r\nHost: "+host+":1\r\n\r\n")
+	require.Equal(t, http.StatusBadGateway, status)
+	require.Equal(t, guardBadBody, body)
+	require.Zero(t, hits.Load(), "cross-port inner request must NOT be forwarded upstream")
+}
+
 // TestRedTeam_InnerRequest_SequentialOverOneTunnel pins that the authority
 // stash is carried on every inner request of a tunnel, not just the first:
 // allowed and rejected requests interleave over a single connection and each

--- a/internal/proxy/redteam_inner_request_test.go
+++ b/internal/proxy/redteam_inner_request_test.go
@@ -1,0 +1,227 @@
+package proxy_test
+
+import (
+	"bufio"
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mmartinez/postern/internal/ca"
+	"github.com/mmartinez/postern/internal/proxy"
+)
+
+// The inner-request guard binds every decrypted request on an intercepted
+// tunnel to the CONNECT authority. These tests drive raw HTTP/1.1 over the
+// MITM connection because Go's http.Client never emits the absolute-form and
+// cross-scheme request lines the guard exists for.
+
+const guardBadBody = "postern: bad gateway\n"
+
+// mitmTunnel is an established MITM connection: the CONNECT succeeded and the
+// TLS handshake against postern's minted leaf completed. Responses are read
+// through the TLS connection; only the plaintext CONNECT exchange runs
+// outside it.
+type mitmTunnel struct {
+	conn *tls.Conn
+	// br wraps conn and is reused across responses: go1.26's
+	// http.ReadResponse needs a *bufio.Reader and may buffer ahead into
+	// the next response.
+	br *bufio.Reader
+}
+
+// openMITMTunnel CONNECTs to target through the proxy and completes the MITM
+// handshake, trusting only postern's CA.
+func openMITMTunnel(t *testing.T, proxyURL, target string, root *ca.CA) *mitmTunnel {
+	t.Helper()
+	u, err := url.Parse(proxyURL)
+	require.NoError(t, err)
+	conn, err := net.Dial("tcp", u.Host)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	_, err = io.WriteString(conn, "CONNECT "+target+" HTTP/1.1\r\nHost: "+target+"\r\n\r\n")
+	require.NoError(t, err)
+
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, &http.Request{Method: http.MethodConnect})
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "CONNECT must be accepted")
+
+	host, _, err := net.SplitHostPort(target)
+	require.NoError(t, err)
+	pool := x509.NewCertPool()
+	pool.AddCert(root.Cert)
+	tc := tls.Client(conn, &tls.Config{
+		ServerName: host,
+		RootCAs:    pool,
+		MinVersion: tls.VersionTLS12,
+	})
+	require.NoError(t, tc.Handshake())
+	return &mitmTunnel{conn: tc, br: bufio.NewReader(tc)}
+}
+
+// roundTrip writes a hand-crafted HTTP/1.1 request over the tunnel, reads one
+// response to completion, and returns its status and body. A per-call
+// deadline keeps a missing response a fast test failure rather than a hang.
+func (tn *mitmTunnel) roundTrip(t *testing.T, raw string) (int, string) {
+	t.Helper()
+	require.NoError(t, tn.conn.SetDeadline(time.Now().Add(10*time.Second)))
+	_, err := io.WriteString(tn.conn, raw)
+	require.NoError(t, err)
+	resp, err := http.ReadResponse(tn.br, &http.Request{Method: http.MethodGet})
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	b, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, string(b)
+}
+
+// startGuardProxy builds an always-intercepting proxy in front of upstream
+// and returns its URL plus the postern CA the tunnel client must trust.
+func startGuardProxy(t *testing.T, upstream *httptest.Server, logBuf io.Writer) (string, *ca.CA) {
+	t.Helper()
+	root := fixtureCA(t)
+	p, err := proxy.New(proxy.Config{
+		CA:          root,
+		Minter:      fixtureMinter(t, root),
+		Logger:      slog.New(slog.NewTextHandler(logBuf, nil)),
+		UpstreamTLS: upstreamTLS(t, upstream),
+	})
+	require.NoError(t, err)
+	return startProxy(t, p), root
+}
+
+// TestRedTeam_InnerRequest_CrossHostAbsoluteForm_FailsClosed pins the
+// semantic-drift fix: an absolute-form inner request naming another host must
+// not be forwarded under passthrough policy — it fails closed with the
+// constant 502 body and the upstream is never dialed.
+func TestRedTeam_InnerRequest_CrossHostAbsoluteForm_FailsClosed(t *testing.T) {
+	t.Parallel()
+
+	var hits atomic.Int64
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+	}))
+	t.Cleanup(upstream.Close)
+
+	logBuf := &lockedBuffer{}
+	proxyURL, root := startGuardProxy(t, upstream, logBuf)
+
+	target := strings.TrimPrefix(upstream.URL, "https://")
+	tn := openMITMTunnel(t, proxyURL, target, root)
+
+	status, body := tn.roundTrip(t, "GET https://other.example/v1/steal HTTP/1.1\r\nHost: other.example\r\n\r\n")
+	require.Equal(t, http.StatusBadGateway, status)
+	require.Equal(t, guardBadBody, body)
+	require.Zero(t, hits.Load(), "cross-host inner request must NOT be forwarded upstream")
+	require.Contains(t, logBuf.String(), "rejecting non-brokered inner host")
+}
+
+// TestRedTeam_InnerRequest_CrossSchemeAbsoluteForm_NoPanic pins the
+// crash-per-tunnel fix: a cross-scheme absolute-form inner request used to
+// crash the logging handler on a nil req.URL (goproxy re-parse failure) or,
+// since goproxy v1.9.0, keeps its own host after the tunnel scheme is forced
+// onto it. Either way the guard must reject it with the generic 502 before
+// any handler can dereference a nil req.URL, so the tunnel closes cleanly
+// with no panic or stack trace in the logs.
+func TestRedTeam_InnerRequest_CrossSchemeAbsoluteForm_NoPanic(t *testing.T) {
+	t.Parallel()
+
+	var hits atomic.Int64
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+	}))
+	t.Cleanup(upstream.Close)
+
+	logBuf := &lockedBuffer{}
+	proxyURL, root := startGuardProxy(t, upstream, logBuf)
+
+	target := strings.TrimPrefix(upstream.URL, "https://")
+	tn := openMITMTunnel(t, proxyURL, target, root)
+
+	status, body := tn.roundTrip(t, "GET http://evil.example/v1/pwn HTTP/1.1\r\nHost: evil.example\r\n\r\n")
+	require.Equal(t, http.StatusBadGateway, status)
+	require.Equal(t, guardBadBody, body)
+	require.Zero(t, hits.Load(), "cross-scheme inner request must NOT be forwarded upstream")
+
+	// The rejection is deliberate (an INFO log line), never a recovered
+	// panic: no panic text and no goroutine dump may reach the logs.
+	logs := logBuf.String()
+	require.Contains(t, logs, "msg=\"rejecting ")
+	require.NotContains(t, logs, "panic", "no panic may reach the logs")
+	require.NotContains(t, logs, "goroutine", "no stack trace may reach the logs")
+}
+
+// TestRedTeam_InnerRequest_SameHostAbsoluteForm_Forwards pins the positive
+// case: an absolute-form inner request whose host matches the CONNECT
+// authority still forwards normally.
+func TestRedTeam_InnerRequest_SameHostAbsoluteForm_Forwards(t *testing.T) {
+	t.Parallel()
+
+	var hits atomic.Int64
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	t.Cleanup(upstream.Close)
+
+	proxyURL, root := startGuardProxy(t, upstream, &lockedBuffer{})
+
+	target := strings.TrimPrefix(upstream.URL, "https://")
+	tn := openMITMTunnel(t, proxyURL, target, root)
+
+	status, body := tn.roundTrip(t, "GET https://"+target+"/v1/ok HTTP/1.1\r\nHost: "+target+"\r\n\r\n")
+	require.Equal(t, http.StatusOK, status)
+	require.Equal(t, "ok", body)
+	require.Equal(t, int64(1), hits.Load(), "same-host inner request must reach the upstream")
+}
+
+// TestRedTeam_InnerRequest_SequentialOverOneTunnel pins that the authority
+// stash is carried on every inner request of a tunnel, not just the first:
+// allowed and rejected requests interleave over a single connection and each
+// is judged independently.
+func TestRedTeam_InnerRequest_SequentialOverOneTunnel(t *testing.T) {
+	t.Parallel()
+
+	var hits atomic.Int64
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	t.Cleanup(upstream.Close)
+
+	proxyURL, root := startGuardProxy(t, upstream, &lockedBuffer{})
+
+	target := strings.TrimPrefix(upstream.URL, "https://")
+	tn := openMITMTunnel(t, proxyURL, target, root)
+
+	// 1. Relative-form: unchanged behavior, forwards.
+	status, body := tn.roundTrip(t, "GET /v1/a HTTP/1.1\r\nHost: "+target+"\r\n\r\n")
+	require.Equal(t, http.StatusOK, status)
+	require.Equal(t, "ok", body)
+
+	// 2. Cross-host absolute-form: rejected without upstream contact.
+	status, body = tn.roundTrip(t, "GET https://other.example/v1/b HTTP/1.1\r\nHost: other.example\r\n\r\n")
+	require.Equal(t, http.StatusBadGateway, status)
+	require.Equal(t, guardBadBody, body)
+
+	// 3. Same-host absolute-form after a rejection: the stash still binds,
+	// so this forwards — proving per-request evaluation on a live tunnel.
+	status, body = tn.roundTrip(t, "GET https://"+target+"/v1/c HTTP/1.1\r\nHost: "+target+"\r\n\r\n")
+	require.Equal(t, http.StatusOK, status)
+	require.Equal(t, "ok", body)
+
+	require.Equal(t, int64(2), hits.Load(), "exactly the two bound requests must reach the upstream")
+}


### PR DESCRIPTION
## Problem

Inner requests on an intercepted tunnel are not bound to the CONNECT authority. Three verified defects share that root cause:

1. Semantic drift: an absolute-form inner request (`GET https://other.example/ HTTP/1.1`) inside a tunnel opened to another host keeps its own URL host and is forwarded under passthrough policy instead of failing closed, contradicting the documented request lifecycle.
2. Cross-port credential theft: a port-stripped comparison would let an absolute-form inner request for `api.example:8443` inside an `api.example:443` tunnel pass the guard and receive the brokered credential. The guard therefore binds to the full authority (host AND port).
3. Attacker-triggerable crash-per-tunnel: a cross-scheme absolute-form inner request used to make goproxy's unchecked re-parse leave `req.URL` nil, and postern's logging handler then nil-derefs `req.URL.Host` with no recover covering that handler. Blast radius is one connection (net/http serve-loop recover), but it is hostile-agent-triggerable and spams stack traces.

## Evidence

- goproxy v1.9.0 (repo go.mod) `https.go:460`: `UserData` is copied from the CONNECT context onto each inner request's fresh `ProxyCtx`.
- goproxy v1.9.0 `https.go:476-484`: absolute-form inner requests keep their URL host and port (only the scheme is forced to the tunnel scheme); relative-form inner requests are rebuilt against the full CONNECT authority; the unchecked re-parse error path (`req.URL` nil) remains for malformed origin-form targets. (In v1.8.4 the cross-scheme concat re-parse produced the nil URL directly; the guard covers both shapes.)
- `internal/proxy/handler.go` (before this PR): request-logging handler dereferences `req.URL.Host`; the only recover wraps the pre-upstream hook.

## Changes

- `internal/proxy/proxy.go`: the MITM branch of `HandleConnect` stashes the full CONNECT authority (lowercased, port kept) in `ctx.UserData`.
- `internal/proxy/handler.go`: new `installInnerGuard`, registered before the logging and pre-upstream handlers, rejects any inner request whose URL is nil or whose lowercased `req.URL.Host` differs exactly from the stashed authority with the constant-body 502; the reason is logged at Info without header values. A malformed CONNECT lacking a port fails closed, per RFC 7231.
- `docs/architecture.md`: lifecycle step 1 now states inner requests are bound to the CONNECT authority and fail closed otherwise.

## Acceptance criteria

Demonstrated by `internal/proxy/redteam_inner_request_test.go` (raw-HTTP-over-MITM harness, counting httptest upstream):

- Cross-host absolute-form inside a brokered tunnel returns 502 with the constant body and dials upstream zero times (`TestRedTeam_InnerRequest_CrossHostAbsoluteForm_FailsClosed`).
- Cross-port absolute-form (same host, different port) is rejected with zero upstream dials (`TestRedTeam_InnerRequest_CrossPortAbsoluteForm_FailsClosed`).
- Cross-scheme absolute-form produces no panic: clean 502, no panic or stack trace in logs, upstream dialed zero times (`TestRedTeam_InnerRequest_CrossSchemeAbsoluteForm_NoPanic`).
- Same-host-same-port absolute-form forwards to the upstream (`TestRedTeam_InnerRequest_SameHostAbsoluteForm_Forwards`).
- Relative-form behavior unchanged; allowed and rejected requests interleave over one tunnel, each judged against the stashed authority (`TestRedTeam_InnerRequest_SequentialOverOneTunnel` and the existing suite).

`make ci` (lint, race-tested coverage, govulncheck, licenses) passes locally.
