### PR TITLE
fix(config): survive silent watch death in config hot reload

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -120,7 +120,7 @@ func NewServerCmd(caDir string, reg *credstore.Registry, store token.Store) *cob
 			// watching a non-existent default-path file would just log noise.
 			var reloadWG sync.WaitGroup
 			if bundle.engine != nil && bundle.cfgPath != "" {
-				watcher := config.NewWatcher(bundle.cfgPath)
+				watcher := config.NewWatcherWithLogger(bundle.cfgPath, logger)
 				events, werr := watcher.Watch(ctx)
 				if werr != nil {
 					logger.Warn("hot reload disabled",

--- a/internal/config/stat_other.go
+++ b/internal/config/stat_other.go
@@ -1,0 +1,26 @@
+//go:build !linux && !darwin
+
+package config
+
+import (
+	"os"
+	"time"
+)
+
+// statSnapshot is the fingerprint of the watched file compared by the
+// stat-poll fallback. Platforms without a portable inode in syscall.Stat_t
+// fall back to size and mtime.
+type statSnapshot struct {
+	size int64
+	mod  time.Time
+}
+
+// statSnapshotOf stats path, reporting ok=false when the file is absent or
+// unreadable. That transition is itself a change the poll must surface.
+func statSnapshotOf(path string) (statSnapshot, bool) {
+	st, err := os.Stat(path)
+	if err != nil {
+		return statSnapshot{}, false
+	}
+	return statSnapshot{size: st.Size(), mod: st.ModTime()}, true
+}

--- a/internal/config/stat_unix.go
+++ b/internal/config/stat_unix.go
@@ -1,0 +1,33 @@
+//go:build linux || darwin
+
+package config
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+// statSnapshot is the fingerprint of the watched file compared by the
+// stat-poll fallback. The inode is included so atomic replacements that
+// preserve size and mtime (rename-over-target from a preserved-stat copy)
+// are still detected.
+type statSnapshot struct {
+	size int64
+	mod  time.Time
+	ino  uint64
+}
+
+// statSnapshotOf stats path, reporting ok=false when the file is absent or
+// unreadable. That transition is itself a change the poll must surface.
+func statSnapshotOf(path string) (statSnapshot, bool) {
+	st, err := os.Stat(path)
+	if err != nil {
+		return statSnapshot{}, false
+	}
+	snap := statSnapshot{size: st.Size(), mod: st.ModTime()}
+	if raw, ok := st.Sys().(*syscall.Stat_t); ok {
+		snap.ino = raw.Ino
+	}
+	return snap, true
+}

--- a/internal/config/watcher.go
+++ b/internal/config/watcher.go
@@ -77,6 +77,15 @@ type fsWatcher struct {
 	path   string
 	logger *slog.Logger
 
+	// Test hooks, nil/zero in production: statFn substitutes the stat
+	// read and tickInterval overrides pollInterval (scripting deterministic
+	// change interleavings); afterEmit runs between an emission and the
+	// post-emission stat — the exact window where a racing edit would
+	// otherwise be silently absorbed into the baseline.
+	statFn       func(path string) (statSnapshot, bool)
+	tickInterval time.Duration
+	afterEmit    func()
+
 	mu       sync.Mutex
 	fsw      *fsnotify.Watcher
 	events   chan Event
@@ -117,9 +126,18 @@ func (w *fsWatcher) startLocked(parent context.Context, fsw *fsnotify.Watcher) (
 
 	// Seed the poll fingerprint synchronously so an edit racing Watch's
 	// return cannot be absorbed into the baseline and missed by the ticker.
-	seed, seedOK := statSnapshotOf(w.path)
+	seed, seedOK := w.statFile()
 	go w.pump(ctx, seed, seedOK)
 	return out, nil
+}
+
+// statFile reads the watched file's poll fingerprint through statFn when a
+// test installed one, and through the real stat otherwise.
+func (w *fsWatcher) statFile() (statSnapshot, bool) {
+	if w.statFn != nil {
+		return w.statFn(w.path)
+	}
+	return statSnapshotOf(w.path)
 }
 
 // pump is the long-lived goroutine that converts fsnotify events on the
@@ -165,7 +183,11 @@ func (w *fsWatcher) pump(ctx context.Context, last statSnapshot, lastOK bool) {
 		}
 	}()
 
-	ticker := time.NewTicker(pollInterval)
+	interval := w.tickInterval
+	if interval <= 0 {
+		interval = pollInterval
+	}
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	for {
@@ -200,19 +222,28 @@ func (w *fsWatcher) pump(ctx context.Context, last statSnapshot, lastOK bool) {
 			// legitimate reload.
 			log.Warn("config watcher error", slog.Any("err", err))
 		case <-ticker.C:
-			cur, ok := statSnapshotOf(w.path)
+			cur, ok := w.statFile()
 			if ok != lastOK || cur != last {
 				last, lastOK = cur, ok
 				armDebounce()
 			}
 		case <-timerCh:
 			timerCh = nil
+			// Snapshot before reading so the baseline can only advance to
+			// a fingerprint whose content this emission actually read.
+			pre, preOK := w.statFile()
 			w.emitReload(ctx)
-			// Record the state that produced this emission so the next
-			// tick does not re-arm for a change the event path already
-			// handled.
-			if cur, ok := statSnapshotOf(w.path); ok {
-				last, lastOK = cur, ok
+			if w.afterEmit != nil {
+				w.afterEmit()
+			}
+			if post, postOK := w.statFile(); postOK != preOK || post != pre {
+				// The file changed while emitting. Leave the baseline at
+				// the last emitted state and re-arm: the newer version
+				// must be emitted too, never silently absorbed into the
+				// baseline.
+				armDebounce()
+			} else {
+				last, lastOK = pre, preOK
 			}
 		}
 	}

--- a/internal/config/watcher.go
+++ b/internal/config/watcher.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
 	"path/filepath"
 	"sync"
 	"time"
@@ -16,6 +18,13 @@ import (
 // Writes (in-place save); 100ms is long enough to merge those without
 // adding user-visible latency.
 const debounceWindow = 100 * time.Millisecond
+
+// pollInterval is how often the stat-poll fallback re-checks the watched
+// file. It runs unconditionally alongside the fsnotify watch so that both
+// inotify queue overflow (events lost) and silent watch death (the kernel
+// drops the parent-directory watch when it is replaced or removed, with no
+// error reported) still converge on a reload.
+const pollInterval = 5 * time.Second
 
 // ErrWatcherNotImplemented is retained for backwards compatibility with the
 // stub Watcher's signature. The fsnotify-backed implementation never
@@ -41,22 +50,32 @@ type Watcher interface {
 
 // NewWatcher returns a Watcher that observes path. The underlying fsnotify
 // watcher is bound to the parent directory (not the file) so atomic-save
-// flows (rename-over-target) survive without the watch dropping.
+// flows (rename-over-target) survive without the watch dropping. fsnotify
+// errors are discarded; use NewWatcherWithLogger to surface them.
 //
 // path is absolutised eagerly so the watcher does not silently track CWD
 // drift if the process chdirs (or if the user passed a bare filename from
 // a busy directory). filepath.Abs failures fall back to the input verbatim
 // — the subsequent fsnotify.Add will surface the underlying error.
 func NewWatcher(path string) Watcher {
+	return NewWatcherWithLogger(path, nil)
+}
+
+// NewWatcherWithLogger behaves like NewWatcher and additionally wires
+// logger into the watcher so fsnotify errors (e.g. inotify queue overflow)
+// are surfaced at Warn level instead of dropped. A nil logger discards all
+// output.
+func NewWatcherWithLogger(path string, logger *slog.Logger) Watcher {
 	abs, err := filepath.Abs(path)
 	if err == nil {
 		path = abs
 	}
-	return &fsWatcher{path: path}
+	return &fsWatcher{path: path, logger: logger}
 }
 
 type fsWatcher struct {
-	path string
+	path   string
+	logger *slog.Logger
 
 	mu       sync.Mutex
 	fsw      *fsnotify.Watcher
@@ -81,7 +100,13 @@ func (w *fsWatcher) Watch(parent context.Context) (<-chan Event, error) {
 		_ = fsw.Close()
 		return nil, fmt.Errorf("watch %s: %w", filepath.Dir(w.path), err)
 	}
+	return w.startLocked(parent, fsw)
+}
 
+// startLocked finishes wiring and launches pump. It expects w.mu held and is
+// split out so tests can inject a bare fsnotify watcher (e.g. one with no
+// registered watches, to exercise the stat-poll fallback in isolation).
+func (w *fsWatcher) startLocked(parent context.Context, fsw *fsnotify.Watcher) (<-chan Event, error) {
 	ctx, cancel := context.WithCancel(parent)
 	out := make(chan Event, 1)
 	w.fsw = fsw
@@ -90,17 +115,29 @@ func (w *fsWatcher) Watch(parent context.Context) (<-chan Event, error) {
 	w.closeCh = make(chan struct{})
 	w.pumpDone = make(chan struct{})
 
-	go w.pump(ctx)
+	// Seed the poll fingerprint synchronously so an edit racing Watch's
+	// return cannot be absorbed into the baseline and missed by the ticker.
+	seed, seedOK := statSnapshotOf(w.path)
+	go w.pump(ctx, seed, seedOK)
 	return out, nil
 }
 
 // pump is the long-lived goroutine that converts fsnotify events on the
-// parent directory into debounced Event values on the output channel. It
-// exits when the context is cancelled, Close is called, or the underlying
-// fsnotify watcher errors out fatally.
-func (w *fsWatcher) pump(ctx context.Context) {
+// parent directory into debounced Event values on the output channel. A
+// stat-poll ticker runs alongside the event stream so changes are still
+// detected when fsnotify events are lost to queue overflow or the watch
+// dies silently (the kernel removes a parent-directory watch on
+// IN_IGNORED/IN_DELETE_SELF without emitting an error). It exits when the
+// context is cancelled, Close is called, or the underlying fsnotify watcher
+// errors out fatally.
+func (w *fsWatcher) pump(ctx context.Context, last statSnapshot, lastOK bool) {
 	defer close(w.pumpDone)
 	defer close(w.events)
+
+	log := w.logger
+	if log == nil {
+		log = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
 
 	target := filepath.Clean(w.path)
 	var timer *time.Timer
@@ -128,6 +165,9 @@ func (w *fsWatcher) pump(ctx context.Context) {
 		}
 	}()
 
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -152,15 +192,28 @@ func (w *fsWatcher) pump(ctx context.Context) {
 				return
 			}
 			// fsnotify Errors are usually transient (Linux inotify queue
-			// overflow under filesystem pressure). Logging them at debug
-			// would require a logger here; we don't have one, so we just
-			// drop. We deliberately do NOT arm the debounce: under
-			// sustained pressure a stream of errors could otherwise reset
-			// the timer indefinitely and starve a legitimate reload.
-			_ = err
+			// overflow under filesystem pressure). Surface them: overflow
+			// means events were lost and only the stat poll below will
+			// recover the missed change. We deliberately do NOT arm the
+			// debounce here: under sustained pressure a stream of errors
+			// could otherwise reset the timer indefinitely and starve a
+			// legitimate reload.
+			log.Warn("config watcher error", slog.Any("err", err))
+		case <-ticker.C:
+			cur, ok := statSnapshotOf(w.path)
+			if ok != lastOK || cur != last {
+				last, lastOK = cur, ok
+				armDebounce()
+			}
 		case <-timerCh:
 			timerCh = nil
 			w.emitReload(ctx)
+			// Record the state that produced this emission so the next
+			// tick does not re-arm for a change the event path already
+			// handled.
+			if cur, ok := statSnapshotOf(w.path); ok {
+				last, lastOK = cur, ok
+			}
 		}
 	}
 }

--- a/internal/config/watcher_internal_test.go
+++ b/internal/config/watcher_internal_test.go
@@ -1,0 +1,167 @@
+package config
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/stretchr/testify/require"
+)
+
+const internalValidConfig = `
+token:
+  source: env
+  env_var: OP_SERVICE_ACCOUNT_TOKEN
+proxy:
+  listen: 127.0.0.1:1701
+  cache_ttl: 5m
+  on_no_match: passthrough
+rules:
+  - host: api.example.com
+    secret_ref: op://Vault/Item/field
+    inject:
+      type: header
+      name: x-api-key
+      template: "{{ CREDENTIAL }}"
+`
+
+const internalSecondValidConfig = `
+token:
+  source: env
+  env_var: OP_SERVICE_ACCOUNT_TOKEN
+proxy:
+  listen: 127.0.0.1:1701
+  cache_ttl: 5m
+  on_no_match: passthrough
+rules:
+  - host: api.anthropic.com
+    secret_ref: op://Agents/Anthropic/api_key
+    inject:
+      type: header
+      name: x-api-key
+      template: "{{ CREDENTIAL }}"
+`
+
+// syncBuffer is a goroutine-safe bytes.Buffer: the pump writes to it while
+// the test reads, and -race flags unsynchronized access.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+// TestWatcher_LogsFsnotifyErrors injects a synthetic error the way the
+// inotify backend would (e.g. ErrEventOverflow) and asserts it is surfaced
+// at Warn level and that the pump goroutine survives to keep reloading.
+func TestWatcher_LogsFsnotifyErrors(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(internalValidConfig), 0o600))
+
+	var buf syncBuffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	w := &fsWatcher{path: path, logger: logger}
+	fsw, err := fsnotify.NewWatcher()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = fsw.Close() })
+
+	events, err := w.startLocked(ctx, fsw)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	synthetic := fmt.Errorf("synthetic: %w", fsnotify.ErrEventOverflow)
+	select {
+	case fsw.Errors <- synthetic:
+	case <-time.After(time.Second):
+		t.Fatal("pump did not consume the injected error within 1s")
+	}
+
+	require.Eventually(t, func() bool {
+		for _, line := range strings.Split(buf.String(), "\n") {
+			if strings.Contains(line, "config watcher error") &&
+				strings.Contains(line, "level=WARN") &&
+				strings.Contains(line, "synthetic") {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond, "expected a Warn log for the injected error; got %q", buf.String())
+
+	// The pump must still be alive: a subsequent edit still reloads.
+	require.NoError(t, os.WriteFile(path, []byte(internalSecondValidConfig), 0o600))
+	select {
+	case ev := <-events:
+		require.NotNil(t, ev.New)
+		require.Equal(t, "api.anthropic.com", ev.New.Rules[0].Host)
+	case <-time.After(pollInterval + debounceWindow + 3*time.Second):
+		t.Fatal("pump died after fsnotify error: no reload event")
+	}
+}
+
+// TestWatcher_PollFallbackWithoutFsnotifyEvents starts the watcher against a
+// bare fsnotify watcher with no registered watches, so its Events channel
+// never delivers anything. A file modification must still produce a reload
+// via the stat-poll fallback alone.
+func TestWatcher_PollFallbackWithoutFsnotifyEvents(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(internalValidConfig), 0o600))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	fsw, err := fsnotify.NewWatcher() // no watches registered: Events never fires
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = fsw.Close() })
+
+	w := &fsWatcher{path: path}
+	events, err := w.startLocked(ctx, fsw)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	require.NoError(t, os.WriteFile(path, []byte(internalSecondValidConfig), 0o600))
+
+	select {
+	case ev := <-events:
+		require.NotNil(t, ev.New)
+		require.Empty(t, ev.Lints, "valid edit should emit no lints")
+		require.Equal(t, "api.anthropic.com", ev.New.Rules[0].Host)
+	case <-time.After(pollInterval + debounceWindow + 3*time.Second):
+		t.Fatal("stat-poll fallback did not fire a reload after a silent edit")
+	}
+
+	// No duplicate emission at the following tick: the poll fingerprint was
+	// refreshed when the reload was emitted.
+	select {
+	case extra := <-events:
+		t.Fatalf("unexpected duplicate reload event: %+v", extra)
+	case <-time.After(pollInterval + 500*time.Millisecond):
+	}
+}

--- a/internal/config/watcher_internal_test.go
+++ b/internal/config/watcher_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -19,14 +20,14 @@ import (
 const internalValidConfig = `
 token:
   source: env
-  env_var: OP_SERVICE_ACCOUNT_TOKEN
+  env_var: SERVICE_ACCOUNT_TOKEN
 proxy:
   listen: 127.0.0.1:1701
   cache_ttl: 5m
   on_no_match: passthrough
 rules:
-  - host: api.example.com
-    secret_ref: op://Vault/Item/field
+  - host: api.one.example
+    secret_ref: op://vault/items/one/credential
     inject:
       type: header
       name: x-api-key
@@ -36,14 +37,14 @@ rules:
 const internalSecondValidConfig = `
 token:
   source: env
-  env_var: OP_SERVICE_ACCOUNT_TOKEN
+  env_var: SERVICE_ACCOUNT_TOKEN
 proxy:
   listen: 127.0.0.1:1701
   cache_ttl: 5m
   on_no_match: passthrough
 rules:
-  - host: api.anthropic.com
-    secret_ref: op://Agents/Anthropic/api_key
+  - host: api.two.example
+    secret_ref: op://vault/items/two/credential
     inject:
       type: header
       name: x-api-key
@@ -117,7 +118,7 @@ func TestWatcher_LogsFsnotifyErrors(t *testing.T) {
 	select {
 	case ev := <-events:
 		require.NotNil(t, ev.New)
-		require.Equal(t, "api.anthropic.com", ev.New.Rules[0].Host)
+		require.Equal(t, "api.two.example", ev.New.Rules[0].Host)
 	case <-time.After(pollInterval + debounceWindow + 3*time.Second):
 		t.Fatal("pump died after fsnotify error: no reload event")
 	}
@@ -152,7 +153,7 @@ func TestWatcher_PollFallbackWithoutFsnotifyEvents(t *testing.T) {
 	case ev := <-events:
 		require.NotNil(t, ev.New)
 		require.Empty(t, ev.Lints, "valid edit should emit no lints")
-		require.Equal(t, "api.anthropic.com", ev.New.Rules[0].Host)
+		require.Equal(t, "api.two.example", ev.New.Rules[0].Host)
 	case <-time.After(pollInterval + debounceWindow + 3*time.Second):
 		t.Fatal("stat-poll fallback did not fire a reload after a silent edit")
 	}
@@ -163,5 +164,81 @@ func TestWatcher_PollFallbackWithoutFsnotifyEvents(t *testing.T) {
 	case extra := <-events:
 		t.Fatalf("unexpected duplicate reload event: %+v", extra)
 	case <-time.After(pollInterval + 500*time.Millisecond):
+	}
+}
+
+// TestWatcher_NoLostUpdateAcrossEmission reproduces, deterministically, the
+// interleaving where an edit lands after emitReload reads the file but
+// before the post-emission stat refreshes the poll baseline: the afterEmit
+// hook writes the new version inside exactly that window. The invariant
+// under test: every fingerprint admitted into the baseline belongs to a
+// version whose content was actually emitted — a version landing
+// mid-emission must be re-armed and emitted, never swallowed as "seen".
+func TestWatcher_NoLostUpdateAcrossEmission(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(internalValidConfig), 0o600))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	fsw, err := fsnotify.NewWatcher() // no watches registered: stat poll drives everything
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = fsw.Close() })
+
+	const thirdConfig = `
+token:
+  source: env
+  env_var: SERVICE_ACCOUNT_TOKEN
+proxy:
+  listen: 127.0.0.1:1701
+  cache_ttl: 5m
+  on_no_match: passthrough
+rules:
+  - host: api.three.example
+    secret_ref: op://vault/items/three/credential
+    inject:
+      type: header
+      name: x-api-key
+      template: "{{ CREDENTIAL }}"
+`
+
+	// tickInterval (500ms) > debounceWindow (100ms): the detection tick and
+	// the emission never overlap, keeping the event order deterministic.
+	var sneaked atomic.Bool
+	w := &fsWatcher{path: path, tickInterval: 500 * time.Millisecond}
+	w.afterEmit = func() {
+		if sneaked.CompareAndSwap(false, true) {
+			if err := os.WriteFile(path, []byte(thirdConfig), 0o600); err != nil {
+				t.Errorf("hook write failed: %v", err)
+			}
+		}
+	}
+
+	events, err := w.startLocked(ctx, fsw)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	// The poll baseline is seeded synchronously inside startLocked, so an
+	// edit written now is guaranteed to be a detected change, not baseline.
+	require.NoError(t, os.WriteFile(path, []byte(internalSecondValidConfig), 0o600))
+
+	ev := <-events
+	require.NotNil(t, ev.New)
+	require.Equal(t, "api.two.example", ev.New.Rules[0].Host,
+		"first emission must carry the content read at emission time")
+
+	// The version written inside the post-emission window must surface as
+	// its own reload; the buggy baseline refresh absorbed it unemitted and
+	// this receive timed out.
+	select {
+	case ev := <-events:
+		require.NotNil(t, ev.New)
+		require.Equal(t, "api.three.example", ev.New.Rules[0].Host,
+			"mid-emission edit must be emitted, not absorbed into the baseline")
+	case <-time.After(3 * time.Second):
+		t.Fatal("update landing across the emission boundary was lost")
 	}
 }

--- a/internal/config/watcher_test.go
+++ b/internal/config/watcher_test.go
@@ -201,3 +201,50 @@ func TestWatcher_ClosesCleanly(t *testing.T) {
 		t.Fatal("events channel did not close within 1s of Close()")
 	}
 }
+
+// TestWatcher_RecoversAfterWatchDeath covers the silent-death failure mode:
+// fsnotify removes a parent-directory watch without emitting any error when
+// the directory itself is deleted or replaced (IN_IGNORED / IN_DELETE_SELF).
+// The watcher keeps looking healthy but no events ever arrive again. The
+// stat-poll fallback must notice the next edit and still fire a reload.
+func TestWatcher_RecoversAfterWatchDeath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(watchedValidConfig), 0o600))
+
+	w := config.NewWatcher(path)
+	t.Cleanup(func() { _ = w.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	events, err := w.Watch(ctx)
+	require.NoError(t, err)
+
+	// Replace the watched directory out from under the watcher. The
+	// inotify watch dies silently; nothing is delivered afterwards.
+	require.NoError(t, os.RemoveAll(dir))
+	require.NoError(t, os.Mkdir(dir, 0o700))
+	writeAtomic(t, path, []byte(watchedSecondValidConfig))
+
+	// Bound: one poll interval to notice, plus the debounce window, plus
+	// scheduler slack. A tick landing inside the delete/recreate window can
+	// surface a transient missing-file lint first, so drain until the real
+	// reload arrives.
+	deadline := time.After(8 * time.Second) // one poll interval (5s) + debounce (100ms) + slack
+	for {
+		select {
+		case ev := <-events:
+			if ev.New == nil {
+				continue // transient unreadable-file lint; keep waiting
+			}
+			require.Len(t, ev.New.Rules, 1)
+			require.Equal(t, "api.anthropic.com", ev.New.Rules[0].Host)
+			return
+		case <-deadline:
+			t.Fatal("no reload event after watch death and edit")
+		}
+	}
+}


### PR DESCRIPTION
## Problem
Two verified hot-reload reliability defects:

1. **Silent error drop**: the pump drained fsnotify's Errors channel with `_ = err` (internal/config/watcher.go:150-160); inotify queue overflow (`ErrEventOverflow`) vanished without an operator signal.
2. **Permanent silent death**: fsnotify v1.10.1 removes a parent-directory watch silently on IN_IGNORED/IN_DELETE_SELF/IN_MOVE_SELF (backend_inotify.go:446-470), emitting no error. Postern watches the parent of config.yaml, so `rm -rf` or atomic replacement of ~/.postern/ ended hot reload forever: subsequent events never arrive and directory events are swallowed by the name filter while the op mask excludes Remove. The server kept serving stale rules behind a healthy-looking "hot reload enabled" log.

Overflow self-heals on the next edit; watch death does not. Severity LOW-to-MED, but the failure was invisible.

## Evidence
- internal/config/watcher.go:150-160 — errors dropped with `_ = err`, comment acknowledges it; no logger on the struct.
- internal/config/watcher.go:41-44,141-147 — parent-dir watch + name filter + op mask that together swallow the death scenario.
- Module cache github.com/fsnotify/fsnotify@v1.10.1/backend_inotify.go:446-470 — silent removal on IN_IGNORED/IN_DELETE_SELF/IN_MOVE_SELF.

## Changes
- Plumb an optional `*slog.Logger` into the watcher (`NewWatcherWithLogger`; nil discards via an io.Discard handler, matching internal/proxy/proxy.go:85-87 and internal/broker/hook.go:59-61). fsnotify errors are logged at Warn. The server wiring now passes its logger through.
- Add a 5s stat-poll fallback (package-level `pollInterval`): each tick stats the config file and arms the existing debounce path when size, mtime, or inode changes versus the last observed values (inode split per GOOS into stat_unix.go/stat_other.go). The fingerprint is seeded synchronously before the pump starts so an edit racing startup cannot be absorbed into the baseline, and refreshed at each emission so handled changes do not re-fire at the next tick. The poll runs unconditionally alongside the watch, covering both overflow gaps and dead watches.
- Deliberately out of scope (per brief): re-establishing the fsnotify watch, new config knobs, multiple paths.
- emitReload/debounce semantics untouched: still non-blocking with the freshest-state contract.
- Baseline invariant (review fix): the poll fingerprint is admitted into the baseline only when the post-emission stat matches the pre-emission snapshot, i.e. only for content that was actually emitted; a version landing mid-emission re-arms the debounce instead of being silently absorbed. `TestWatcher_NoLostUpdateAcrossEmission` reproduces the interleaving deterministically via `afterEmit`/`statFn`/`tickInterval` test seams (nil/zero in production) and was verified to fail against the old unconditional refresh.
- New watcher test fixtures use neutral literals (`SERVICE_ACCOUNT_TOKEN`, `op://vault/items/*`, `api.one/two/three.example`).

## Acceptance criteria (demonstrated by tests)
- Watch-death recovery: `TestWatcher_RecoversAfterWatchDeath` deletes and recreates the watched directory (killing the inotify watch silently), edits config.yaml, and asserts a reload fires within poll interval + debounce window.
- Error surfacing: `TestWatcher_LogsFsnotifyErrors` injects a synthetic error into the Errors channel and asserts a Warn log and that the pump survives.
- Poll fallback alone: `TestWatcher_PollFallbackWithoutFsnotifyEvents` runs against a bare fsnotify watcher with no registered watches; a file edit still triggers a reload within the same bound.
- All pre-existing watcher/config tests pass unchanged; full suite green under `-race`, plus watcher tests repeated 3x under the race detector.
