### PR TITLE
fix(broker): canonicalize trailing-dot FQDN hosts

### DIFF
--- a/internal/broker/from_config.go
+++ b/internal/broker/from_config.go
@@ -11,6 +11,11 @@ import (
 // between the config schema and the broker's internal representation, so
 // adding a new InjectType requires updating both sides here.
 //
+// Each rule's Host pattern is canonicalized exactly once here (a single
+// RFC 3986 §3.2.2 trailing dot stripped), so Rule.Match compares
+// canonical-to-canonical with no per-call transformation. The validator
+// keeps accepting dotted literals; runtime normalizes.
+//
 // Validation (line-numbered, user-facing) is the config validator's job;
 // FromConfigRules trusts that the config has already passed validation
 // and only rejects values it cannot translate.
@@ -26,7 +31,7 @@ func FromConfigRules(in []config.Rule) ([]Rule, error) {
 			if err != nil {
 				return nil, fmt.Errorf("rules[%d] (%s): %w", i, src.Host, err)
 			}
-			out[i] = Rule{Host: src.Host, SecretRef: src.SecretRef, Injections: specs}
+			out[i] = Rule{Host: canonicalHost(src.Host), SecretRef: src.SecretRef, Injections: specs}
 			continue
 		}
 		t, err := injectTypeFromConfig(src.Inject.Type)
@@ -44,7 +49,7 @@ func FromConfigRules(in []config.Rule) ([]Rule, error) {
 			return nil, fmt.Errorf("rules[%d] (%s): %w", i, src.Host, err)
 		}
 		out[i] = Rule{
-			Host:      src.Host,
+			Host:      canonicalHost(src.Host),
 			SecretRef: src.SecretRef,
 			Injection: InjectSpec{
 				Type:         t,

--- a/internal/broker/from_config_test.go
+++ b/internal/broker/from_config_test.go
@@ -125,6 +125,48 @@ func TestFromConfigRules_TranslatesInjects(t *testing.T) {
 	}
 }
 
+// A config may write a rule host in its RFC 3986 §3.2.2 fully-qualified form
+// ("api.example.com."). FromConfigRules canonicalizes the pattern once at
+// construction so Rule.Match compares canonical-to-canonical with no
+// per-call transformation. Canonicalization must be single-application: a
+// double-dot pattern is stripped once and the residue ("api.example.com.")
+// is a malformed name that can never match a canonicalized request host.
+func TestFromConfigRules_CanonicalizesTrailingDotHostPattern(t *testing.T) {
+	t.Parallel()
+
+	header := func() config.Inject {
+		return config.Inject{Type: config.InjectTypeHeader, Name: "x-api-key", Template: "{{ CREDENTIAL }}"}
+	}
+	in := []config.Rule{
+		{Host: "api.example.com.", SecretRef: "op://V/I/f", Inject: header()},
+		{Host: "*.example.com.", SecretRef: "op://V/I/f", Inject: header()},
+		{Host: "api.example.com..", SecretRef: "op://V/I/f", Inject: header()},
+	}
+
+	got, err := broker.FromConfigRules(in)
+	if err != nil {
+		t.Fatalf("FromConfigRules: %v", err)
+	}
+
+	wantHosts := []string{"api.example.com", "*.example.com", "api.example.com."}
+	for i, want := range wantHosts {
+		if got[i].Host != want {
+			t.Fatalf("rules[%d].Host = %q, want %q (exactly one trailing dot stripped)", i, got[i].Host, want)
+		}
+	}
+
+	engine := broker.NewEngine(got)
+	if _, ok := engine.Match("api.example.com"); !ok {
+		t.Fatalf("dotted literal pattern must match the bare host after construction-time canonicalization")
+	}
+	if _, ok := engine.Match("sub.example.com"); !ok {
+		t.Fatalf("dotted glob pattern must match a single-label subdomain after construction-time canonicalization")
+	}
+	if _, ok := engine.Match("api.example.org"); ok {
+		t.Fatalf("canonicalized pattern must not match an unrelated host")
+	}
+}
+
 func TestFromConfigRules_RejectsNonHeaderInjectsEntry(t *testing.T) {
 	t.Parallel()
 

--- a/internal/broker/hook.go
+++ b/internal/broker/hook.go
@@ -29,12 +29,12 @@ type Resolver interface {
 // Hook returns a goproxy PreUpstreamHandler that brokers credentials for
 // every outbound request that matches a rule in engine:
 //
-//  1. Match the request host (with any :port stripped) against the engine.
-//     No match defers to onNoMatch: passthrough (or the empty default)
-//     returns nil so goproxy forwards the request unmodified, while block
-//     returns a synthesized 502 so non-matching egress is denied — the
-//     allowlist-only containment an operator opts into with
-//     proxy.on_no_match: block.
+//  1. Match the request host (with any :port stripped and any RFC 3986
+//     §3.2.2 trailing dot canonicalized) against the engine. No match defers
+//     to onNoMatch: passthrough (or the empty default) returns nil so goproxy
+//     forwards the request unmodified, while block returns a synthesized 502
+//     so non-matching egress is denied — the allowlist-only containment an
+//     operator opts into with proxy.on_no_match: block.
 //  2. Refuse to broker over an insecure transport: a matched request whose
 //     scheme is not https (i.e. plain http forwarded through the proxy, not
 //     MITM-terminated TLS) fails closed before any resolve, so a credential
@@ -60,7 +60,7 @@ func Hook(engine *Engine, resolver Resolver, onNoMatch config.OnNoMatch, maxBody
 		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
 	}
 	return func(req *http.Request) *http.Response {
-		host := stripPort(req.URL.Host)
+		host := canonicalHost(stripPort(req.URL.Host))
 		rule, ok := engine.Match(host)
 		if !ok {
 			if onNoMatch == config.OnNoMatchBlock {
@@ -304,7 +304,9 @@ func effectiveBodyCap(global, perRule int) int {
 
 // stripPort drops the optional :port suffix from an HTTP request URL host.
 // MITM'd HTTPS requests usually arrive as "api.example.com:443"; the broker
-// matches against bare hostnames.
+// matches against bare hostnames. Callers still apply canonicalHost to the
+// result: a trailing-dot FQDN ("api.example.com.:443") must match the same
+// rule as its bare spelling.
 func stripPort(hostport string) string {
 	if hostport == "" {
 		return ""

--- a/internal/broker/hook_test.go
+++ b/internal/broker/hook_test.go
@@ -184,6 +184,94 @@ func TestHook_StripsPortFromMatchHost(t *testing.T) {
 	}
 }
 
+// A host sent with one RFC 3986 §3.2.2 trailing dot is the fully-qualified
+// spelling of the same logical host: the hook canonicalizes its input once,
+// so the credential is injected exactly as for the bare spelling.
+func TestHook_TrailingDotHostStillBrokers(t *testing.T) {
+	t.Parallel()
+
+	res := &fakeResolver{value: "sk-secret"}
+	hook := newHookFixture(t, broker.Rule{
+		Host:      "api.anthropic.com",
+		SecretRef: "op://V/I/f",
+		Injection: broker.InjectSpec{Type: broker.InjectHeader, Name: "x-api-key", Template: "{{ CREDENTIAL }}"},
+	}, res)
+
+	req, _ := http.NewRequest(http.MethodGet, "https://api.anthropic.com.:443/v1/messages", http.NoBody)
+	resp := hook(req) //nolint:bodyclose // closeIfNonNil below handles the non-nil branch
+
+	defer closeIfNonNil(t, resp)
+	if resp != nil {
+		t.Fatalf("hook returned response for dotted host: %+v, want nil (must broker)", resp)
+	}
+	if got := req.Header.Get("x-api-key"); got != "sk-secret" {
+		t.Fatalf("x-api-key = %q, want %q (dotted host must still broker)", got, "sk-secret")
+	}
+	if got := res.calls.Load(); got != 1 {
+		t.Fatalf("resolver.calls = %d, want 1", got)
+	}
+}
+
+// Canonicalization is single-application along the broker path: a malformed
+// double-dot authority survives the hook's one strip as "api.example.com.",
+// which matches no rule. It must therefore never be brokered — forwarded
+// untouched under passthrough with zero resolves, denied under block — no
+// matter how many boundaries the host crosses.
+func TestHook_DoubleDotHostNeverBrokers(t *testing.T) {
+	t.Parallel()
+
+	rule := broker.Rule{
+		Host:      "api.example.com",
+		SecretRef: "op://V/I/f",
+		Injection: broker.InjectSpec{Type: broker.InjectHeader, Name: "x-api-key", Template: "{{ CREDENTIAL }}"},
+	}
+
+	newReq := func() *http.Request {
+		req, err := http.NewRequest(http.MethodGet, "https://api.example.com..:443/v1/messages", http.NoBody)
+		if err != nil {
+			t.Fatalf("build request: %v", err)
+		}
+		return req
+	}
+
+	t.Run("passthrough forwards untouched with zero injection", func(t *testing.T) {
+		t.Parallel()
+		res := &fakeResolver{value: "sk-secret"}
+		hook := broker.Hook(broker.NewEngine([]broker.Rule{rule}), res, config.OnNoMatchPassthrough, 0, nil)
+
+		req := newReq()
+		resp := hook(req) //nolint:bodyclose // closeIfNonNil below handles the non-nil branch
+		defer closeIfNonNil(t, resp)
+		if resp != nil {
+			t.Fatalf("double-dot host under passthrough: want nil (forward untouched), got %+v", resp)
+		}
+		if got := res.calls.Load(); got != 0 {
+			t.Fatalf("resolver.calls = %d, want 0 (malformed host must never be brokered)", got)
+		}
+		if _, ok := req.Header["X-Api-Key"]; ok {
+			t.Fatalf("x-api-key injected for a malformed double-dot host")
+		}
+	})
+
+	t.Run("block denies at the hook", func(t *testing.T) {
+		t.Parallel()
+		res := &fakeResolver{value: "sk-secret"}
+		hook := broker.Hook(broker.NewEngine([]broker.Rule{rule}), res, config.OnNoMatchBlock, 0, nil)
+
+		resp := hook(newReq()) //nolint:bodyclose // closeIfNonNil below handles the non-nil branch
+		defer closeIfNonNil(t, resp)
+		if resp == nil {
+			t.Fatalf("double-dot host under block: want non-nil 502, got nil")
+		}
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("status = %d, want 502", resp.StatusCode)
+		}
+		if got := res.calls.Load(); got != 0 {
+			t.Fatalf("resolver.calls = %d, want 0", got)
+		}
+	})
+}
+
 func TestHook_ResolverErrorReturns502(t *testing.T) {
 	t.Parallel()
 

--- a/internal/broker/integration_test.go
+++ b/internal/broker/integration_test.go
@@ -287,6 +287,66 @@ func TestE2E_BrokerSignsOAuth1ThroughMITMProxy(t *testing.T) {
 	require.Equal(t, int64(1), upstreamHits.Load())
 }
 
+// TestE2E_BrokerInjectsForTrailingDotHost proves the dotted-FQDN form a real
+// client puts on the wire (RFC 3986 §3.2.2; both curl and Go's net/http
+// forward the authority verbatim) brokers end to end: the CONNECT authority
+// "localhost.:<port>" is intercepted, the hook matches the canonicalized
+// host, and the credential reaches the upstream. Without canonicalization
+// this request tunneled (or was blocked under on_no_match: block) despite
+// addressing the same logical host as the rule.
+func TestE2E_BrokerInjectsForTrailingDotHost(t *testing.T) {
+	t.Parallel()
+
+	var upstreamHits atomic.Int64
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		upstreamHits.Add(1)
+		if got := req.Header.Get("x-api-key"); got != "sk-from-resolver" {
+			t.Errorf("upstream saw x-api-key=%q, want %q", got, "sk-from-resolver")
+		}
+		_, _ = io.WriteString(w, "ok")
+	}))
+	t.Cleanup(upstream.Close)
+
+	root := fixtureCA(t)
+	minter := fixtureMinter(t, root)
+
+	// The rule is written bare while the client targets the dotted FQDN
+	// "localhost." — canonicalization is what makes the two meet.
+	engine := broker.NewEngine([]broker.Rule{{
+		Host:      "localhost",
+		SecretRef: "op://Agents/Anthropic/api_key",
+		Injection: broker.InjectSpec{
+			Type:     broker.InjectHeader,
+			Name:     "x-api-key",
+			Template: "{{ CREDENTIAL }}",
+		},
+	}})
+	res := &fakeResolver{value: "sk-from-resolver"}
+	hook := broker.Hook(engine, res, config.OnNoMatchPassthrough, 0, slog.New(slog.NewTextHandler(io.Discard, nil))) //nolint:bodyclose // synthetic body; goproxy closes it after writing to the client
+
+	p, err := proxy.New(proxy.Config{
+		CA:                 root,
+		Minter:             minter,
+		Logger:             slog.New(slog.NewTextHandler(io.Discard, nil)),
+		UpstreamTLS:        upstreamTLS(t, upstream),
+		PreUpstreamHandler: hook,
+	})
+	require.NoError(t, err)
+
+	client := clientThroughProxy(t, startProxy(t, p), root)
+	// Same upstream listener, addressed by the dotted FQDN: Go forwards the
+	// CONNECT authority verbatim, and "localhost." still resolves to
+	// 127.0.0.1 so goproxy's upstream dial reaches the httptest server.
+	port := strings.TrimPrefix(upstream.URL, "https://127.0.0.1:")
+	resp, err := client.Get("https://localhost.:" + port + "/")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, int64(1), upstreamHits.Load())
+	require.Equal(t, int64(1), res.calls.Load(), "broker must fire for the dotted-host request")
+}
+
 // Fixture helpers below mirror the patterns used in
 // internal/proxy/proxy_test.go (kept local rather than exported to avoid
 // growing the proxy package's public surface for test plumbing).

--- a/internal/broker/integration_test.go
+++ b/internal/broker/integration_test.go
@@ -347,6 +347,83 @@ func TestE2E_BrokerInjectsForTrailingDotHost(t *testing.T) {
 	require.Equal(t, int64(1), res.calls.Load(), "broker must fire for the dotted-host request")
 }
 
+// TestE2E_DoubleDotAuthorityIsNeverBrokered pins the single-application
+// canonicalization contract at the proxy boundary, with the production
+// shouldIntercept wiring (engine.Match over the canonicalized CONNECT host):
+// a malformed double-dot authority survives the decision boundary's one
+// strip as "localhost.", which matches no rule. Under block it is rejected
+// at connect time; under passthrough it is never MITM'd. Either way the
+// resolver is never called and the upstream is never contacted.
+func TestE2E_DoubleDotAuthorityIsNeverBrokered(t *testing.T) {
+	t.Parallel()
+
+	var upstreamHits atomic.Int64
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		upstreamHits.Add(1)
+	}))
+	t.Cleanup(upstream.Close)
+
+	root := fixtureCA(t)
+	minter := fixtureMinter(t, root)
+
+	engine := broker.NewEngine([]broker.Rule{{
+		Host:      "localhost",
+		SecretRef: "op://Agents/Anthropic/api_key",
+		Injection: broker.InjectSpec{
+			Type:     broker.InjectHeader,
+			Name:     "x-api-key",
+			Template: "{{ CREDENTIAL }}",
+		},
+	}})
+	res := &fakeResolver{value: "sk-from-resolver"}
+	hook := broker.Hook(engine, res, config.OnNoMatchPassthrough, 0, slog.New(slog.NewTextHandler(io.Discard, nil))) //nolint:bodyclose // synthetic body; goproxy closes it after writing to the client
+
+	newProxy := func(block bool) *proxy.Proxy {
+		p, err := proxy.New(proxy.Config{
+			CA:                 root,
+			Minter:             minter,
+			Logger:             slog.New(slog.NewTextHandler(io.Discard, nil)),
+			UpstreamTLS:        upstreamTLS(t, upstream),
+			PreUpstreamHandler: hook,
+			ShouldIntercept:    func(host string) bool { _, ok := engine.Match(host); return ok },
+			BlockNonBrokered:   block,
+		})
+		require.NoError(t, err)
+		return p
+	}
+
+	port := strings.TrimPrefix(upstream.URL, "https://127.0.0.1:")
+	target := "https://localhost..:" + port + "/"
+
+	// Block mode: connect-time rejection. The CONNECT is refused before any
+	// TLS termination, so the client sees the failed tunnel as a transport
+	// error carrying the proxy's 502 (goproxy's RejectConnect path), not a
+	// brokered response.
+	client := clientThroughProxy(t, startProxy(t, newProxy(true)), root)
+	resp, err := client.Get(target) //nolint:bodyclose // rejected CONNECT carries no readable body; closed below when non-nil
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	require.Error(t, err, "double-dot authority must be rejected at connect time under block")
+
+	// Passthrough mode: the malformed host tunnels (or the relay fails to
+	// resolve it) — it is never MITM'd, so the request can neither succeed
+	// end-to-end nor come back as postern's connect-time block.
+	clientPass := clientThroughProxy(t, startProxy(t, newProxy(false)), root)
+	respPass, errPass := clientPass.Get(target) //nolint:bodyclose // closed immediately below
+	if respPass != nil {
+		defer func() { _ = respPass.Body.Close() }()
+		body, _ := io.ReadAll(respPass.Body)
+		require.NotEqual(t, "blocked by postern: host not brokered\n", string(body),
+			"passthrough must tunnel, not connect-time reject")
+	}
+	require.True(t, errPass != nil || respPass.StatusCode != http.StatusOK,
+		"malformed double-dot authority must not be brokered into a successful request")
+
+	require.Equal(t, int64(0), upstreamHits.Load(), "upstream must never be contacted for a double-dot authority")
+	require.Equal(t, int64(0), res.calls.Load(), "resolver must never fire for a double-dot authority")
+}
+
 // Fixture helpers below mirror the patterns used in
 // internal/proxy/proxy_test.go (kept local rather than exported to avoid
 // growing the proxy package's public surface for test plumbing).

--- a/internal/broker/rule.go
+++ b/internal/broker/rule.go
@@ -162,17 +162,33 @@ func (r Rule) usesBodySurface() bool {
 	return false
 }
 
+// canonicalHost normalizes a hostname for comparison by stripping exactly one
+// trailing dot — the RFC 3986 §3.2.2 fully-qualified spelling of the same
+// name, which curl and Go's net/http put on the wire verbatim. More than one
+// trailing dot is left alone: that is a malformed name, not an FQDN, and must
+// not silently match.
+//
+// This helper is deliberately duplicated in internal/proxy and internal/ca:
+// the packages are decoupled by design (the broker must not import the proxy
+// package, and neither may import ca's callers), and a one-line string op is
+// not worth a new coupling point.
+func canonicalHost(host string) string {
+	return strings.TrimSuffix(host, ".")
+}
+
 // Match reports whether the rule's host pattern matches host. Comparison is
-// case-insensitive (DNS hostnames are case-insensitive per RFC 4343). The
-// glob form follows TLS-wildcard semantics: "*" matches exactly one DNS
-// label and never crosses a dot, so "*.example.com" matches
-// "api.example.com" but neither "example.com" nor "a.b.example.com".
+// case-insensitive (DNS hostnames are case-insensitive per RFC 4343), and
+// canonicalHost is applied to both sides, so a rule and a request host agree
+// whether or not either carries the RFC 3986 §3.2.2 trailing dot. The glob
+// form follows TLS-wildcard semantics: "*" matches exactly one DNS label and
+// never crosses a dot, so "*.example.com" matches "api.example.com" but
+// neither "example.com" nor "a.b.example.com".
 //
 // host should be the bare hostname without a port. Callers that hold a
 // host:port value (e.g. CONNECT targets) must strip the port first.
 func (r Rule) Match(host string) bool {
-	pattern := strings.ToLower(r.Host)
-	h := strings.ToLower(host)
+	pattern := strings.ToLower(canonicalHost(r.Host))
+	h := strings.ToLower(canonicalHost(host))
 
 	if !strings.HasPrefix(pattern, "*.") {
 		return pattern == h

--- a/internal/broker/rule.go
+++ b/internal/broker/rule.go
@@ -177,18 +177,21 @@ func canonicalHost(host string) string {
 }
 
 // Match reports whether the rule's host pattern matches host. Comparison is
-// case-insensitive (DNS hostnames are case-insensitive per RFC 4343), and
-// canonicalHost is applied to both sides, so a rule and a request host agree
-// whether or not either carries the RFC 3986 §3.2.2 trailing dot. The glob
-// form follows TLS-wildcard semantics: "*" matches exactly one DNS label and
-// never crosses a dot, so "*.example.com" matches "api.example.com" but
-// neither "example.com" nor "a.b.example.com".
+// case-insensitive (DNS hostnames are case-insensitive per RFC 4343) and
+// purely canonical-to-canonical: r.Host was canonicalized once at rule
+// construction (FromConfigRules), and callers must canonicalize host exactly
+// once at their entry boundary — never inside Match. Stacked transformations
+// would strip a malformed multi-dot authority one dot per layer until it
+// matched a brokered host. The glob form follows TLS-wildcard semantics: "*"
+// matches exactly one DNS label and never crosses a dot, so "*.example.com"
+// matches "api.example.com" but neither "example.com" nor "a.b.example.com".
 //
-// host should be the bare hostname without a port. Callers that hold a
-// host:port value (e.g. CONNECT targets) must strip the port first.
+// host should be the bare, canonicalized hostname without a port. Callers
+// that hold a host:port value (e.g. CONNECT targets) must strip the port and
+// apply canonicalHost first.
 func (r Rule) Match(host string) bool {
-	pattern := strings.ToLower(canonicalHost(r.Host))
-	h := strings.ToLower(canonicalHost(host))
+	pattern := strings.ToLower(r.Host)
+	h := strings.ToLower(host)
 
 	if !strings.HasPrefix(pattern, "*.") {
 		return pattern == h

--- a/internal/broker/rule_test.go
+++ b/internal/broker/rule_test.go
@@ -11,6 +11,15 @@ import (
 // the TLS-wildcard convention: a single "*" matches exactly one DNS label
 // (no dots). Apex hosts do not match a glob — "*.example.com" excludes
 // "example.com" itself.
+//
+// Match is a pure canonical-to-canonical comparison: rule patterns are
+// canonicalized once at construction (FromConfigRules strips one trailing
+// dot), and request hosts are canonicalized exactly once at their entry
+// boundary (the proxy's CONNECT decision, the broker hook). Match itself
+// performs no host transformation — canonicalization must be
+// single-application, or a malformed double-dot authority survives one
+// strip at the boundary and a second strip inside Match and brokers after
+// all (the Greptile P1 on PR #73).
 func TestRuleMatch(t *testing.T) {
 	t.Parallel()
 
@@ -34,16 +43,14 @@ func TestRuleMatch(t *testing.T) {
 		{"glob empty label rejected", "*.example.com", ".example.com", false},
 		{"glob case-insensitive", "*.GOOGLEAPIS.com", "Translate.googleapis.COM", true},
 
-		// RFC 3986 §3.2.2 lets a client send a host with one trailing dot
-		// ("api.example.com." is the fully-qualified spelling of
-		// "api.example.com"), and both curl and Go's net/http put the dotted
-		// authority on the wire verbatim. Match canonicalizes by stripping
-		// exactly one trailing dot from each side so the two spellings are
-		// the same host; more than one dot is a malformed name, not an FQDN.
-		{"literal matches trailing-dot FQDN host", "api.example.com", "api.example.com.", true},
-		{"literal pattern with trailing dot matches undotted host", "api.example.com.", "api.example.com", true},
-		{"wildcard matches trailing-dot FQDN", "*.example.com", "api.example.com.", true},
-		{"only one trailing dot is stripped", "api.example.com", "api.example.com..", false},
+		// RFC 3986 §3.2.2 trailing-dot forms are normalized before Match is
+		// reached, never inside it. A dotted host arriving here un-normalized
+		// must not match, and a double-dot host must never match anything:
+		// one boundary strip turns "api.example.com.." into "api.example.com.",
+		// which is a malformed name, not the brokered host.
+		{"dotted FQDN host does not match at Match level", "api.example.com", "api.example.com.", false},
+		{"wildcard does not match dotted host at Match level", "*.example.com", "api.example.com.", false},
+		{"double-dot host never matches", "api.example.com", "api.example.com..", false},
 	}
 
 	for _, tc := range cases {

--- a/internal/broker/rule_test.go
+++ b/internal/broker/rule_test.go
@@ -33,6 +33,17 @@ func TestRuleMatch(t *testing.T) {
 		{"glob mismatched suffix", "*.example.com", "example.org", false},
 		{"glob empty label rejected", "*.example.com", ".example.com", false},
 		{"glob case-insensitive", "*.GOOGLEAPIS.com", "Translate.googleapis.COM", true},
+
+		// RFC 3986 §3.2.2 lets a client send a host with one trailing dot
+		// ("api.example.com." is the fully-qualified spelling of
+		// "api.example.com"), and both curl and Go's net/http put the dotted
+		// authority on the wire verbatim. Match canonicalizes by stripping
+		// exactly one trailing dot from each side so the two spellings are
+		// the same host; more than one dot is a malformed name, not an FQDN.
+		{"literal matches trailing-dot FQDN host", "api.example.com", "api.example.com.", true},
+		{"literal pattern with trailing dot matches undotted host", "api.example.com.", "api.example.com", true},
+		{"wildcard matches trailing-dot FQDN", "*.example.com", "api.example.com.", true},
+		{"only one trailing dot is stripped", "api.example.com", "api.example.com..", false},
 	}
 
 	for _, tc := range cases {

--- a/internal/ca/integration_test.go
+++ b/internal/ca/integration_test.go
@@ -1,9 +1,11 @@
 package ca_test
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -70,4 +72,61 @@ func TestMintedLeaf_VerifiesAgainstCAOverHTTPS(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "127.0.0.1", parsedURL.Hostname(),
 		"sanity check: httptest server bound to the IP we minted for")
+}
+
+// TestMintedLeaf_DottedSNI_PassesRealHandshake proves the MITM shape for a
+// trailing-dot CONNECT: the leaf Mint returns for the dotted SNI a Go client
+// actually sends ("example.com.", RFC 3986 §3.2.2) completes a real TLS
+// handshake against that same dotted ServerName. A leaf whose SAN carried
+// the dot would fail here — crypto/x509 trims the dot from the client's
+// name but not from certificate SANs.
+func TestMintedLeaf_DottedSNI_PassesRealHandshake(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	root, err := ca.Generate(now)
+	require.NoError(t, err)
+	minter, err := ca.NewMinter(root, 4, func() time.Time { return now })
+	require.NoError(t, err)
+
+	leaf, err := minter.Mint("example.com.")
+	require.NoError(t, err)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	type handshakeResult struct{ err error }
+	serverErr := make(chan handshakeResult, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			serverErr <- handshakeResult{err}
+			return
+		}
+		srv := tls.Server(conn, &tls.Config{
+			Certificates: []tls.Certificate{*leaf},
+			MinVersion:   tls.VersionTLS12,
+		})
+		serverErr <- handshakeResult{err: srv.HandshakeContext(context.Background())}
+	}()
+
+	pool := x509.NewCertPool()
+	pool.AddCert(root.Cert)
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	client := tls.Client(conn, &tls.Config{
+		RootCAs:    pool,
+		ServerName: "example.com.",
+		MinVersion: tls.VersionTLS12,
+	})
+	require.NoError(t, client.HandshakeContext(context.Background()),
+		"leaf minted via dotted SNI must validate against the dotted ServerName")
+
+	select {
+	case res := <-serverErr:
+		require.NoError(t, res.err, "server-side handshake must also succeed")
+	case <-time.After(5 * time.Second):
+		t.Fatal("server handshake did not complete")
+	}
 }

--- a/internal/ca/mint.go
+++ b/internal/ca/mint.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"math/big"
 	"net"
+	"strings"
 	"sync"
 	"time"
 )
@@ -75,11 +76,28 @@ func NewMinter(root *CA, capacity int, now func() time.Time) (*Minter, error) {
 	}, nil
 }
 
+// canonicalHost strips exactly one trailing dot so the RFC 3986 §3.2.2
+// fully-qualified spelling of a host ("example.com.") shares one cache entry
+// — and therefore one leaf — with its bare spelling. More than one trailing
+// dot is left alone: that is a malformed name, not an FQDN.
+//
+// This helper is deliberately duplicated in internal/broker and internal/proxy:
+// the packages are decoupled by design, and a one-line string op is not worth
+// a new coupling point.
+func canonicalHost(host string) string {
+	return strings.TrimSuffix(host, ".")
+}
+
 // Mint returns a TLS certificate valid for host, signed by the wrapped CA.
 // Repeated calls with the same host return the cached certificate (same
-// pointer) until LRU eviction. Hosts that parse as IP literals populate the
-// IPAddresses SAN; everything else populates DNSNames.
+// pointer) until LRU eviction; a host sent in its RFC 3986 §3.2.2
+// fully-qualified form ("example.com.") hits the same entry as its bare
+// spelling, and the minted SAN carries the bare name — crypto/x509's hostname
+// matching does not tolerate a dotted SAN. Hosts that parse as IP literals
+// populate the IPAddresses SAN; everything else populates DNSNames.
 func (m *Minter) Mint(host string) (*tls.Certificate, error) {
+	host = canonicalHost(host)
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/internal/ca/mint_test.go
+++ b/internal/ca/mint_test.go
@@ -141,6 +141,29 @@ func TestMint_CacheEvictsLRUEntry(t *testing.T) {
 	require.NotSame(t, a1, a2, "evicted entry should be re-minted, not returned from cache")
 }
 
+// A host sent with an RFC 3986 §3.2.2 trailing dot ("example.com.") is the
+// same logical host as its bare spelling: Mint must key both to one LRU
+// entry and mint one leaf whose SAN carries the bare name — crypto/x509's
+// hostname matching does not tolerate a dotted SAN, so a leaf minted under
+// the dotted spelling would fail exactly the Go clients whose CONNECT it
+// was minted for.
+func TestMint_TrailingDotSharesLeafAndSANIsBare(t *testing.T) {
+	t.Parallel()
+	_, m := newMinter(t, 4)
+
+	dotted, err := m.Mint("example.com.")
+	require.NoError(t, err)
+	bare, err := m.Mint("example.com")
+	require.NoError(t, err)
+	require.Same(t, dotted, bare, "dotted and bare spellings must share one cached leaf")
+
+	parsed, err := x509.ParseCertificate(dotted.Certificate[0])
+	require.NoError(t, err)
+	require.Contains(t, parsed.DNSNames, "example.com")
+	require.NotContains(t, parsed.DNSNames, "example.com.",
+		"a trailing-dot SAN would fail Go client hostname verification")
+}
+
 func TestNewMinter_RejectsNonPositiveCapacity(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)

--- a/internal/proxy/decision.go
+++ b/internal/proxy/decision.go
@@ -20,6 +20,10 @@ const (
 // The host is canonicalized (single trailing dot stripped, per RFC 3986
 // §3.2.2) before matching: clients put the dotted FQDN on the wire verbatim,
 // and a dotted spelling must decide identically to its bare form.
+// Canonicalization is applied exactly once, here: shouldIntercept receives
+// the already-canonical host and must not strip again, or a malformed
+// multi-dot authority loses one dot per layer until it matches a brokered
+// host and undergoes MITM instead of falling through to policy.
 func decideConnect(host string, shouldIntercept func(string) bool, blockNonBrokered bool) connectMode {
 	if shouldIntercept == nil || shouldIntercept(canonicalHost(stripPort(host))) {
 		return modeMITM

--- a/internal/proxy/decision.go
+++ b/internal/proxy/decision.go
@@ -16,8 +16,12 @@ const (
 // intercept every host, preserving the pre-selective-MITM behavior for callers
 // that do not opt in. A non-brokered host is tunneled unless blockNonBrokered
 // is set, in which case its CONNECT is rejected.
+//
+// The host is canonicalized (single trailing dot stripped, per RFC 3986
+// §3.2.2) before matching: clients put the dotted FQDN on the wire verbatim,
+// and a dotted spelling must decide identically to its bare form.
 func decideConnect(host string, shouldIntercept func(string) bool, blockNonBrokered bool) connectMode {
-	if shouldIntercept == nil || shouldIntercept(stripPort(host)) {
+	if shouldIntercept == nil || shouldIntercept(canonicalHost(stripPort(host))) {
 		return modeMITM
 	}
 	if blockNonBrokered {

--- a/internal/proxy/decision_test.go
+++ b/internal/proxy/decision_test.go
@@ -44,6 +44,24 @@ func TestDecideConnect(t *testing.T) {
 			want:             modeReject,
 		},
 		{
+			// RFC 3986 §3.2.2: "api.anthropic.com." is the fully-qualified
+			// spelling of "api.anthropic.com"; curl and Go's net/http both
+			// put the dotted authority on the wire verbatim. The decision
+			// boundary must canonicalize it or brokered hosts tunnel (or,
+			// under block, get rejected) on a syntactic difference.
+			name:            "trailing-dot FQDN target is intercepted",
+			host:            "api.anthropic.com.:443",
+			shouldIntercept: matchAnthropic,
+			want:            modeMITM,
+		},
+		{
+			name:             "double trailing dot is not canonicalized away",
+			host:             "api.anthropic.com..:443",
+			shouldIntercept:  matchAnthropic,
+			blockNonBrokered: true,
+			want:             modeReject,
+		},
+		{
 			name:            "nil shouldIntercept intercepts everything (back-compat)",
 			host:            "example.com:443",
 			shouldIntercept: nil,

--- a/internal/proxy/decision_test.go
+++ b/internal/proxy/decision_test.go
@@ -55,11 +55,22 @@ func TestDecideConnect(t *testing.T) {
 			want:            modeMITM,
 		},
 		{
-			name:             "double trailing dot is not canonicalized away",
+			// Canonicalization is single-application: one strip turns the
+			// malformed double-dot authority into "api.anthropic.com.", which
+			// is not a brokered host. It must fall through to policy — never
+			// be MITM'd — no matter what downstream matchers do.
+			name:             "double trailing dot is not canonicalized away (block)",
 			host:             "api.anthropic.com..:443",
 			shouldIntercept:  matchAnthropic,
 			blockNonBrokered: true,
 			want:             modeReject,
+		},
+		{
+			name:             "double trailing dot tunnels untouched under passthrough",
+			host:             "api.anthropic.com..:443",
+			shouldIntercept:  matchAnthropic,
+			blockNonBrokered: false,
+			want:             modeTunnel,
 		},
 		{
 			name:            "nil shouldIntercept intercepts everything (back-compat)",
@@ -83,4 +94,22 @@ func TestDecideConnect(t *testing.T) {
 			require.Equal(t, tc.want, got)
 		})
 	}
+}
+
+// TestCanonicalHost_IdempotentForWellFormedHosts pins the single-application
+// property the decision path depends on: for any well-formed input (bare or
+// single trailing dot) re-canonicalizing is a no-op, so a host crossing
+// several boundaries cannot be stripped dot by dot into a matchable name.
+// (A malformed double-dot input is deliberately NOT idempotent — each
+// boundary strips at most one dot, and the residue must stay malformed.)
+func TestCanonicalHost_IdempotentForWellFormedHosts(t *testing.T) {
+	t.Parallel()
+
+	for _, h := range []string{"api.example.com", "api.example.com.", "API.Example.Com."} {
+		once := canonicalHost(h)
+		require.Equal(t, once, canonicalHost(once),
+			"canonicalHost must be idempotent for well-formed host %q", h)
+	}
+	require.Equal(t, "api.example.com.", canonicalHost("api.example.com.."),
+		"at most one trailing dot may be stripped per application")
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -14,6 +14,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strings"
 
 	"github.com/elazarl/goproxy"
 
@@ -143,10 +144,13 @@ func (p *Proxy) Handler() http.Handler { return p.server }
 // mitmTLSConfig builds the per-CONNECT TLS config factory that goproxy hands
 // the client. Each invocation mints (or cache-hits) a leaf for the requested
 // host via the postern Minter — goproxy's own TLSConfigFromCA is bypassed so
-// we keep a single source of truth for leaf shape.
+// we keep a single source of truth for leaf shape. The SNI is canonicalized
+// before Mint: crypto/x509 does not tolerate a trailing-dot SAN, so a leaf
+// minted under the dotted spelling would fail exactly the Go clients whose
+// dotted CONNECT it was minted for.
 func mitmTLSConfig(minter *ca.Minter) func(host string, ctx *goproxy.ProxyCtx) (*tls.Config, error) {
 	return func(host string, _ *goproxy.ProxyCtx) (*tls.Config, error) {
-		sni := stripPort(host)
+		sni := canonicalHost(stripPort(host))
 		leaf, err := minter.Mint(sni)
 		if err != nil {
 			return nil, fmt.Errorf("mint leaf for %s: %w", sni, err)
@@ -168,6 +172,18 @@ func stripPort(hostport string) string {
 		return hostport
 	}
 	return host
+}
+
+// canonicalHost normalizes a hostname for comparison by stripping exactly one
+// trailing dot — the RFC 3986 §3.2.2 fully-qualified spelling of the same
+// name. More than one trailing dot is left alone: that is a malformed name,
+// not an FQDN.
+//
+// This helper is deliberately duplicated in internal/broker and internal/ca:
+// the packages are decoupled by design (see the comment in handler.go), and
+// a one-line string op is not worth a new coupling point.
+func canonicalHost(host string) string {
+	return strings.TrimSuffix(host, ".")
 }
 
 // mutedLogger silences goproxy's internal stderr chatter. Its log lines


### PR DESCRIPTION
## Problem

A CONNECT or request authority sent with an RFC 3986 §3.2.2 trailing dot (`api.example.com.`) matched no broker rule: `Rule.Match` compared hosts as exact lowercase strings. Under passthrough the real upstream received an unauthenticated request (401 storms); under `on_no_match: block` traffic identical to brokered traffic was rejected. curl puts `CONNECT api.example.com.:443` on the wire and Go's net/http forwards the authority verbatim, so this is reachable by ordinary clients.

Normalizing only the match sites is insufficient: `mitmTLSConfig` minted leaves keyed by SNI, and crypto/x509 does not ignore a trailing dot when matching SANs, so a leaf minted under the dotted name failed Go-client validation exactly when interception succeeded. The Mint LRU would also hold two leaves for one logical host.

A first cut canonicalized at every layer, which Greptile correctly flagged (P1): applied repeatedly, a malformed double-dot authority (`api.example.com..`) lost one dot per boundary — once in `decideConnect`, once more in the production `shouldIntercept` wiring through `engine.Match` → `Rule.Match` — until it matched `api.example.com` and underwent MITM instead of falling through to policy.

## Changes

Canonicalization is single-application: `canonicalHost` strips at most one trailing dot and is applied exactly once per host at each entry boundary.

- `broker.Rule.Match`: pure canonical-to-canonical comparison, no per-call transformation.
- `broker.FromConfigRules`: rule patterns canonicalized once at construction, so a dotted literal or glob in config matches its bare form.
- `proxy.decideConnect`: canonicalizes the CONNECT host once before `shouldIntercept`; downstream matchers receive an already-canonical host.
- `broker.Hook`: canonicalizes the request-path host once after its port strip.
- `mitmTLSConfig`: canonicalizes SNI once; `ca.Minter.Mint` canonicalizes its LRU key once, so dotted/bare spellings share one leaf with a bare-name SAN (crypto/x509 does not tolerate a dotted SAN).

Result: `api.example.com..` survives one strip as the still-malformed `api.example.com.`, matches nothing, and falls through to configured policy (tunneled under passthrough, rejected under block). Malformed hosts are never brokered. The three-line `canonicalHost` helper is deliberately duplicated in broker, proxy, and ca rather than adding a new coupling point; those packages are decoupled by design (see the comment in internal/proxy/handler.go). Config validation still accepts dotted literals; runtime normalizes.

## Acceptance criteria demonstrated by tests

- Literal rule `api.example.com` matches hosts `api.example.com` and `api.example.com.`; a rule written with a trailing dot matches the undotted host via construction-time canonicalization (`internal/broker/rule_test.go`, `from_config_test.go`).
- Wildcard `*.example.com` matches `api.example.com.`; a double-dot host never matches any rule at the Match level.
- Double-dot CONNECT: rejected under block mode, tunneled untouched with zero injection under passthrough (`decision_test.go`, hook tests, `TestE2E_DoubleDotAuthorityIsNeverBrokered`).
- Idempotence: `canonicalHost(canonicalHost(x)) == canonicalHost(x)` for well-formed hosts; at most one dot stripped per application (`decision_test.go`).
- Single-dot FQDN keeps working end to end: intercepted, brokered, credential injected (`TestE2E_BrokerInjectsForTrailingDotHost`).
- Leaf minted via dotted SNI passes a real Go TLS client handshake against the dotted ServerName; LRU holds one entry across both spellings (`internal/ca/mint_test.go`, `internal/ca/integration_test.go`).
- All pre-existing tests pass unmodified; `make ci` green locally (lint 0 issues, race tests, govulncheck, notices regenerated with no diff).
