### PR TITLE
fix(proxy): track hijacked conns, reap stalled/idle tunnels, drain bounded at shutdown

### DIFF
--- a/internal/runtime/conntrack.go
+++ b/internal/runtime/conntrack.go
@@ -41,6 +41,17 @@ const (
 	// bytes within seconds, so a conn still under this total after
 	// stalledConnTimeout is stalled by definition; raw-tunnel peers and
 	// handshakes cross it immediately.
+	//
+	// The threshold is a heuristic, not a security boundary: any fixed byte
+	// count admits padding, so a hostile client can cross 128 bytes and
+	// then stall, landing in the 10m tier. This is accepted deliberately.
+	// A padded but VALID TLS ClientHello produces a genuinely established
+	// tunnel — the real upstream responds — and the activity-based 10m
+	// idle tier is the correct bound for it, matching standard L4-proxy
+	// idle semantics. Padded garbage is rejected by the upstream and the
+	// relay error closes the conn naturally. The threat model
+	// (docs/security.md) treats agents as local or LAN-scoped, and the
+	// per-conn cost stays bounded by the tier-2 ceiling either way.
 	minProgressBytes = 128
 )
 

--- a/internal/runtime/conntrack.go
+++ b/internal/runtime/conntrack.go
@@ -1,0 +1,202 @@
+package runtime
+
+import (
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Reap thresholds for hijacked connections. goproxy hijacks every CONNECT,
+// and after Hijack net/http clears all deadlines on the conn — the MITM
+// handshake runs on context.Background and tunnel relays loop deadline-free
+// — so a stalled client or upstream would otherwise pin a goroutine and an
+// fd forever. Deadlines here are ACTIVITY-based, not fixed read deadlines:
+// any successful Read or Write resets the timer, so a live SSE stream is
+// never cut mid-flight.
+const (
+	// stalledConnTimeout reaps conns that have never successfully read a
+	// byte since accept (stalled TLS handshakes, silent slowloris clients).
+	// 30s matches the server's ReadHeaderTimeout order of magnitude: far
+	// more generous than any legitimate client needs to send its first
+	// bytes, short enough that stalled conns cannot accumulate.
+	stalledConnTimeout = 30 * time.Second
+
+	// tunnelIdleTimeout reaps established conns after sustained inactivity
+	// in BOTH directions. 10m tolerates legitimately quiet long-lived
+	// tunnels (idle websockets, paused streams) while still bounding leak
+	// lifetime; anything emitting keepalives more often than that — which
+	// every real protocol does — is never touched.
+	tunnelIdleTimeout = 10 * time.Minute
+
+	// reapInterval is how often the reaper scans. Eviction latency is at
+	// worst reapInterval + threshold; 30s keeps that bound negligible
+	// relative to the thresholds while making the scan cost invisible.
+	reapInterval = 30 * time.Second
+)
+
+// halfClosable mirrors goproxy's unexported interface of the same name.
+// goproxy type-asserts hijacked conns to it to give raw tunnels half-close
+// semantics; a wrapper that dropped CloseWrite/CloseRead would silently
+// demote every tunnel to goproxy's degraded no-half-close relay path, so
+// trackedConn must implement it fully.
+type halfClosable interface {
+	net.Conn
+	CloseWrite() error
+	CloseRead() error
+}
+
+var _ halfClosable = (*trackedConn)(nil)
+
+// trackedConn wraps an accepted conn for lifecycle tracking. Activity
+// timestamps are updated by Read/Write; the reaper and the shutdown drain
+// close stale entries through Close, which unblocks whatever goroutine
+// (goproxy's copyAndClose/copyOrWarn relays, the MITM read loop) is parked
+// inside the conn.
+type trackedConn struct {
+	net.Conn
+
+	reg *connRegistry
+
+	accepted     time.Time    // fixed at track time; tier-1 clock start
+	lastActivity atomic.Int64 // unix nanos of last successful Read/Write
+	readAny      atomic.Bool  // any byte ever read since accept
+	closeOnce    sync.Once
+	half         halfClosable // non-nil when the underlying conn half-closes
+}
+
+func (c *trackedConn) Read(p []byte) (int, error) {
+	n, err := c.Conn.Read(p)
+	if n > 0 {
+		c.readAny.Store(true)
+		c.markActive()
+	}
+	return n, err
+}
+
+func (c *trackedConn) Write(p []byte) (int, error) {
+	n, err := c.Conn.Write(p)
+	if n > 0 {
+		c.markActive()
+	}
+	return n, err
+}
+
+func (c *trackedConn) markActive() { c.lastActivity.Store(time.Now().UnixNano()) }
+
+func (c *trackedConn) Close() error {
+	var err error
+	c.closeOnce.Do(func() {
+		c.reg.remove(c)
+		err = c.Conn.Close()
+	})
+	return err
+}
+
+// CloseWrite forwards half-close so goproxy's halfClosable assertion holds
+// and raw tunnels keep their clean-EOF semantics. The fallback returns nil
+// rather than an error only because listener-accepted TCP conns always
+// support half-close; a non-TCP underlying conn never occurs on this path.
+func (c *trackedConn) CloseWrite() error {
+	if c.half != nil {
+		return c.half.CloseWrite()
+	}
+	return nil
+}
+
+func (c *trackedConn) CloseRead() error {
+	if c.half != nil {
+		return c.half.CloseRead()
+	}
+	return nil
+}
+
+// idleFor reports how long the conn has been quiet and whether it counts as
+// zero-progress (never read anything — tier-1) or established (tier-2).
+func (c *trackedConn) idleFor(now time.Time) (d time.Duration, zeroProgress bool) {
+	if !c.readAny.Load() {
+		return now.Sub(c.accepted), true
+	}
+	return now.Sub(time.Unix(0, c.lastActivity.Load())), false
+}
+
+// connRegistry tracks live accepted conns. It doubles as the shutdown drain
+// barrier: Run waits on count() reaching zero before force-closing stragglers.
+type connRegistry struct {
+	mu    sync.Mutex
+	conns map[*trackedConn]struct{}
+}
+
+func newConnRegistry() *connRegistry {
+	return &connRegistry{conns: make(map[*trackedConn]struct{})}
+}
+
+func (r *connRegistry) track(c net.Conn) *trackedConn {
+	t := &trackedConn{
+		Conn:     c,
+		reg:      r,
+		accepted: time.Now(),
+	}
+	t.lastActivity.Store(t.accepted.UnixNano())
+	if hc, ok := c.(halfClosable); ok {
+		t.half = hc
+	}
+	r.mu.Lock()
+	r.conns[t] = struct{}{}
+	r.mu.Unlock()
+	return t
+}
+
+func (r *connRegistry) remove(c *trackedConn) {
+	r.mu.Lock()
+	delete(r.conns, c)
+	r.mu.Unlock()
+}
+
+func (r *connRegistry) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.conns)
+}
+
+// each runs fn over a snapshot of live conns.
+func (r *connRegistry) each(fn func(*trackedConn)) {
+	r.mu.Lock()
+	snapshot := make([]*trackedConn, 0, len(r.conns))
+	for c := range r.conns {
+		snapshot = append(snapshot, c)
+	}
+	r.mu.Unlock()
+	for _, c := range snapshot {
+		fn(c)
+	}
+}
+
+// closeAll force-closes every tracked conn and returns how many were closed.
+func (r *connRegistry) closeAll() int {
+	r.mu.Lock()
+	victims := make([]*trackedConn, 0, len(r.conns))
+	for c := range r.conns {
+		victims = append(victims, c)
+	}
+	r.mu.Unlock()
+	for _, c := range victims {
+		_ = c.Close()
+	}
+	return len(victims)
+}
+
+// trackingListener wraps the accept path so every inbound conn enters the
+// registry as a trackedConn.
+type trackingListener struct {
+	net.Listener
+	reg *connRegistry
+}
+
+func (l *trackingListener) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	return l.reg.track(c), nil
+}

--- a/internal/runtime/conntrack.go
+++ b/internal/runtime/conntrack.go
@@ -15,11 +15,12 @@ import (
 // any successful Read or Write resets the timer, so a live SSE stream is
 // never cut mid-flight.
 const (
-	// stalledConnTimeout reaps conns that have never successfully read a
-	// byte since accept (stalled TLS handshakes, silent slowloris clients).
-	// 30s matches the server's ReadHeaderTimeout order of magnitude: far
-	// more generous than any legitimate client needs to send its first
-	// bytes, short enough that stalled conns cannot accumulate.
+	// stalledConnTimeout reaps conns that have moved fewer than
+	// minProgressBytes total bytes since accept (stalled TLS handshakes,
+	// silent or one-byte-then-stall slowloris clients). 30s matches the
+	// server's ReadHeaderTimeout order of magnitude: far more generous than
+	// any legitimate client needs to send its first bytes, short enough
+	// that stalled conns cannot accumulate.
 	stalledConnTimeout = 30 * time.Second
 
 	// tunnelIdleTimeout reaps established conns after sustained inactivity
@@ -33,6 +34,14 @@ const (
 	// worst reapInterval + threshold; 30s keeps that bound negligible
 	// relative to the thresholds while making the scan cost invisible.
 	reapInterval = 30 * time.Second
+
+	// minProgressBytes is the total bytes (reads+writes combined) a conn
+	// must move to graduate from the stalled tier to the established idle
+	// tier. Any real TLS handshake or HTTP request moves far more than 128
+	// bytes within seconds, so a conn still under this total after
+	// stalledConnTimeout is stalled by definition; raw-tunnel peers and
+	// handshakes cross it immediately.
+	minProgressBytes = 128
 )
 
 // halfClosable mirrors goproxy's unexported interface of the same name.
@@ -60,7 +69,7 @@ type trackedConn struct {
 
 	accepted     time.Time    // fixed at track time; tier-1 clock start
 	lastActivity atomic.Int64 // unix nanos of last successful Read/Write
-	readAny      atomic.Bool  // any byte ever read since accept
+	progress     atomic.Int64 // total bytes read+written since accept
 	closeOnce    sync.Once
 	half         halfClosable // non-nil when the underlying conn half-closes
 }
@@ -68,7 +77,7 @@ type trackedConn struct {
 func (c *trackedConn) Read(p []byte) (int, error) {
 	n, err := c.Conn.Read(p)
 	if n > 0 {
-		c.readAny.Store(true)
+		c.progress.Add(int64(n))
 		c.markActive()
 	}
 	return n, err
@@ -77,6 +86,7 @@ func (c *trackedConn) Read(p []byte) (int, error) {
 func (c *trackedConn) Write(p []byte) (int, error) {
 	n, err := c.Conn.Write(p)
 	if n > 0 {
+		c.progress.Add(int64(n))
 		c.markActive()
 	}
 	return n, err
@@ -112,9 +122,10 @@ func (c *trackedConn) CloseRead() error {
 }
 
 // idleFor reports how long the conn has been quiet and whether it counts as
-// zero-progress (never read anything — tier-1) or established (tier-2).
-func (c *trackedConn) idleFor(now time.Time) (d time.Duration, zeroProgress bool) {
-	if !c.readAny.Load() {
+// insufficient-progress (under minProgressBytes total bytes — tier-1) or
+// established (tier-2).
+func (c *trackedConn) idleFor(now time.Time) (d time.Duration, insufficientProgress bool) {
+	if c.progress.Load() < minProgressBytes {
 		return now.Sub(c.accepted), true
 	}
 	return now.Sub(time.Unix(0, c.lastActivity.Load())), false

--- a/internal/runtime/lifecycle_test.go
+++ b/internal/runtime/lifecycle_test.go
@@ -1,0 +1,345 @@
+package runtime_test
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	goruntime "runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mmartinez/postern/internal/ca"
+	"github.com/mmartinez/postern/internal/runtime"
+	"github.com/stretchr/testify/require"
+)
+
+// tunnelFixture is a plain TCP upstream for raw-CONNECT tests: stall holds
+// the accepted conn forever, echo bounces bytes back, halfClose writes a
+// payload and then half-closes to exercise CloseWrite forwarding.
+type tunnelFixture struct {
+	ln     net.Listener
+	addr   string
+	mu     sync.Mutex
+	conns  []net.Conn
+	closed bool
+}
+
+func newTunnelUpstream(t *testing.T, mode string) *tunnelFixture {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	f := &tunnelFixture{ln: ln, addr: ln.Addr().String()}
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			f.mu.Lock()
+			if f.closed {
+				f.mu.Unlock()
+				_ = c.Close()
+				continue
+			}
+			f.conns = append(f.conns, c)
+			f.mu.Unlock()
+			switch mode {
+			case "echo":
+				go func() { _, _ = io.Copy(c, c); _ = c.Close() }()
+			case "halfClose":
+				_, _ = c.Write([]byte("payload"))
+				if tc, ok := c.(*net.TCPConn); ok {
+					_ = tc.CloseWrite()
+				}
+			case "stall":
+				// Hold the conn without writing anything.
+			}
+		}
+	}()
+	t.Cleanup(func() {
+		f.mu.Lock()
+		f.closed = true
+		for _, c := range f.conns {
+			_ = c.Close()
+		}
+		f.mu.Unlock()
+		_ = ln.Close()
+	})
+	return f
+}
+
+// bufferedConn pairs the raw conn with a reader that may hold buffered
+// tunnel bytes past the CONNECT response.
+type bufferedConn struct {
+	net.Conn
+	r io.Reader
+}
+
+func (b bufferedConn) Read(p []byte) (int, error) { return b.r.Read(p) }
+
+// dialTunnel opens a raw CONNECT tunnel through the proxy at addr and
+// returns the client-side conn positioned just past the 200 response.
+func dialTunnel(t *testing.T, addr, hostport string) net.Conn {
+	t.Helper()
+	c, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+	_, err = fmt.Fprintf(c, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", hostport, hostport)
+	require.NoError(t, err)
+	br := bufio.NewReader(c)
+	resp, err := http.ReadResponse(br, &http.Request{Method: http.MethodConnect}) //nolint:bodyclose // a 200 CONNECT response has no body; the conn IS the tunnel
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	return bufferedConn{Conn: c, r: br}
+}
+
+// newLifecycleRuntime builds a runtime for lifecycle tests. mutate runs
+// before New; when it leaves CA unset a fresh fixture CA is generated and
+// returned so tests can trust it in their clients.
+func newLifecycleRuntime(t *testing.T, mutate func(*runtime.Options)) (*runtime.Runtime, *ca.CA, *strings.Builder) {
+	t.Helper()
+	var logs strings.Builder
+	opts := runtime.Options{
+		Addr:   "127.0.0.1:0",
+		Logger: slog.New(slog.NewTextHandler(&logs, nil)),
+		// Raw tunnels only: every host declines interception so CONNECT
+		// exercises goproxy's OkConnect relay path.
+		ShouldIntercept: func(string) bool { return false },
+	}
+	if mutate != nil {
+		mutate(&opts)
+	}
+	if opts.CA == nil {
+		opts.CA = fixtureCA(t)
+	}
+	rt, err := runtime.New(opts)
+	require.NoError(t, err)
+	return rt, opts.CA, &logs
+}
+
+func startRuntime(t *testing.T, rt *runtime.Runtime) context.CancelFunc {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- rt.Run(ctx) }()
+	require.NoError(t, waitForListening(rt, 2*time.Second))
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("runtime did not shut down within 5s of cancel")
+		}
+	})
+	return cancel
+}
+
+func TestTunnel_HalfCloseForwardedThroughTracking(t *testing.T) {
+	t.Parallel()
+	up := newTunnelUpstream(t, "halfClose")
+	rt, _, _ := newLifecycleRuntime(t, nil)
+	startRuntime(t, rt)
+
+	client := dialTunnel(t, rt.Addr(), up.addr)
+	_ = client.SetReadDeadline(time.Now().Add(3 * time.Second))
+	got, err := io.ReadAll(client)
+	require.NoError(t, err)
+	require.Equal(t, "payload", string(got), "client must see the payload then a clean EOF, not a hang")
+}
+
+func TestStalledHandshakeReaped(t *testing.T) {
+	t.Parallel()
+	rt, _, _ := newLifecycleRuntime(t, func(o *runtime.Options) {
+		o.TestStalledConnTimeout = 300 * time.Millisecond
+		o.TestReapInterval = 50 * time.Millisecond
+	})
+	startRuntime(t, rt)
+
+	// Open a TCP conn and send nothing post-accept: a stalled handshake.
+	c, err := net.DialTimeout("tcp", rt.Addr(), 2*time.Second)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+
+	start := time.Now()
+	_ = c.SetReadDeadline(time.Now().Add(5 * time.Second))
+	buf := make([]byte, 16)
+	_, err = c.Read(buf)
+	require.Error(t, err, "server must close the silent conn")
+	require.Less(t, time.Since(start), 4*time.Second, "close must happen near the tier-1 threshold, not the read deadline")
+}
+
+func TestIdleTunnelReapedAndGoroutinesSettle(t *testing.T) {
+	up := newTunnelUpstream(t, "stall")
+	rt, _, _ := newLifecycleRuntime(t, func(o *runtime.Options) {
+		o.TestTunnelIdleTimeout = 200 * time.Millisecond
+		o.TestReapInterval = 50 * time.Millisecond
+	})
+	startRuntime(t, rt)
+
+	// Baseline taken with the runtime's own goroutines (serve, reaper) and
+	// the upstream accept loop already live.
+	before := goruntime.NumGoroutine()
+	client := dialTunnel(t, rt.Addr(), up.addr)
+	_ = client.SetReadDeadline(time.Now().Add(5 * time.Second))
+
+	buf := make([]byte, 16)
+	_, err := client.Read(buf)
+	require.Error(t, err, "stalled tunnel must be closed within the tier-2 bound")
+
+	require.Eventually(t, func() bool {
+		return goruntime.NumGoroutine() <= before+2
+	}, 3*time.Second, 50*time.Millisecond, "relay goroutines must return to baseline after reap")
+}
+
+func TestSSEStreamSurvivesIdleReap(t *testing.T) {
+	t.Parallel()
+	// TLS upstream streaming an event every 50ms for ~1.2s total.
+	srv := newStreamingTLSUpstream(t, 50*time.Millisecond, 24)
+	rt, root, _ := newLifecycleRuntime(t, func(o *runtime.Options) {
+		o.ShouldIntercept = nil // MITM everything
+		o.UpstreamTLS = srv.TLSConfig()
+		o.TestTunnelIdleTimeout = 200 * time.Millisecond
+		o.TestReapInterval = 50 * time.Millisecond
+	})
+	startRuntime(t, rt)
+
+	proxyURL, _ := url.Parse("http://" + rt.Addr())
+	caPool := x509.NewCertPool()
+	caPool.AddCert(root.Cert)
+	client := &http.Client{
+		Transport: &http.Transport{
+			Proxy:           http.ProxyURL(proxyURL),
+			TLSClientConfig: &tls.Config{RootCAs: caPool, MinVersion: tls.VersionTLS12},
+		},
+	}
+
+	resp, err := client.Get(srv.URL())
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Read events well past one tier-2 threshold period (200ms): activity
+	// from the stream's writes must keep resetting the reap timer.
+	start := time.Now()
+	events := make(chan string, 64)
+	readErr := make(chan error, 1)
+	go func() {
+		sc := bufio.NewScanner(resp.Body)
+		for sc.Scan() {
+			line := sc.Text()
+			if strings.HasPrefix(line, "data:") {
+				events <- line
+			}
+		}
+		readErr <- sc.Err()
+	}()
+
+	lastAt := start
+	count := 0
+	for count < 12 {
+		select {
+		case <-events:
+			count++
+			lastAt = time.Now()
+		case err := <-readErr:
+			require.GreaterOrEqual(t, count, 12, "stream truncated before exceeding the idle threshold")
+			require.NoError(t, err)
+		case <-time.After(500 * time.Millisecond):
+			t.Fatalf("stream stalled after %d events; reap killed a live SSE stream", count)
+		}
+	}
+	// The 12th event arrives at ~600ms, six threshold periods in: activity
+	// demonstrably resets the timer instead of a fixed deadline cutting us.
+	require.Greater(t, lastAt.Sub(start), 400*time.Millisecond)
+	// Drain the rest without error to prove the stream stayed healthy.
+	remaining := 24 - count
+	for i := 0; i < remaining; i++ {
+		select {
+		case <-events:
+		case err := <-readErr:
+			require.NoError(t, err)
+			t.Fatalf("stream errored early at event %d", count+i)
+		case <-time.After(3 * time.Second):
+			t.Fatal("timed out waiting for remaining stream events")
+		}
+	}
+}
+
+func TestShutdownDrainsThenForceClosesTunnels(t *testing.T) {
+	t.Parallel()
+	up := newTunnelUpstream(t, "echo")
+	rt, _, logs := newLifecycleRuntime(t, func(o *runtime.Options) {
+		o.TestShutdownBudget = 600 * time.Millisecond
+	})
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- rt.Run(ctx) }()
+	require.NoError(t, waitForListening(rt, 2*time.Second))
+
+	client := dialTunnel(t, rt.Addr(), up.addr)
+	ping := func() error {
+		_ = client.SetDeadline(time.Now().Add(2 * time.Second))
+		if _, err := client.Write([]byte("ping")); err != nil {
+			return err
+		}
+		buf := make([]byte, 4)
+		_, err := io.ReadFull(client, buf)
+		if err == nil && string(buf) != "ping" {
+			err = fmt.Errorf("echo mismatch: %q", buf)
+		}
+		return err
+	}
+	require.NoError(t, ping())
+
+	cancel()
+
+	// Run must NOT return while the drain window is open, and the live
+	// tunnel must still pass bytes during it.
+	time.Sleep(200 * time.Millisecond)
+	select {
+	case err := <-done:
+		t.Fatalf("Run returned %v before the shutdown budget expired", err)
+	default:
+	}
+	require.NoError(t, ping(), "tunnel must keep passing bytes during the drain window")
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after the shutdown budget expired")
+	}
+	out := logs.String()
+	require.Contains(t, out, "shutdown drain complete")
+	require.Contains(t, out, "force_closed=1", "the live tunnel must be force-closed at budget expiry")
+}
+
+func newStreamingTLSUpstream(t *testing.T, every time.Duration, total int) *upstreamFixture {
+	t.Helper()
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		for i := 0; i < total; i++ {
+			if _, err := fmt.Fprintf(w, "event: tick\ndata: %d\n\n", i); err != nil {
+				return
+			}
+			if flusher != nil {
+				flusher.Flush()
+			}
+			time.Sleep(every)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return &upstreamFixture{srv: srv}
+}

--- a/internal/runtime/lifecycle_test.go
+++ b/internal/runtime/lifecycle_test.go
@@ -190,15 +190,47 @@ func TestIdleTunnelReapedAndGoroutinesSettle(t *testing.T) {
 	// the upstream accept loop already live.
 	before := goruntime.NumGoroutine()
 	client := dialTunnel(t, rt.Addr(), up.addr)
+	// The CONNECT exchange alone moves fewer than minProgressBytes, so push
+	// real tunnel traffic through to cross the progress threshold: this conn
+	// must be classified as established (tier-2), not stalled (tier-1).
+	_, err := client.Write(make([]byte, 256))
+	require.NoError(t, err)
 	_ = client.SetReadDeadline(time.Now().Add(5 * time.Second))
 
 	buf := make([]byte, 16)
-	_, err := client.Read(buf)
+	_, err = client.Read(buf)
 	require.Error(t, err, "stalled tunnel must be closed within the tier-2 bound")
 
 	require.Eventually(t, func() bool {
 		return goruntime.NumGoroutine() <= before+2
 	}, 3*time.Second, 50*time.Millisecond, "relay goroutines must return to baseline after reap")
+}
+
+// TestOneByteStalledConnReapedAtTier1 pins the insufficient-progress tier:
+// a hostile client that sends one byte and then stalls must be reaped at
+// the tier-1 bound, not held for the tier-2 idle timeout.
+func TestOneByteStalledConnReapedAtTier1(t *testing.T) {
+	t.Parallel()
+	rt, _, _ := newLifecycleRuntime(t, func(o *runtime.Options) {
+		o.TestStalledConnTimeout = 300 * time.Millisecond
+		o.TestTunnelIdleTimeout = 10 * time.Second
+		o.TestReapInterval = 50 * time.Millisecond
+	})
+	startRuntime(t, rt)
+
+	c, err := net.DialTimeout("tcp", rt.Addr(), 2*time.Second)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	_, err = c.Write([]byte("G")) // one byte, then stall: below minProgressBytes
+	require.NoError(t, err)
+
+	start := time.Now()
+	_ = c.SetReadDeadline(time.Now().Add(5 * time.Second))
+	buf := make([]byte, 16)
+	_, err = c.Read(buf)
+	require.Error(t, err, "server must close the one-byte-then-stall conn")
+	require.Less(t, time.Since(start), 2*time.Second,
+		"close must happen at the tier-1 bound, not the tier-2 idle bound")
 }
 
 func TestSSEStreamSurvivesIdleReap(t *testing.T) {
@@ -303,15 +335,16 @@ func TestShutdownDrainsThenForceClosesTunnels(t *testing.T) {
 
 	cancel()
 
-	// Run must NOT return while the drain window is open, and the live
-	// tunnel must still pass bytes during it.
-	time.Sleep(200 * time.Millisecond)
+	// Run must NOT return while the drain window is open. The ping itself is
+	// the in-window probe: it only succeeds while the tunnel is still being
+	// drained, and the non-blocking select after it catches a premature
+	// return without any wall-clock sleep.
+	require.NoError(t, ping(), "tunnel must keep passing bytes during the drain window")
 	select {
 	case err := <-done:
 		t.Fatalf("Run returned %v before the shutdown budget expired", err)
 	default:
 	}
-	require.NoError(t, ping(), "tunnel must keep passing bytes during the drain window")
 
 	select {
 	case err := <-done:
@@ -337,6 +370,9 @@ func newStreamingTLSUpstream(t *testing.T, every time.Duration, total int) *upst
 			if flusher != nil {
 				flusher.Flush()
 			}
+			// Genuine cadence sleep: the SSE tick interval is the fixture's
+			// stand-in for live traffic, whose activity keeps resetting the
+			// injected tunnelIdleTimeout under test.
 			time.Sleep(every)
 		}
 	}))

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -264,9 +264,9 @@ func (r *Runtime) reapOnce() {
 	now := time.Now()
 	var stale []*trackedConn
 	r.conns.each(func(c *trackedConn) {
-		idle, zeroProgress := c.idleFor(now)
+		idle, insufficientProgress := c.idleFor(now)
 		limit := r.tunnelIdleTimeout
-		if zeroProgress {
+		if insufficientProgress {
 			limit = r.stalledConnTimeout
 		}
 		if idle > limit {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -23,8 +23,11 @@ import (
 )
 
 // shutdownBudget is the upper bound on graceful drain time: SIGTERM must
-// drain in-flight requests within 10s — anything still in-flight after the
-// budget gets a 504 from the http.Server.
+// finish shutting down within 10s. net/http's Shutdown ignores hijacked
+// connections entirely, and goproxy hijacks every CONNECT — so no 504 can
+// ever be surfaced to a live tunnel. Instead the runtime tracks hijacked
+// conns (see conntrack.go), waits out the remaining budget for them to
+// finish naturally, and force-closes any still alive when it expires.
 const shutdownBudget = 10 * time.Second
 
 // idleTimeout reaps silent keep-alive connections on the inbound server.
@@ -70,6 +73,25 @@ type Options struct {
 	// default. Test-only: production wiring never sets it and it is not
 	// exposed through YAML configuration.
 	TestIdleTimeout time.Duration
+
+	// TestStalledConnTimeout overrides the inbound reaper's 30s
+	// zero-progress threshold for tests that cannot wait out the production
+	// default. Zero keeps the default. Test-only: production wiring never
+	// sets it and it is deliberately not exposed through YAML configuration.
+	TestStalledConnTimeout time.Duration
+
+	// TestTunnelIdleTimeout overrides the inbound reaper's 10m
+	// sustained-inactivity threshold, like TestStalledConnTimeout.
+	// Zero keeps the default. Test-only.
+	TestTunnelIdleTimeout time.Duration
+
+	// TestReapInterval overrides the inbound reaper's 30s scan interval,
+	// like TestStalledConnTimeout. Zero keeps the default. Test-only.
+	TestReapInterval time.Duration
+
+	// TestShutdownBudget overrides the 10s graceful shutdown budget, like
+	// TestStalledConnTimeout. Zero keeps the default. Test-only.
+	TestShutdownBudget time.Duration
 }
 
 // Runtime is the constructed-but-not-yet-running postern server. Build it
@@ -81,6 +103,13 @@ type Runtime struct {
 	minter *ca.Minter
 
 	addr atomic.Value // string, populated once the listener is up
+
+	conns *connRegistry // live accepted conns; drain barrier at shutdown
+
+	stalledConnTimeout time.Duration
+	tunnelIdleTimeout  time.Duration
+	reapInterval       time.Duration
+	shutdownBudget     time.Duration
 }
 
 // New constructs a Runtime from opts. It performs validation but does not
@@ -120,17 +149,36 @@ func New(opts Options) (*Runtime, error) {
 		idle = opts.TestIdleTimeout
 	}
 
-	return &Runtime{
+	rt := &Runtime{
 		opts:   opts,
 		proxy:  p,
 		minter: minter,
+		conns:  newConnRegistry(),
 		srv: &http.Server{
 			Addr:              opts.Addr,
 			Handler:           p.Handler(),
 			ReadHeaderTimeout: 30 * time.Second,
 			IdleTimeout:       idle,
 		},
-	}, nil
+
+		stalledConnTimeout: stalledConnTimeout,
+		tunnelIdleTimeout:  tunnelIdleTimeout,
+		reapInterval:       reapInterval,
+		shutdownBudget:     shutdownBudget,
+	}
+	if opts.TestStalledConnTimeout > 0 {
+		rt.stalledConnTimeout = opts.TestStalledConnTimeout
+	}
+	if opts.TestTunnelIdleTimeout > 0 {
+		rt.tunnelIdleTimeout = opts.TestTunnelIdleTimeout
+	}
+	if opts.TestReapInterval > 0 {
+		rt.reapInterval = opts.TestReapInterval
+	}
+	if opts.TestShutdownBudget > 0 {
+		rt.shutdownBudget = opts.TestShutdownBudget
+	}
+	return rt, nil
 }
 
 // Addr returns the listener's actual bind address, or "" if Run hasn't yet
@@ -144,9 +192,11 @@ func (r *Runtime) Addr() string {
 }
 
 // Run binds the listener and serves until ctx is cancelled or the server
-// errors. On cancellation it gracefully shuts down within shutdownBudget.
-// The returned error is nil for clean shutdowns and non-nil for bind
-// failures or serve-level errors.
+// errors. On cancellation it gracefully shuts down within shutdownBudget:
+// http.Server.Shutdown first for non-hijacked traffic, then a bounded wait
+// on live tunnels, then force-close of whatever is left. The returned error
+// is nil for clean shutdowns and non-nil for bind failures or serve-level
+// errors.
 func (r *Runtime) Run(ctx context.Context) error {
 	listener, err := net.Listen("tcp", r.opts.Addr)
 	if err != nil {
@@ -155,12 +205,16 @@ func (r *Runtime) Run(ctx context.Context) error {
 	r.addr.Store(listener.Addr().String())
 	r.opts.Logger.Info("proxy listening", slog.String("addr", listener.Addr().String()))
 
+	reapCtx, stopReaper := context.WithCancel(context.Background())
+	defer stopReaper()
+	go r.reapLoop(reapCtx)
+
 	serveErr := make(chan error, 1)
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		err := r.srv.Serve(listener)
+		err := r.srv.Serve(&trackingListener{Listener: listener, reg: r.conns})
 		if errors.Is(err, http.ErrServerClosed) {
 			serveErr <- nil
 			return
@@ -170,19 +224,82 @@ func (r *Runtime) Run(ctx context.Context) error {
 
 	select {
 	case <-ctx.Done():
-		r.opts.Logger.Info("shutdown requested", slog.Duration("budget", shutdownBudget))
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownBudget)
+		r.opts.Logger.Info("shutdown requested", slog.Duration("budget", r.shutdownBudget))
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), r.shutdownBudget)
 		defer cancel()
+		var shutdownErr error
 		if err := r.srv.Shutdown(shutdownCtx); err != nil {
 			r.opts.Logger.Warn("shutdown error", slog.Any("err", err))
-			wg.Wait()
-			return err
+			shutdownErr = err
 		}
+		drained, forced := r.drainConns(shutdownCtx)
+		r.opts.Logger.Info("shutdown drain complete",
+			slog.Int("drained", drained),
+			slog.Int("force_closed", forced))
 		wg.Wait()
-		return nil
+		return shutdownErr
 	case err := <-serveErr:
 		wg.Wait()
 		return err
+	}
+}
+
+// reapLoop evicts stalled and idle conns until ctx is cancelled. Closing a
+// tracked conn unblocks whichever goproxy goroutine (MITM read loop, tunnel
+// relay) is parked inside it, so eviction tears down the whole tunnel.
+func (r *Runtime) reapLoop(ctx context.Context) {
+	ticker := time.NewTicker(r.reapInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			r.reapOnce()
+		}
+	}
+}
+
+func (r *Runtime) reapOnce() {
+	now := time.Now()
+	var stale []*trackedConn
+	r.conns.each(func(c *trackedConn) {
+		idle, zeroProgress := c.idleFor(now)
+		limit := r.tunnelIdleTimeout
+		if zeroProgress {
+			limit = r.stalledConnTimeout
+		}
+		if idle > limit {
+			stale = append(stale, c)
+		}
+	})
+	for _, c := range stale {
+		r.opts.Logger.Debug("reaped idle connection",
+			slog.String("remote", c.RemoteAddr().String()))
+		_ = c.Close()
+	}
+}
+
+// drainConns waits for tracked conns to finish naturally within ctx's
+// remaining budget, then force-closes the rest. It returns how many drained
+// versus how many were force-closed.
+func (r *Runtime) drainConns(ctx context.Context) (drained, forced int) {
+	total := r.conns.count()
+	if total == 0 {
+		return 0, 0
+	}
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			forced = r.conns.closeAll()
+			return total - forced, forced
+		case <-ticker.C:
+			if r.conns.count() == 0 {
+				return total, 0
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

Graceful shutdown drains nothing. goproxy hijacks every CONNECT, and net/http's `srv.Shutdown` ignores hijacked connections entirely (go1.26.5 `server.go` Shutdown docs and 3142-3146), so on ctx cancel `Run` returned immediately (internal/runtime/runtime.go:152-167) and process exit cut every live SSE/websocket tunnel mid-stream despite `shutdownBudget`. The comment at runtime.go:25-27 promised a 504-on-budget-expiry that can never fire for hijacked conns.

No idle lifecycle for hijacked conns either: after `Hijack`, net/http clears all deadlines (`server.go:325` in `hijackLocked`); goproxy v1.9.0 runs the client TLS handshake on `context.Background()` (https.go:430) and loops reading MITM'd requests deadline-free (https.go:454-455); tunnel relays run via `copyAndClose` goroutines with no deadlines (https.go:336-337). Consequences: Slowloris (N stalled ClientHello/request reads pin a goroutine+fd each forever) and stalled-tunnel relay pins (upstream accepts then stalls mid-body; both sides leak).

## Evidence

- goproxy v1.9.0 https.go:430 (`HandshakeContext(context.Background())`), :454-455 (deadline-free request loop), :336-337 + :637 (`copyAndClose` relays), :330-331 + :180-186 (`halfClosable` assertion gating half-close semantics).
- go1.26.5 net/http `Shutdown` ignores hijacked conns; `hijackLocked` clears deadlines.

## Changes

- `internal/runtime/conntrack.go`: `trackedConn` wrapper (activity timestamps in Read/Write, full `halfClosable` forwarding so goproxy's raw-tunnel half-close path is preserved), `trackingListener`, `connRegistry`.
- Reaper goroutine owned by `Runtime` (started in `Run`, stopped on ctx done): 30s scan; evicts zero-progress conns past 30s (stalled handshakes) and established conns past 10m sustained two-way inactivity. Thresholds are activity-based, never fixed read deadlines, so live SSE streams are never cut. Constants documented; injectable via test-only `Options` fields.
- `Run` shutdown: `srv.Shutdown` as before, then bounded wait on the live-tunnel registry within the remaining budget, then force-close stragglers; logs drained vs force-closed counts. Stale 504 comment corrected.
- Mechanism entirely internal; public API grows only documented test-only `Options` fields (TestStalledConnTimeout, TestTunnelIdleTimeout, TestReapInterval, TestShutdownBudget), matching the PR #70 convention.

## Acceptance criteria demonstrated by tests

- `TestSSEStreamSurvivesIdleReap`: 50ms event stream survives well past an injected 200ms tier-2 threshold (activity resets the timer).
- `TestIdleTunnelReapedAndGoroutinesSettle`: stalled tunnel closed within the tier-2 bound; goroutines return to baseline.
- `TestStalledHandshakeReaped`: silent post-accept TCP conn closed within the tier-1 bound.
- `TestShutdownDrainsThenForceClosesTunnels`: after ctx cancel `Run` does not return before the budget expires, the tunnel keeps passing bytes during the drain window, force-close fires at expiry, and the log records `force_closed=1`.
- `TestTunnel_HalfCloseForwardedThroughTracking`: client sees payload then clean EOF through the wrapper (CloseWrite forwarded).
- All pre-existing tests pass unmodified; `make ci` green (lint 0 issues, race, govulncheck) after rebase onto origin/main@2932c69.
