### PR TITLE
docs: close behavior-gap coverage from docs-consistency audit

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,13 +46,18 @@ agent                     postern (127.0.0.1:1701)                 upstream
    the postern CA for hosts it actually brokers. (When no broker is configured
    at all, postern falls back to intercepting every host.)
    Inner requests on an intercepted tunnel are bound to the CONNECT
-   authority; a decrypted request naming any other host fails closed with a 502.
+   authority; a decrypted request naming any other authority (host and port)
+   fails closed with a 502.
 
 2. **Match.** For an intercepted host the decrypted request's host (with any
    `:port` stripped) is matched against the YAML-declared rules — first match
    wins. Host patterns are either a literal hostname or a single-`*` glob
-   (`*.example.com`, matching one label like a TLS wildcard). A host that
-   matches no rule is tunneled at `CONNECT` without decryption (the default
+   (`*.example.com`, matching one label like a TLS wildcard). A single
+   trailing dot is stripped from the wire host and from the rule pattern
+   alike, exactly once, so a dotted FQDN decides identically to its bare
+   form; a malformed multi-dot authority matches nothing and falls through
+   to the configured `passthrough`/`block` policy. A host that matches no
+   rule is tunneled at `CONNECT` without decryption (the default
    `passthrough` behavior); `block` rejects the `CONNECT` instead.
 
 3. **Resolve.** The matched rule's `secret_ref` (e.g. `op://Vault/Item/field`)
@@ -67,6 +72,9 @@ agent                     postern (127.0.0.1:1701)                 upstream
 5. **Forward.** Postern forwards the now-authenticated request and streams the
    response back to the agent without buffering, so server-sent events and other
    incremental responses arrive as they are produced.
+
+Tunnel lifetime: hijacked tunnels are activity-tracked, not deadline-bound. A connection that has moved fewer than 128 bytes of total progress is closed after ~30s of silence, and an established tunnel after ~10m of sustained two-way silence (any activity resets the timer, so live SSE streams are not cut).
+Shutdown drains open tunnels within the remaining budget before force-closing whatever is still alive.
 
 If resolution or injection fails at step 3 or 4, postern **fails closed**: it
 returns a generic `502` to the agent and never contacts the upstream. See
@@ -97,9 +105,9 @@ any other private key.
 | `internal/credstore/onepassword` | Provider for 1Password Service Accounts (`op://`), backed by the 1Password Go SDK. Registered by default. |
 | `internal/credstore/bitwarden` | Provider for Bitwarden Secrets Manager (`bw://`), shelling out to the `bws` CLI. Registered by default. |
 | `internal/credstore/oauth2` | Provider that mints short-lived bearer tokens (`oauth2://`) via `golang.org/x/oauth2` (client-credentials / refresh-token grants). Registered by default. |
-| `internal/config` | YAML schema, strict-mode loader, line-numbered validator, and the fsnotify-backed hot-reload watcher. |
+| `internal/config` | YAML schema, strict-mode loader, line-numbered validator, and the fsnotify-backed hot-reload watcher with a 5s stat-poll fallback that survives silent watch death (watcher errors are logged at Warn). |
 | `internal/token` | Service-account token resolution chain (file → env → keychain) and the OS-keychain-backed store. |
-| `internal/runtime` | Assembles the proxy listener, wires the broker hook, and owns graceful shutdown. |
+| `internal/runtime` | Assembles the proxy listener, wires the broker hook, and owns graceful shutdown, connection tracking, and tunnel reaping. |
 | `internal/cli` | Cobra commands: `config`, `token`, `ca`, `server`, `rules`, `bootstrap`. |
 | `internal/logging` | slog factory (text/JSON, level, color) and the per-request summary handler. |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -89,6 +89,8 @@ proxy:
 | `on_no_match` | no | What to do with a `CONNECT` to a host that matches no rule. `passthrough` (default) tunnels the connection untouched — postern does **not** terminate TLS, so the agent reaches the real upstream with the real certificate and only needs to trust the postern CA for brokered hosts. `block` rejects the `CONNECT` with a `502` and never contacts the upstream (allowlist-only egress for proxied traffic). See [security.md](security.md#egress-containment-with-on_no_match). |
 | `max_body_bytes` | no | Cap (in bytes) on how much of a request body postern buffers when a rule rewrites the body (`inject.in` includes `body`). Default 1 MiB when unset or `0`. A larger body is rejected with `413 Request Entity Too Large` and never reaches the upstream. Bound at startup; a hot-reload edit warns and does not take effect (a per-rule `inject.max_body_bytes` override does hot-reload). |
 
+The timeout budget around the proxy itself is fixed constants, not YAML options: outbound dial 10s, TCP keep-alive 30s, upstream TLS handshake 10s, response-header wait 30s, and idle pooled upstream connections reaped after 90s; on the inbound side, idle keep-alive connections are closed after 2m and request headers must arrive within 30s.
+
 ### `proxy.cache`
 
 Credential resolution is a background concern: the request/inject path reads
@@ -143,7 +145,7 @@ rules:
 
 | Field | Required | Meaning |
 |---|---|---|
-| `host` | yes* | A literal hostname (`api.example.com`) or a single-`*` glob (`*.example.com`, matching exactly one label). **Do not use a wildcard on a multi-tenant or shared-suffix domain** (e.g. `*.s3.amazonaws.com`, `*.blob.core.windows.net`): any host an attacker can register under that suffix would also match the rule and receive the injected credential. Reserve wildcards for single-tenant domains you control. |
+| `host` | yes* | A literal hostname (`api.example.com`) or a single-`*` glob (`*.example.com`, matching exactly one label). A trailing-dot literal (`api.example.com.`) is accepted and normalized once at load; a malformed multi-dot host on the wire matches no rule and falls through to `on_no_match`. **Do not use a wildcard on a multi-tenant or shared-suffix domain** (e.g. `*.s3.amazonaws.com`, `*.blob.core.windows.net`): any host an attacker can register under that suffix would also match the rule and receive the injected credential. Reserve wildcards for single-tenant domains you control. |
 | `secret_ref` | yes | A `<scheme>://<rest>` URI the matching provider resolves (e.g. `op://VAULT/ITEM/FIELD`). Omit when using `routes` (each route carries its own). |
 | `inject` | yes* | How to attach the resolved credential — see below. |
 | `injects` | no | Several header injections fed by the rule's one `secret_ref`, for a host that authenticates the same credential through two different headers. Mutually exclusive with `inject`, `routes`, and `template`; see below. |


### PR DESCRIPTION
Docs-only follow-up to the five merged behavior PRs. Six additions covering statements the audit found missing (no stale statements; coverage gaps only). Every cited behavior was verified against the code on `main` before writing.

## docs/architecture.md

1. **Request lifecycle, step 2 (host matching).** Documents that a single trailing dot is stripped from the wire host and from the rule pattern alike, exactly once (`internal/proxy/decision.go:20-29`, `internal/broker/rule.go:181-185`), and that a malformed multi-dot authority matches nothing and falls through to the configured `passthrough`/`block` policy.
2. **New short "Tunnel lifetime" paragraph after step 5.** Hijacked tunnels are activity-tracked: ~30s close for connections under 128 bytes of total progress, ~10m close for sustained two-way silence with any activity resetting the timer (live SSE streams are not cut), and shutdown drains tunnels within the remaining budget before force-closing (`internal/runtime/runtime.go:25-31`, `internal/runtime/conntrack.go`).
3. **Components table, `internal/config`.** The hot-reload watcher is fsnotify-backed with a 5s stat-poll fallback that survives silent watch death; watcher errors are logged at Warn (`internal/config/watcher.go:19-27`, `223-230`).
4. **Components table, `internal/runtime`.** Graceful-shutdown responsibility now includes connection tracking and tunnel reaping (`internal/runtime/runtime.go:164-167`).
5. **Step 1 precision fix.** "naming any other host" → "naming any other authority (host and port)", matching the port-inclusive guard in `internal/proxy/handler.go:65-68`.

## docs/configuration.md

6a. **`proxy` block.** One sentence noting the timeout budget is fixed constants, not YAML options: outbound dial 10s, TCP keep-alive 30s, TLS handshake 10s, response-header wait 30s, idle pooled conn 90s; inbound idle 2m and read-header 30s (`internal/proxy/proxy.go:169-189`, `internal/runtime/runtime.go:33-38`).
6b. **`rules.host` row.** A trailing-dot literal is accepted and normalized once at load; a malformed multi-dot host on the wire matches nothing and falls through to `on_no_match` (`internal/broker/from_config.go:12-15`, `internal/config/validator.go:614-623`).

## Verification

- `make ci` green in the devcontainer: golangci-lint 0 issues, full `-race` test suite passes, govulncheck clean.
- Diff touches only the two doc files.