### PR TITLE
docs: clarify stalled-tunnel closure window (30-60s)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,7 +73,9 @@ agent                     postern (127.0.0.1:1701)                 upstream
    response back to the agent without buffering, so server-sent events and other
    incremental responses arrive as they are produced.
 
-Tunnel lifetime: hijacked tunnels are activity-tracked, not deadline-bound. A connection that has moved fewer than 128 bytes of total progress is closed after ~30s of silence, and an established tunnel after ~10m of sustained two-way silence (any activity resets the timer, so live SSE streams are not cut).
+Tunnel lifetime: hijacked tunnels are activity-tracked, not deadline-bound.
+The reaper scans every 30s, so closure lands within the stated bound plus one scan.
+A connection that has moved fewer than 128 bytes of total progress is closed within roughly 30-60s of silence, and an established tunnel after roughly 10m of sustained two-way silence (any activity resets the timer, so live SSE streams are not cut).
 Shutdown drains open tunnels within the remaining budget before force-closing whatever is still alive.
 
 If resolution or injection fails at step 3 or 4, postern **fails closed**: it

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,7 +75,7 @@ agent                     postern (127.0.0.1:1701)                 upstream
 
 Tunnel lifetime: hijacked tunnels are activity-tracked, not deadline-bound.
 The reaper scans every 30s, so closure lands within the stated bound plus one scan.
-A connection that has moved fewer than 128 bytes of total progress is closed within roughly 30-60s of silence, and an established tunnel after roughly 10m of sustained two-way silence (any activity resets the timer, so live SSE streams are not cut).
+A connection that has moved fewer than 128 bytes of total progress is closed roughly 30-60s after acceptance regardless of any intervening activity, while an established tunnel is closed after roughly 10m without two-way traffic (activity resets that longer timer, so live SSE streams are not cut).
 Shutdown drains open tunnels within the remaining budget before force-closing whatever is still alive.
 
 If resolution or injection fails at step 3 or 4, postern **fails closed**: it


### PR DESCRIPTION
Problem
Greptile P2 on #77 (merged before its review completed): the new Tunnel lifetime paragraph stated a ~30s closure bound for sub-128-byte connections, but eviction latency is threshold plus one reaper scan (reapInterval = 30s), so real closure lands in 30-60s.

Evidence
internal/runtime/conntrack.go:33-36 documents 'eviction latency is at worst reapInterval + threshold'; docs/architecture.md:76 claimed ~30s flat.

Changes
architecture.md Tunnel lifetime paragraph: state that the reaper scans every 30s so closure lands within the stated bound plus one scan; insufficient-progress tier expressed as roughly 30-60s; established tier as roughly 10m.

Acceptance
Docs-only change; wording matches conntrack.go constants and comments.