### PR TITLE
test(runtime): deflake goroutine-settle assertion

### DIFF
--- a/internal/runtime/lifecycle_test.go
+++ b/internal/runtime/lifecycle_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/mmartinez/postern/internal/ca"
 	"github.com/mmartinez/postern/internal/runtime"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -179,10 +180,12 @@ func TestStalledHandshakeReaped(t *testing.T) {
 }
 
 func TestIdleTunnelReapedAndGoroutinesSettle(t *testing.T) {
+	reaped := make(chan struct{}, 1)
 	up := newTunnelUpstream(t, "stall")
 	rt, _, _ := newLifecycleRuntime(t, func(o *runtime.Options) {
 		o.TestTunnelIdleTimeout = 200 * time.Millisecond
 		o.TestReapInterval = 50 * time.Millisecond
+		o.TestReapHook = func() { reaped <- struct{}{} }
 	})
 	startRuntime(t, rt)
 
@@ -201,9 +204,23 @@ func TestIdleTunnelReapedAndGoroutinesSettle(t *testing.T) {
 	_, err = client.Read(buf)
 	require.Error(t, err, "stalled tunnel must be closed within the tier-2 bound")
 
-	require.Eventually(t, func() bool {
-		return goruntime.NumGoroutine() <= before+2
-	}, 3*time.Second, 50*time.Millisecond, "relay goroutines must return to baseline after reap")
+	// Wait on the reaper's own eviction signal rather than racing a fixed
+	// clock: under CI load the reap tick can land long after the client
+	// observes the close.
+	select {
+	case <-reaped:
+	case <-time.After(10 * time.Second):
+		t.Fatal("reaper never evicted the stalled tunnel")
+	}
+
+	// Leak check: after eviction the relay goroutines must actually exit.
+	// The bound is generous so scheduler noise under load cannot flake it,
+	// but a reaped tunnel that leaks its goroutines still fails here.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		now := goruntime.NumGoroutine()
+		assert.LessOrEqual(c, now, before+2,
+			fmt.Sprintf("relay goroutines must settle at baseline %d after reap; observed %d", before, now))
+	}, 10*time.Second, 100*time.Millisecond)
 }
 
 // TestOneByteStalledConnReapedAtTier1 pins the insufficient-progress tier:

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -92,6 +92,12 @@ type Options struct {
 	// TestShutdownBudget overrides the 10s graceful shutdown budget, like
 	// TestStalledConnTimeout. Zero keeps the default. Test-only.
 	TestShutdownBudget time.Duration
+
+	// TestReapHook, when non-nil, runs once for each connection the inbound
+	// reaper closes during eviction. Tests use it to observe reap events
+	// deterministically instead of polling a wall clock. Test-only:
+	// production wiring never sets it.
+	TestReapHook func()
 }
 
 // Runtime is the constructed-but-not-yet-running postern server. Build it
@@ -277,6 +283,9 @@ func (r *Runtime) reapOnce() {
 		r.opts.Logger.Debug("reaped idle connection",
 			slog.String("remote", c.RemoteAddr().String()))
 		_ = c.Close()
+		if r.opts.TestReapHook != nil {
+			r.opts.TestReapHook()
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

`TestIdleTunnelReapedAndGoroutinesSettle` (internal/runtime/lifecycle_test.go) failed once on CI with `Condition never satisfied` after 3.32s while passing repeatedly on identical code elsewhere.

Root cause: the test raced a fixed 3s `require.Eventually` window on global `goruntime.NumGoroutine()` after the client observed the tunnel close. Under CI load the reaper tick and relay teardown can land outside that window, and sibling parallel tests move the global goroutine count independently of this tunnel. The assertion measured the clock, not the reap.

Not reproduced locally: 0 failures across 60 pre-fix runs (`-race -count=20`, plus `-count=10` under 8 busy-loop CPU-load workers and with `GOMAXPROCS=1/2`), consistent with a load-dependent CI-only flake.

## Change

- Add a test-only `Options.TestReapHook` seam (matching the existing documented Test* Options pattern): invoked once per connection the inbound reaper closes during eviction. Production wiring never sets it; no production behavior change.
- The test now waits deterministically on the hook's channel for the eviction event instead of racing the clock, then keeps the goroutine-count check as a secondary leak assertion via `require.EventuallyWithT` with a generous but bounded 10s window that reports baseline and observed counts on failure.

Leak-freedom is preserved: if a reaped tunnel leaks its relay goroutines, the count never returns to baseline within 10s and the test fails with both numbers in the message. Verified by mutation: injecting three leaked goroutines into the hook fails the test with `"10" is not less than or equal to "8" ... baseline 6 after reap; observed 10`.

## Verification

- Stress: `go test -race -run TestIdleTunnelReapedAndGoroutinesSettle -count=50` green (14.2s).
- Stress under starvation: same test `-count=20 -race GOMAXPROCS=1` green.
- Full package: `go test -race -count=2 ./internal/runtime/` green.
- `make ci` green in the devcontainer (golangci-lint 0 issues, full suite with race + coverage, govulncheck clean).