### PR TITLE
feat(test): add black-box e2e suite

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -25,7 +25,7 @@ func TestHTTPSBrokeredInjection(t *testing.T) {
 	e := newEnv(t)
 	idp := startIdP(t, e)
 	up := startUpstream(t, e)
-	proc := startPostern(t, e, renderConfig(freePort(t), idp.URL, "127.0.0.1", "passthrough"))
+	proc := startPostern(t, e, renderConfig(idp.URL, "127.0.0.1", "passthrough"))
 	client := proxiedClient(t, proc.proxyURL, e.caPEM)
 
 	target := fmt.Sprintf("https://127.0.0.1:%s/", up.port)
@@ -69,7 +69,7 @@ func TestPlainHTTPInjectionFailsClosed(t *testing.T) {
 	e := newEnv(t)
 	idp := startIdP(t, e)
 	up := startUpstream(t, e)
-	proc := startPostern(t, e, renderConfig(freePort(t), idp.URL, "127.0.0.1", "passthrough"))
+	proc := startPostern(t, e, renderConfig(idp.URL, "127.0.0.1", "passthrough"))
 	client := proxiedClient(t, proc.proxyURL, e.caPEM)
 
 	target := fmt.Sprintf("http://127.0.0.1:%s/", up.port)
@@ -97,7 +97,7 @@ func TestFailClosedOnResolverFailure(t *testing.T) {
 	e := newEnv(t)
 	idp := startIdP(t, e)
 	up := startUpstream(t, e)
-	proc := startPostern(t, e, renderConfig(freePort(t), idp.URL, "127.0.0.1", "passthrough"))
+	proc := startPostern(t, e, renderConfig(idp.URL, "127.0.0.1", "passthrough"))
 	client := proxiedClient(t, proc.proxyURL, e.caPEM)
 
 	idp.srv.Close() // token URL now points at a closed port
@@ -117,7 +117,7 @@ func TestHotReloadSwapsRuleHost(t *testing.T) {
 	e := newEnv(t)
 	idp := startIdP(t, e)
 	up := startUpstream(t, e)
-	proc := startPostern(t, e, renderConfig(freePort(t), idp.URL, "localhost", "block"))
+	proc := startPostern(t, e, renderConfig(idp.URL, "localhost", "block"))
 	client := proxiedClient(t, proc.proxyURL, e.caPEM)
 
 	oldURL := fmt.Sprintf("https://localhost:%s/", up.port)
@@ -133,7 +133,7 @@ func TestHotReloadSwapsRuleHost(t *testing.T) {
 	baselineReqs := up.Requests()
 
 	// Swap the rule's host; credstores stay identical so the reload applies.
-	proc.rewriteConfig(t, renderConfig(freePort(t), idp.URL, "127.0.0.1", "block"))
+	proc.rewriteConfig(t, renderConfig(idp.URL, "127.0.0.1", "block"))
 
 	// Poll within the watcher's poll interval + debounce window until the
 	// new host brokers. During the transition the old ruleset still serves,
@@ -146,7 +146,10 @@ func TestHotReloadSwapsRuleHost(t *testing.T) {
 			swapped = true
 			break
 		}
-		time.Sleep(100 * time.Millisecond)
+		// 10ms poll cadence against a 10s cap; the watcher's stat-poll
+		// fallback runs on a 5s interval, so no fixed delay coordinates us
+		// with the server — each attempt observes current ruleset state.
+		time.Sleep(10 * time.Millisecond)
 	}
 	require.True(t, swapped, "new host never brokered after reload\nlogs:\n%s", proc.logs.String())
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,0 +1,166 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// failClosedBody is the exact body every postern fail-closed 502 carries.
+const failClosedBody = "postern: bad gateway\n"
+
+// TestHTTPSBrokeredInjection covers the full brokered flow over real TLS:
+// the client CONNECTs through postern to an https upstream, postern
+// terminates TLS with a leaf minted from its CA, resolves the rule's OAuth2
+// credential at the stub IdP, injects the Authorization header, and forwards
+// upstream. The token is fetched exactly once (boot ping + first use) and
+// reused for subsequent requests.
+func TestHTTPSBrokeredInjection(t *testing.T) {
+	t.Parallel()
+
+	e := newEnv(t)
+	idp := startIdP(t, e)
+	up := startUpstream(t, e)
+	proc := startPostern(t, e, renderConfig(freePort(t), idp.URL, "127.0.0.1", "passthrough"))
+	client := proxiedClient(t, proc.proxyURL, e.caPEM)
+
+	target := fmt.Sprintf("https://127.0.0.1:%s/", up.port)
+	status, body := get(t, client, target)
+	require.Equal(t, 200, status, "body: %q", body)
+	require.Equal(t, "upstream-ok\n", body)
+
+	// The boot-time credential ping consumes mint #1; the runtime resolver's
+	// first use consumes mint #2 and is then reused from x/oauth2's cache.
+	require.Equal(t, int64(2), idp.Fetches())
+	require.Equal(t, 1, up.Requests())
+	require.Equal(t, "Bearer "+idp.Token(2), up.AuthHeader(0))
+
+	// Second request: same injected token, still no new token exchange.
+	status, body = get(t, client, target)
+	require.Equal(t, 200, status)
+	require.Equal(t, "upstream-ok\n", body)
+	require.Equal(t, int64(2), idp.Fetches(), "token must be reused, not re-minted")
+	require.Equal(t, 2, up.Requests())
+	require.Equal(t, "Bearer "+idp.Token(2), up.AuthHeader(1))
+
+	// The response arrived over a TLS connection whose leaf chains to
+	// postern's planted CA (the client trusts nothing else).
+	resp, err := client.Get(target)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.NotNil(t, resp.TLS)
+	require.NotEmpty(t, resp.TLS.PeerCertificates)
+	require.Equal(t, caCommonName, resp.TLS.PeerCertificates[0].Issuer.CommonName)
+}
+
+// TestPlainHTTPInjectionFailsClosed documents why the plain-HTTP brokered
+// injection scenario is not implementable against this binary without a
+// production change: the broker refuses to inject on any non-https hop by
+// design (internal/broker/hook.go), so a matched plain-http request fails
+// closed with the uniform 502 before the resolver is called or the upstream
+// is contacted.
+func TestPlainHTTPInjectionFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	e := newEnv(t)
+	idp := startIdP(t, e)
+	up := startUpstream(t, e)
+	proc := startPostern(t, e, renderConfig(freePort(t), idp.URL, "127.0.0.1", "passthrough"))
+	client := proxiedClient(t, proc.proxyURL, e.caPEM)
+
+	target := fmt.Sprintf("http://127.0.0.1:%s/", up.port)
+	status, body := get(t, client, target)
+	require.Equal(t, 502, status)
+	require.Equal(t, failClosedBody, body)
+
+	require.Equal(t, 0, up.Requests(), "upstream must never be contacted")
+	require.Equal(t, int64(1), idp.Fetches(), "only the boot ping may hit the IdP; the request path must not resolve")
+}
+
+// TestFailClosedOnResolverFailure proves the fail-closed guarantee when the
+// credential source is unreachable: the client gets the uniform 502 with the
+// exact body and the stub upstream records zero requests.
+//
+// Deviation from the original scenario shape: postern pings the token
+// endpoint once at boot (fail-closed-at-boot provider validation), so a
+// config pointing at an already-closed port never boots. Instead the server
+// boots against a live stub IdP and the IdP listener is closed before the
+// request, which leaves the token URL pointing at a closed port at request
+// time.
+func TestFailClosedOnResolverFailure(t *testing.T) {
+	t.Parallel()
+
+	e := newEnv(t)
+	idp := startIdP(t, e)
+	up := startUpstream(t, e)
+	proc := startPostern(t, e, renderConfig(freePort(t), idp.URL, "127.0.0.1", "passthrough"))
+	client := proxiedClient(t, proc.proxyURL, e.caPEM)
+
+	idp.srv.Close() // token URL now points at a closed port
+
+	status, body := get(t, client, fmt.Sprintf("https://127.0.0.1:%s/", up.port))
+	require.Equal(t, 502, status)
+	require.Equal(t, failClosedBody, body)
+	require.Equal(t, 0, up.Requests(), "unauthenticated request must never reach the upstream")
+}
+
+// TestHotReloadSwapsRuleHost rewrites the watched config in place, swapping
+// the rule's host, and asserts the new host brokers while the old host stops
+// doing so — without restarting the process.
+func TestHotReloadSwapsRuleHost(t *testing.T) {
+	t.Parallel()
+
+	e := newEnv(t)
+	idp := startIdP(t, e)
+	up := startUpstream(t, e)
+	proc := startPostern(t, e, renderConfig(freePort(t), idp.URL, "localhost", "block"))
+	client := proxiedClient(t, proc.proxyURL, e.caPEM)
+
+	oldURL := fmt.Sprintf("https://localhost:%s/", up.port)
+	newURL := fmt.Sprintf("https://127.0.0.1:%s/", up.port)
+
+	// Baseline: the old host brokers.
+	status, body := get(t, client, oldURL)
+	require.Equal(t, 200, status, "body: %q", body)
+	require.Equal(t, "upstream-ok\n", body)
+	require.Equal(t, "Bearer "+idp.Token(2), up.AuthHeader(0))
+
+	// Only requests after the reload are held to the no-old-host invariant.
+	baselineReqs := up.Requests()
+
+	// Swap the rule's host; credstores stay identical so the reload applies.
+	proc.rewriteConfig(t, renderConfig(freePort(t), idp.URL, "127.0.0.1", "block"))
+
+	// Poll within the watcher's poll interval + debounce window until the
+	// new host brokers. During the transition the old ruleset still serves,
+	// so a 502 here just means "not swapped yet".
+	var swapped bool
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		status, body := get(t, client, newURL)
+		if status == 200 && body == "upstream-ok\n" {
+			swapped = true
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	require.True(t, swapped, "new host never brokered after reload\nlogs:\n%s", proc.logs.String())
+
+	newReqs := up.Requests()
+	require.GreaterOrEqual(t, newReqs, 2)
+	require.Equal(t, "Bearer "+idp.Token(2), up.AuthHeader(newReqs-1))
+
+	// The old host no longer brokers: on_no_match block rejects its CONNECT
+	// with the uniform 502 and it never reaches the upstream again.
+	status, body = get(t, client, oldURL)
+	require.Equal(t, 502, status)
+	require.Equal(t, failClosedBody, body)
+
+	for _, h := range up.Hosts()[baselineReqs:] {
+		require.NotEqual(t, "localhost:"+up.port, h, "old host must not be forwarded after reload")
+	}
+}

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -1,0 +1,441 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// listenRe extracts the port from the config's `listen: 127.0.0.1:<port>`.
+var listenRe = regexp.MustCompile(`(?m)^\s*listen:\s*127\.0\.0\.1:(\d+)\s*$`)
+
+const clientSecretEnv = "POSTERN_E2E_CLIENT_SECRET"
+
+// readyTimeout bounds how long startPostern waits for the listener.
+const readyTimeout = 15 * time.Second
+
+// caCommonName is the Subject CN of the CA the tests plant under
+// $HOME/.postern so the server finds it via ca.Load; clients assert the
+// MITM leaf chains to it.
+const caCommonName = "postern e2e root"
+
+// syncBuffer is a race-safe sink for subprocess output.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// env is the per-test isolated environment: a temp HOME holding the planted
+// CA, and the self-signed serving cert every local TLS stub presents.
+type env struct {
+	home        string
+	caPEM       []byte // postern CA; clients trust only this
+	stubCert    tls.Certificate
+	stubCertPEM []byte // served by upstream/IdP stubs; postern trusts via SSL_CERT_FILE
+}
+
+func newEnv(t *testing.T) *env {
+	t.Helper()
+
+	home := t.TempDir()
+	caPEM := plantCA(t, home)
+	cert, certPEM := selfSignedServingCert(t)
+
+	// Go's crypto/x509 reads this env var for the process-wide root pool; the
+	// system trust store is never touched.
+	bundle := append(append([]byte{}, caPEM...), certPEM...)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "trust-bundle.pem"), bundle, 0o600))
+
+	return &env{home: home, caPEM: caPEM, stubCert: cert, stubCertPEM: certPEM}
+}
+
+// plantCA generates an ECDSA P-256 self-signed CA and writes it where the
+// server expects it ($HOME/.postern/ca.pem + ca.key, both 0600, dir 0700),
+// mirroring ca.Generate/ca.Save. `postern ca install` is deliberately never
+// invoked: the CA is trusted via SSL_CERT_FILE only.
+func plantCA(t *testing.T, home string) []byte {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: caCommonName, Organization: []string{"postern"}},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	dir := filepath.Join(home, ".postern")
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ca.pem"), certPEM, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ca.key"), keyPEM, 0o600))
+	return certPEM
+}
+
+// selfSignedServingCert mints the cert every local TLS stub serves. It covers
+// 127.0.0.1 and localhost so postern's upstream/token dials verify regardless
+// of which spelling the CONNECT target uses.
+func selfSignedServingCert(t *testing.T) (tls.Certificate, []byte) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "postern e2e stub"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+		DNSNames:     []string{"localhost"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	cert := tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+	return cert, certPEM
+}
+
+// startTLSStub runs an httptest server on 127.0.0.1 presenting the shared
+// stub cert over TLS.
+func startTLSStub(t *testing.T, e *env, h http.Handler) *httptest.Server {
+	t.Helper()
+
+	srv := httptest.NewUnstartedServer(h)
+	srv.TLS = &tls.Config{Certificates: []tls.Certificate{e.stubCert}}
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// idpStub is the OAuth2 token endpoint. Every POST mints a fresh token and
+// is counted, so tests can assert exactly how many exchanges happened.
+type idpStub struct {
+	srv    *httptest.Server
+	URL    string
+	mu     sync.Mutex
+	count  int64
+	tokens []string
+}
+
+func startIdP(t *testing.T, e *env) *idpStub {
+	t.Helper()
+
+	s := &idpStub{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		s.mu.Lock()
+		s.count++
+		tok := fmt.Sprintf("e2e-token-%d", s.count)
+		s.tokens = append(s.tokens, tok)
+		s.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": tok,
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	})
+	srv := startTLSStub(t, e, mux)
+	s.srv = srv
+	s.URL = srv.URL + "/token"
+	return s
+}
+
+// Fetches reports how many token exchanges the stub served.
+func (s *idpStub) Fetches() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.count
+}
+
+// Token returns the nth minted token (1-based).
+func (s *idpStub) Token(n int) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.tokens[n-1]
+}
+
+// upstreamStub records every forwarded request's Authorization header and
+// Host so tests can assert injection and (non-)contact.
+type upstreamStub struct {
+	srv   *httptest.Server
+	port  string
+	mu    sync.Mutex
+	auth  []string
+	hosts []string
+}
+
+func startUpstream(t *testing.T, e *env) *upstreamStub {
+	t.Helper()
+
+	u := &upstreamStub{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		u.mu.Lock()
+		u.auth = append(u.auth, r.Header.Get("Authorization"))
+		u.hosts = append(u.hosts, r.Host)
+		u.mu.Unlock()
+		_, _ = w.Write([]byte("upstream-ok\n"))
+	})
+	u.srv = startTLSStub(t, e, mux)
+	u.port = u.srv.URL[strings.LastIndexByte(u.srv.URL, ':')+1:]
+	return u
+}
+
+func (u *upstreamStub) Requests() int {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return len(u.auth)
+}
+
+func (u *upstreamStub) AuthHeader(i int) string {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.auth[i]
+}
+
+func (u *upstreamStub) Hosts() []string {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return append([]string(nil), u.hosts...)
+}
+
+// renderConfig writes the YAML config for one scenario. ruleHost is the
+// brokered host; onNoMatch is "passthrough" or "block".
+func renderConfig(listenPort int, tokenURL, ruleHost, onNoMatch string) []byte {
+	return []byte(fmt.Sprintf(`credstores:
+  - name: e2e-idp
+    provider: oauth2
+    token:
+      source: env
+      env_var: %s
+    settings:
+      token_url: %s
+      client_id: e2e-client
+      grant_type: client_credentials
+
+proxy:
+  cache_ttl: 30s
+  listen: 127.0.0.1:%d
+  on_no_match: %s
+
+rules:
+  - host: %s
+    secret_ref: oauth2://e2e-idp
+    inject:
+      type: header
+      name: authorization
+      template: "Bearer {{ CREDENTIAL }}"
+`, clientSecretEnv, tokenURL, listenPort, onNoMatch, ruleHost))
+}
+
+// posternProc is one running `postern server` subprocess.
+type posternProc struct {
+	cfgPath  string
+	addr     string // 127.0.0.1:<port>
+	proxyURL string
+	logs     *syncBuffer
+	done     chan struct{} // closed once cmd.Wait has reaped the process
+	mu       sync.Mutex
+	waitErr  error
+	cmd      *exec.Cmd
+}
+
+// startPostern launches the compiled binary as a subprocess with a fully
+// isolated environment (temp HOME, bundled SSL_CERT_FILE, no inherited proxy
+// vars), waits for its listener, and registers shutdown cleanup.
+func startPostern(t *testing.T, e *env, cfg []byte) *posternProc {
+	t.Helper()
+
+	// The listen address comes from the config the caller rendered; derive
+	// the readiness address from it so client and server agree on the port.
+	m := listenRe.FindSubmatch(cfg)
+	require.NotNil(t, m, "config must declare proxy.listen: 127.0.0.1:<port>")
+	addr := "127.0.0.1:" + string(m[1])
+	cfgPath := filepath.Join(e.home, "config.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, cfg, 0o600))
+
+	logs := &syncBuffer{}
+	cmd := exec.Command(posternBin, "server", "--config", cfgPath, "--log-level", "debug")
+	cmd.Dir = e.home
+	cmd.Env = []string{
+		"HOME=" + e.home,
+		"PATH=" + os.Getenv("PATH"),
+		"SSL_CERT_FILE=" + filepath.Join(e.home, "trust-bundle.pem"),
+		clientSecretEnv + "=e2e-client-secret",
+	}
+	cmd.Stdout = logs
+	cmd.Stderr = logs
+
+	p := &posternProc{
+		cfgPath:  cfgPath,
+		addr:     addr,
+		proxyURL: "http://" + addr,
+		logs:     logs,
+		done:     make(chan struct{}),
+		cmd:      cmd,
+	}
+	require.NoError(t, cmd.Start())
+	go func() {
+		p.mu.Lock()
+		p.waitErr = cmd.Wait()
+		p.mu.Unlock()
+		close(p.done)
+	}()
+	t.Cleanup(p.stop)
+
+	waitReady(t, p)
+	return p
+}
+
+func waitReady(t *testing.T, p *posternProc) {
+	t.Helper()
+
+	deadline := time.Now().Add(readyTimeout)
+	for time.Now().Before(deadline) {
+		select {
+		case <-p.done:
+			t.Fatalf("postern exited during startup: %v\nlogs:\n%s", p.waitResult(), p.logs.String())
+		default:
+		}
+		conn, err := net.DialTimeout("tcp", p.addr, 250*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("postern not listening on %s within %v\nlogs:\n%s", p.addr, readyTimeout, p.logs.String())
+}
+
+func (p *posternProc) stop() {
+	select {
+	case <-p.done:
+		return
+	default:
+	}
+	if p.cmd.Process != nil {
+		_ = p.cmd.Process.Signal(syscall.SIGTERM)
+	}
+	select {
+	case <-p.done:
+	case <-time.After(5 * time.Second):
+		if p.cmd.Process != nil {
+			_ = p.cmd.Process.Kill()
+		}
+		<-p.done
+	}
+}
+
+// waitResult blocks until the subprocess has been reaped and returns its
+// exit error (nil on clean shutdown).
+func (p *posternProc) waitResult() error {
+	<-p.done
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.waitErr
+}
+
+// rewriteConfig atomically replaces the server's config file the way an
+// editor does (write temp + rename) so the hot-reload watcher sees it.
+func (p *posternProc) rewriteConfig(t *testing.T, cfg []byte) {
+	t.Helper()
+
+	tmp := p.cfgPath + ".new"
+	require.NoError(t, os.WriteFile(tmp, cfg, 0o600))
+	require.NoError(t, os.Rename(tmp, p.cfgPath))
+}
+
+// proxiedClient returns an HTTP client that routes through the postern
+// subprocess and trusts only postern's planted CA for MITM'd TLS.
+func proxiedClient(t *testing.T, proxyURL string, caPEM []byte) *http.Client {
+	t.Helper()
+
+	pool := x509.NewCertPool()
+	require.True(t, pool.AppendCertsFromPEM(caPEM), "postern CA PEM must parse")
+	proxyU, err := url.Parse(proxyURL)
+	require.NoError(t, err)
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy:               http.ProxyURL(proxyU),
+			DialContext:         (&net.Dialer{Timeout: 5 * time.Second}).DialContext,
+			TLSHandshakeTimeout: 5 * time.Second,
+			TLSClientConfig:     &tls.Config{RootCAs: pool},
+		},
+		Timeout: 15 * time.Second,
+	}
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	require.NoError(t, l.Close())
+	return port
+}
+
+// get performs a GET through the client and returns status + body.
+func get(t *testing.T, c *http.Client, target string) (int, string) {
+	t.Helper()
+
+	resp, err := c.Get(target)
+	if err != nil {
+		return 0, fmt.Sprintf("transport error: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, string(body)
+}

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -32,8 +32,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// listenRe extracts the port from the config's `listen: 127.0.0.1:<port>`.
-var listenRe = regexp.MustCompile(`(?m)^\s*listen:\s*127\.0\.0\.1:(\d+)\s*$`)
+// boundAddrRe extracts the actual bound address from the server's
+// "proxy listening" log line. Test configs declare `listen: 127.0.0.1:0`
+// so the OS assigns the port at bind time (no allocate-then-close race);
+// the real address is only observable here.
+var boundAddrRe = regexp.MustCompile(`proxy listening addr=(\S+)`)
 
 const clientSecretEnv = "POSTERN_E2E_CLIENT_SECRET"
 
@@ -250,9 +253,11 @@ func (u *upstreamStub) Hosts() []string {
 	return append([]string(nil), u.hosts...)
 }
 
-// renderConfig writes the YAML config for one scenario. ruleHost is the
-// brokered host; onNoMatch is "passthrough" or "block".
-func renderConfig(listenPort int, tokenURL, ruleHost, onNoMatch string) []byte {
+// renderConfig writes the YAML config for one scenario. The proxy listens
+// on 127.0.0.1:0 so the OS assigns the port at bind time; the tests read
+// the actual address from the server's log (see boundAddrRe). ruleHost is
+// the brokered host; onNoMatch is "passthrough" or "block".
+func renderConfig(tokenURL, ruleHost, onNoMatch string) []byte {
 	return []byte(fmt.Sprintf(`credstores:
   - name: e2e-idp
     provider: oauth2
@@ -266,7 +271,7 @@ func renderConfig(listenPort int, tokenURL, ruleHost, onNoMatch string) []byte {
 
 proxy:
   cache_ttl: 30s
-  listen: 127.0.0.1:%d
+  listen: 127.0.0.1:0
   on_no_match: %s
 
 rules:
@@ -276,7 +281,7 @@ rules:
       type: header
       name: authorization
       template: "Bearer {{ CREDENTIAL }}"
-`, clientSecretEnv, tokenURL, listenPort, onNoMatch, ruleHost))
+`, clientSecretEnv, tokenURL, onNoMatch, ruleHost))
 }
 
 // posternProc is one running `postern server` subprocess.
@@ -297,11 +302,6 @@ type posternProc struct {
 func startPostern(t *testing.T, e *env, cfg []byte) *posternProc {
 	t.Helper()
 
-	// The listen address comes from the config the caller rendered; derive
-	// the readiness address from it so client and server agree on the port.
-	m := listenRe.FindSubmatch(cfg)
-	require.NotNil(t, m, "config must declare proxy.listen: 127.0.0.1:<port>")
-	addr := "127.0.0.1:" + string(m[1])
 	cfgPath := filepath.Join(e.home, "config.yaml")
 	require.NoError(t, os.WriteFile(cfgPath, cfg, 0o600))
 
@@ -318,12 +318,10 @@ func startPostern(t *testing.T, e *env, cfg []byte) *posternProc {
 	cmd.Stderr = logs
 
 	p := &posternProc{
-		cfgPath:  cfgPath,
-		addr:     addr,
-		proxyURL: "http://" + addr,
-		logs:     logs,
-		done:     make(chan struct{}),
-		cmd:      cmd,
+		cfgPath: cfgPath,
+		logs:    logs,
+		done:    make(chan struct{}),
+		cmd:     cmd,
 	}
 	require.NoError(t, cmd.Start())
 	go func() {
@@ -338,6 +336,9 @@ func startPostern(t *testing.T, e *env, cfg []byte) *posternProc {
 	return p
 }
 
+// waitReady polls the subprocess log for the bound listener address and
+// confirms it accepts connections. Polls every 10ms against a generous
+// deadline; no fixed startup delay.
 func waitReady(t *testing.T, p *posternProc) {
 	t.Helper()
 
@@ -348,14 +349,18 @@ func waitReady(t *testing.T, p *posternProc) {
 			t.Fatalf("postern exited during startup: %v\nlogs:\n%s", p.waitResult(), p.logs.String())
 		default:
 		}
-		conn, err := net.DialTimeout("tcp", p.addr, 250*time.Millisecond)
-		if err == nil {
-			_ = conn.Close()
-			return
+		if m := boundAddrRe.FindStringSubmatch(p.logs.String()); m != nil {
+			p.addr = m[1]
+			p.proxyURL = "http://" + p.addr
+			conn, err := net.DialTimeout("tcp", p.addr, 250*time.Millisecond)
+			if err == nil {
+				_ = conn.Close()
+				return
+			}
 		}
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatalf("postern not listening on %s within %v\nlogs:\n%s", p.addr, readyTimeout, p.logs.String())
+	t.Fatalf("postern not listening within %v\nlogs:\n%s", readyTimeout, p.logs.String())
 }
 
 func (p *posternProc) stop() {
@@ -414,16 +419,6 @@ func proxiedClient(t *testing.T, proxyURL string, caPEM []byte) *http.Client {
 		},
 		Timeout: 15 * time.Second,
 	}
-}
-
-func freePort(t *testing.T) int {
-	t.Helper()
-
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	port := l.Addr().(*net.TCPAddr).Port
-	require.NoError(t, l.Close())
-	return port
 }
 
 // get performs a GET through the client and returns status + body.

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,0 +1,49 @@
+//go:build e2e
+
+// Package e2e_test exercises the compiled postern binary black-box: each
+// test builds the real config.yaml, runs `postern server` as a subprocess
+// against local stub upstreams and IdPs, and asserts on observable HTTP
+// behavior. Run with:
+//
+//	go test -tags=e2e ./test/e2e/...
+package e2e_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// posternBin is the path of the binary built once by TestMain.
+var posternBin string
+
+func TestMain(m *testing.M) {
+	tmp, err := os.MkdirTemp("", "postern-e2e-bin-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "e2e: mktemp: %v\n", err)
+		os.Exit(1)
+	}
+	bin := filepath.Join(tmp, "postern")
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		fmt.Fprintln(os.Stderr, "e2e: cannot locate repo root")
+		os.Exit(1)
+	}
+	root := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+
+	build := exec.Command("go", "build", "-o", bin, "./cmd/postern")
+	build.Dir = root
+	if out, err := build.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "e2e: build postern: %v\n%s\n", err, out)
+		os.Exit(1)
+	}
+	posternBin = bin
+
+	code := m.Run()
+	_ = os.RemoveAll(tmp)
+	os.Exit(code)
+}


### PR DESCRIPTION
## Problem

The repo had no end-to-end coverage: every test drives internal packages in-process, so the compiled binary's boot path, subprocess behavior, CA handling, and hot-reload wiring were never exercised together.

## Changes

New `test/e2e/` package (build tag `e2e`, package `e2e_test`). `TestMain` builds `cmd/postern` once; each test runs the binary as a subprocess with an isolated temp `$HOME`, a written `config.yaml`, and a stub OAuth2 IdP + upstream as local TLS servers. No external network; nothing touches the system trust store (postern's CA is planted under temp HOME and trusted via `SSL_CERT_FILE`; all listeners bind 127.0.0.1).

Scenarios:

- **HTTPS brokered injection over real TLS**: client CONNECTs through postern to an https upstream; asserts the injected `Authorization: Bearer` header at the upstream, response pass-through, the minted leaf chaining to postern's CA, and exactly one runtime token fetch across two requests.
- **Fail-closed on resolver failure**: token endpoint closed at request time → client gets `502` with body exactly `postern: bad gateway\n`, upstream records zero requests.
- **Hot reload round-trip**: rewriting the watched config swaps the rule's host without restarting; new host brokers, old host is rejected (`on_no_match: block`), asserted within the watcher poll interval + debounce window.
- **Plain HTTP fails closed** (see deviation): matched plain-http requests get the uniform 502 before any resolve or upstream contact.

## Deviations from the original scenario list

1. **Plain-HTTP brokered injection is not implementable against this binary without a production change.** The broker refuses injection on any non-https hop by design (`internal/broker/hook.go`: "a plain-http request forwarded through the proxy keeps scheme http ... fail closed"). The suite includes `TestPlainHTTPInjectionFailsClosed` documenting that behavior black-box. Enabling cleartext injection would be a deliberate security-posture change and needs its own decision.
2. **Scenario 3 boots against a live token endpoint that is then closed**, rather than pointing at a dead port from the start: providers ping the credential source once at boot (fail-closed-at-boot validation in `internal/cli/server.go` / oauth2 `Provider.Validate`), so a config whose token URL is unreachable never boots. Closing the listener after boot leaves the token URL pointing at a closed port at request time, which is the property under test.
3. The oauth2 provider requires an absolute `https` `token_url`, so the stub IdP serves TLS with a self-signed cert added to postern's `SSL_CERT_FILE` bundle alongside the CA.

## Acceptance demonstrated by the suite

- `go test -tags=e2e -race -count=2 ./test/e2e/...` green locally in the devcontainer: `ok github.com/mmartinez/postern/test/e2e 12.873s` (4 tests, wall ~13s including binary build).
- Untagged default build unaffected: `go test ./test/...` skips the directory without the tag; `make ci` green (lint 0 issues, full suite ok, govulncheck clean, licenses regenerated).
