### PR TITLE
docs: macOS support for CA trust and token keychain

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ configured provider; adding a new provider is a single package. See
 
 > **Status:** early development. The proxy works end-to-end, and the release
 > pipeline (checksum-verified binaries, SBOMs, and a signed multi-arch container
-> image) publishes from the first tagged release (`v0.1.0`) onward. **Linux
-> amd64/arm64 only** — macOS and Windows are deferred until there is demand.
+> image) publishes from the first tagged release (`v0.1.0`) onward. **Linux and
+> macOS amd64/arm64** are supported; Windows is deferred until there is demand.
 
 ## Install
 
@@ -110,6 +110,10 @@ postern server            # run the proxy
 # in the agent's shell, wire HTTPS_PROXY + CA trust in one step:
 eval "$(postern bootstrap)"
 ```
+
+On macOS, `postern ca install` triggers an authorization prompt and trusts the
+CA in your user login keychain — no `sudo`. `postern ca uninstall` revokes that
+trust setting and deletes the certificate from the keychain.
 
 `postern config validate` checks a config with line-numbered errors, and
 `postern rules list` shows the loaded rules (never the resolved credentials).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,6 +45,13 @@ token:
 Never put the token value itself in the config or on a command line. The config
 names *where* the token lives, not the token.
 
+On macOS the OS-keychain step resolves against the **login Keychain**: the
+backend probe prefers the Keychain backend over every other store, so
+`source: keychain` (and the keychain step of `source: auto`) reads and writes
+the token there. On macOS the local CA that `postern ca install` anchors lives
+at `~/.postern/trust/ca.pem`; see [security.md](security.md) for the trust
+mechanics.
+
 ## `credstores`
 
 The multi-vendor form. Each entry names a vendor and how to get its token.

--- a/docs/security.md
+++ b/docs/security.md
@@ -100,9 +100,23 @@ When a token must be referenced in human-facing output, it is masked to a
 
 **Local CA.** `postern ca install` generates a CA at `~/.postern/ca.{pem,key}`
 (`0600` files under a `0700` directory) and adds the certificate to the system
-trust store. `postern ca uninstall [--purge]` reverses it. The CA private key
-never leaves the machine and is used only to mint short-lived per-host leaf
+trust store. On macOS it instead anchors the certificate at
+`~/.postern/trust/ca.pem` and records a **user-domain** trust setting in your
+login keychain via `/usr/bin/security add-trusted-cert`: per-user, not
+system-wide, which is why no `sudo` is required (the authorization prompt the
+command triggers is expected). System-wide (admin-domain) trust is a deliberate
+follow-up, not current behavior. `postern ca uninstall [--purge]` reverses it:
+on macOS that revokes the user trust setting (`security remove-trusted-cert`),
+deletes the certificate from the login keychain
+(`security delete-certificate -Z`), and removes the anchor PEM. The CA private
+key never leaves the machine and is used only to mint short-lived per-host leaf
 certificates at request time.
+
+**`SSL_CERT_FILE` and GUI clients.** `postern bootstrap` prints an
+`SSL_CERT_FILE` export unconditionally. On macOS that variable is honored by Go
+programs and OpenSSL-linked CLIs (such as `curl`), but GUI apps and browsers
+ignore it: an agent that is a browser or other GUI client needs the keychain
+trust installed by `postern ca install` instead.
 
 **Service-account token.** Postern obtains the credential vendor's
 service-account token through a resolution chain. With `source: auto` it tries,


### PR DESCRIPTION
## Problem

#80 landed macOS support (`feat(ca): macOS trust-store install via security`) but the docs still say "Linux amd64/arm64 only" and describe only the Linux trust model.

## Changes

- **README.md** - status line now reads Linux and macOS amd64/arm64 (Windows deferred). Quick start gains a macOS note: `postern ca install` triggers an authorization prompt and trusts the CA in the user login keychain without sudo; `postern ca uninstall` revokes it.
- **docs/configuration.md** - `token` section notes that on macOS the OS-keychain step resolves against the login Keychain (the backend probe prefers `KeychainBackend` first, `internal/token/probe.go:16-26`), and records the macOS CA anchor path `~/.postern/trust/ca.pem` (`defaultTrustDir` in `internal/ca/trust_darwin.go`).
- **docs/security.md** - Local CA section now covers the macOS mechanics: user-domain (per-user, not system-wide) trust recorded in the login keychain via `/usr/bin/security add-trusted-cert`, no sudo, expected authorization prompt; uninstall revokes the trust setting (`remove-trusted-cert`), deletes the keychain certificate by SHA-256 (`delete-certificate -Z`), and removes the anchor PEM; system-wide admin-domain trust is stated as a deliberate follow-up, not current behavior. New `SSL_CERT_FILE` paragraph: `postern bootstrap` prints the export unconditionally (`internal/cli/bootstrap.go:110-117`); on macOS Go programs and OpenSSL-linked CLIs honor it but GUI apps and browsers ignore it, so browser/GUI agents need keychain trust from `postern ca install` instead.

No launchd/plist content: none ships in this release.

## Acceptance

- [x] Docs-only diff across README.md, docs/configuration.md, docs/security.md
- [x] Claims match merged M1 behavior (internal/ca/trust_darwin.go: user-domain `add-trusted-cert -r trustRoot -k <login keychain>`, anchor at ~/.postern/trust/ca.pem, idempotent uninstall)
- [x] `make ci` green in devcontainer (golangci-lint 0 issues, go test -race ok, govulncheck clean)
