### PR TITLE
feat(release): darwin targets built natively on macos runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,23 @@ name: release
 
 # Release-please drives versioning. Conventional-commit pushes to main keep a
 # Release PR up to date (version bump + CHANGELOG); merging that PR creates the
-# tag and GitHub Release. The goreleaser job runs in the SAME workflow run,
+# tag and GitHub Release. The goreleaser jobs run in the SAME workflow run,
 # gated on release_created — the default GITHUB_TOKEN cannot trigger a separate
 # tag-triggered workflow, so the build runs here rather than via on:push:tags.
-# release-please owns the release body (CHANGELOG); goreleaser uploads the
-# binaries, checksums, SBOMs, cosign bundle and image onto it
+#
+# Split build (OSS goreleaser has no native split/merge — that is Pro-only):
+#   1. goreleaser-darwin builds the darwin targets natively on a macos runner
+#      (cgo against Security.framework needs the real macOS SDK) and uploads
+#      its archives, SBOMs and checksum slice as a workflow artifact. It does
+#      not publish anything.
+#   2. goreleaser (ubuntu) keeps the linux builds, docker push/manifest signing,
+#      and publishes to the release; then it merges the darwin checksum slice
+#      into checksums.txt, signs the merged file with keyless cosign, and
+#      uploads it plus the darwin assets. Signing happens only after the merge:
+#      the bundle must cover every artifact by digest, and each single run's
+#      checksums.txt covers only its own half.
+#
+# release-please owns the release body (CHANGELOG)
 # (release.mode: keep-existing in .goreleaser.yaml).
 on:
   push:
@@ -41,9 +53,48 @@ jobs:
           # config-file and manifest-file default to release-please-config.json
           # and .release-please-manifest.json at the repo root.
 
-  goreleaser:
-    name: goreleaser
+  goreleaser-darwin:
+    name: goreleaser (darwin)
     needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Build the exact commit release-please tagged, not the branch head.
+          ref: ${{ needs.release-please.outputs.tag_name }}
+          fetch-depth: 0
+      - uses: actions/setup-go@v7
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      - name: install syft (SBOM generation)
+        uses: anchore/sbom-action/download-syft@v0
+      - name: goreleaser release (darwin)
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: ${{ env.GORELEASER_VERSION }}
+          # The host-GOOS skip filters in .goreleaser.yaml make this run build
+          # darwin targets only. No publish/docker here: this job produces the
+          # darwin archives, SBOMs and checksum slice for the ubuntu job to
+          # merge into the release.
+          args: release --clean --skip=publish,docker
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: upload darwin artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: darwin-dist
+          if-no-files-found: error
+          path: |
+            dist/*.tar.gz
+            dist/*.sbom.spdx.json
+            dist/checksums.txt
+
+  goreleaser:
+    name: goreleaser (linux + publish)
+    needs: [release-please, goreleaser-darwin]
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
@@ -75,7 +126,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: goreleaser release
+      - name: goreleaser release (linux + publish)
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
@@ -83,3 +134,33 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: download darwin artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: darwin-dist
+          path: dist-darwin
+      - name: merge checksums and sign (covers every archive by digest)
+        env:
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          # goreleaser just published its linux-only checksums.txt, unsigned
+          # (signing lives in this step). Swap in the merged file before
+          # signing so the release never holds a partial final-looking list
+          # for longer than one step.
+          cat dist/checksums.txt dist-darwin/checksums.txt > /tmp/checksums.txt.merged
+          mv /tmp/checksums.txt.merged dist/checksums.txt
+          cosign sign-blob \
+            "--bundle=dist/checksums.txt.sigstore.json" \
+            dist/checksums.txt \
+            --yes
+      - name: upload darwin assets and signed checksums
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          gh release upload "$TAG_NAME" --clobber \
+            dist/checksums.txt \
+            dist/checksums.txt.sigstore.json \
+            dist-darwin/*.tar.gz \
+            dist-darwin/*.sbom.spdx.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,8 @@ jobs:
       - name: install syft (SBOM generation)
         uses: anchore/sbom-action/download-syft@v0
       - name: goreleaser release (darwin)
-        uses: goreleaser/goreleaser-action@v7
+        # f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 = goreleaser-action v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           distribution: goreleaser
           version: ${{ env.GORELEASER_VERSION }}
@@ -127,7 +128,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: goreleaser release (linux + publish)
-        uses: goreleaser/goreleaser-action@v7
+        # f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 = goreleaser-action v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           distribution: goreleaser
           version: ${{ env.GORELEASER_VERSION }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,6 +1,7 @@
 # goreleaser v2 config.
 #
-# Scope: linux only. macOS support is deferred until there is demand.
+# Scope: linux (cross-compiled with zig on ubuntu) + darwin (built natively on
+# a macos runner; see the split-build flow in .github/workflows/release.yml).
 #
 # `make snapshot` and the snapshot CI job exercise everything below except
 # signing and ghcr push (those need a real tag run under GitHub OIDC — see
@@ -16,13 +17,18 @@ before:
     - go mod tidy
 
 builds:
-  # The credential SDK (internal/credstore/onepassword) forces CGO_ENABLED=1
-  # (its no-cgo path is a deliberate compile wall). A stock gcc only emits
-  # host-arch objects, so cross-compiling
+  # CGO status: darwin needs CGO_ENABLED=1 because the keyring backend links
+  # Security.framework (99designs/keyring). The vendored credential SDK ships
+  # a working !cgo variant, so it does not pin cgo either way.
+  #
+  # Linux: a stock gcc only emits host-arch objects, so cross-compiling
   # the C half of the matrix needs a cross C compiler: zig cc, pinned to a
   # glibc 2.31 floor so the binaries run on the distroless/base runtime image
   # (glibc 2.36) and on older hosts via the tarball install path.
   - id: postern
+    # Skip on macs, where the darwin build below runs instead; keeps linux
+    # snapshot runs linux-only. See the split-build flow in release.yml.
+    skip: '{{ eq .Runtime.Goos "darwin" }}'
     main: ./cmd/postern
     binary: postern
     env:
@@ -50,6 +56,51 @@ builds:
       - -X github.com/mmartinez/postern/internal/version.Version={{.Version}}
       - -X github.com/mmartinez/postern/internal/version.Commit={{.Commit}}
       - -X github.com/mmartinez/postern/internal/version.BuildDate={{.Date}}
+  # Darwin: cgo against Security.framework needs the real macOS SDK, which
+  # only exists on Apple hardware, so these targets build natively on the
+  # macos runner in release.yml and are skipped everywhere else (the host-GOOS
+  # `skip` filters keep every single goreleaser run on targets its host can
+  # actually build). Checksums for both runs are merged and signed by the
+  # publish job — a signature made inside one run could only cover that run's
+  # archives.
+  - id: postern-darwin
+    skip: '{{ ne .Runtime.Goos "darwin" }}'
+    main: ./cmd/postern
+    binary: postern
+    env:
+      - CGO_ENABLED=1
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    overrides:
+      # goreleaser picks no cross-arch C compiler by default; pin clang -arch
+      # so amd64 builds correctly on the arm64 macos runner (and vice versa).
+      - goos: darwin
+        goarch: amd64
+        env:
+          - CC=clang -arch x86_64
+          - CXX=clang++ -arch x86_64
+      - goos: darwin
+        goarch: arm64
+        env:
+          - CC=clang -arch arm64
+          - CXX=clang++ -arch arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X github.com/mmartinez/postern/internal/version.Version={{.Version}}
+      - -X github.com/mmartinez/postern/internal/version.Commit={{.Commit}}
+      - -X github.com/mmartinez/postern/internal/version.BuildDate={{.Date}}
+    hooks:
+      post:
+        # arm64 macOS refuses to run completely unsigned binaries; the linker
+        # ad-hoc signs by default, but sign explicitly so that does not depend
+        # on a toolchain default. Deliberately ad-hoc only: Developer ID
+        # signing + notarization is a tracked follow-up.
+        - cmd: codesign --sign - --force "{{ .Path }}"
 
 archives:
   - id: postern
@@ -65,8 +116,8 @@ checksum:
   name_template: "checksums.txt"
 
 # release-please publishes the GitHub Release (with CHANGELOG notes) and creates
-# the tag when the Release PR merges; the goreleaser job then uploads the
-# archives, checksums, SBOMs and cosign bundle onto that existing release.
+# the tag when the Release PR merges; the goreleaser jobs then upload the
+# archives, checksums, SBOMs and image onto that existing release.
 # mode: keep-existing preserves release-please's notes and appends the assets.
 # This requires repository release immutability to stay OFF — an immutable
 # release rejects asset uploads with HTTP 422. See .github/workflows/release.yml.
@@ -89,20 +140,11 @@ changelog:
       - Merge branch
 
 # === Signing ===
-# Keyless cosign (OIDC via GitHub Actions; no private key). Signs the checksums
-# file into a sigstore bundle — verifying it covers every artifact by digest.
-# --snapshot does NOT imply skipping this, so snapshot/PR runs pass --skip=sign
-# (there is no OIDC token or cosign there); a real tag run signs for real.
-signs:
-  - cmd: cosign
-    signature: "${artifact}.sigstore.json"
-    args:
-      - sign-blob
-      - "--bundle=${signature}"
-      - "${artifact}"
-      - "--yes"
-    artifacts: checksum
-    output: true
+# The checksums file is signed with keyless cosign (OIDC via GitHub Actions) in
+# .github/workflows/release.yml — AFTER the darwin and linux checksum slices
+# are merged, so the sigstore bundle covers every artifact by digest. It cannot
+# live here: each split run produces only its own slice of checksums.txt, and
+# there is no `signs` pipeline step that runs after a merge in OSS goreleaser.
 
 # === SBOM ===
 # syft produces an SPDX-JSON SBOM per archive. Runs in snapshot and release.

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# postern installer — Linux amd64/arm64 only (macOS/Windows deferred).
+# postern installer — Linux and macOS, amd64/arm64 (Windows deferred).
 #
 # Downloads a release tarball and checksums.txt from GitHub, verifies the
 # tarball's sha256, and installs the binary to /usr/local/bin (override with
@@ -32,14 +32,14 @@ err() {
 }
 
 case "$OS" in
-linux) ;;
-*) err "unsupported OS '${OS}' (linux only; macOS/Windows deferred)" ;;
+linux | darwin) ;;
+*) err "unsupported OS '${OS}' (linux/darwin only; Windows deferred)" ;;
 esac
 
 case "$ARCH" in
 x86_64 | amd64) ARCH=amd64 ;;
 aarch64 | arm64) ARCH=arm64 ;;
-*) err "unsupported architecture '${ARCH}' (linux amd64/arm64 only)" ;;
+*) err "unsupported architecture '${ARCH}' (linux/darwin amd64/arm64 only)" ;;
 esac
 
 VERSION="${POSTERN_VERSION:-}"
@@ -65,7 +65,12 @@ curl -fsSL -o "${tmp}/checksums.txt" "${BASE_URL}/${VERSION}/checksums.txt" ||
 echo "postern: verifying checksum…"
 expected="$(awk -v f="$ASSET" '$2 == f {print $1}' "${tmp}/checksums.txt")"
 [ -n "$expected" ] || err "${ASSET} is missing from checksums.txt"
-actual="$(sha256sum "${tmp}/${ASSET}" | awk '{print $1}')"
+if command -v sha256sum >/dev/null 2>&1; then
+	actual="$(sha256sum "${tmp}/${ASSET}" | awk '{print $1}')"
+else
+	# macOS ships shasum instead of GNU coreutils' sha256sum.
+	actual="$(shasum -a 256 "${tmp}/${ASSET}" | awk '{print $1}')"
+fi
 [ "$expected" = "$actual" ] || err "checksum verification failed for ${ASSET}"
 
 tar -xzf "${tmp}/${ASSET}" -C "$tmp" postern || err "could not extract postern from ${ASSET}"

--- a/test/install/install_test.go
+++ b/test/install/install_test.go
@@ -83,7 +83,9 @@ func serveRelease(t *testing.T, tag, asset string, tarball []byte, sum, checksum
 // stdout, stderr, and the run error.
 func runInstall(t *testing.T, env map[string]string) (string, string, error) {
 	t.Helper()
-	cmd := exec.Command("sh", installScript(t))
+	// Absolute interpreter path: one test runs with a hermetic PATH that
+	// deliberately excludes everything but the tools install.sh needs.
+	cmd := exec.Command("/bin/sh", installScript(t))
 	cmd.Env = append(os.Environ(), "POSTERN_OS=linux")
 	for k, v := range env {
 		cmd.Env = append(cmd.Env, k+"="+v)
@@ -156,4 +158,84 @@ func TestInstallUnsupportedArchAborts(t *testing.T) {
 	require.Contains(t, strings.ToLower(stderr), "unsupported architecture")
 	_, statErr := os.Stat(filepath.Join(installDir, "postern"))
 	require.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+// TestInstallDarwinHappyPath pins the darwin asset naming against the
+// goreleaser name_template (postern_<ver>_<os>_<arch>.tar.gz) for both new
+// darwin targets, and proves the script end-to-end on the darwin path.
+func TestInstallDarwinHappyPath(t *testing.T) {
+	t.Parallel()
+	for _, arch := range []string{"amd64", "arm64"} {
+		t.Run(arch, func(t *testing.T) {
+			t.Parallel()
+			const tag, ver = "v1.2.3", "1.2.3"
+			asset := "postern_" + ver + "_darwin_" + arch + ".tar.gz"
+			tarball, sum := fakeTarball(t, "#!/bin/sh\necho 'postern fake "+ver+"'\n")
+			srv := serveRelease(t, tag, asset, tarball, sum, "")
+			installDir := t.TempDir()
+
+			_, stderr, err := runInstall(t, map[string]string{
+				"POSTERN_OS":          "darwin",
+				"POSTERN_ARCH":        arch,
+				"POSTERN_VERSION":     tag,
+				"POSTERN_BASE_URL":    srv.URL,
+				"POSTERN_INSTALL_DIR": installDir,
+			})
+			require.NoError(t, err, "install.sh failed; stderr:\n%s", stderr)
+
+			out, runErr := exec.Command(filepath.Join(installDir, "postern")).Output()
+			require.NoError(t, runErr)
+			require.Contains(t, string(out), "postern fake "+ver)
+		})
+	}
+}
+
+func TestInstallUnsupportedOSAborts(t *testing.T) {
+	t.Parallel()
+	installDir := t.TempDir()
+	_, stderr, err := runInstall(t, map[string]string{
+		"POSTERN_OS":          "windows",
+		"POSTERN_ARCH":        "amd64",
+		"POSTERN_VERSION":     "v1.2.3",
+		"POSTERN_BASE_URL":    "http://127.0.0.1:0", // must never be reached
+		"POSTERN_INSTALL_DIR": installDir,
+	})
+	require.Error(t, err, "install.sh should reject an unsupported OS")
+	require.Contains(t, strings.ToLower(stderr), "unsupported os")
+	_, statErr := os.Stat(filepath.Join(installDir, "postern"))
+	require.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+// TestInstallShasumFallbackOnDarwin exercises the checksum-tool fallback a
+// stock macOS host hits: no GNU sha256sum, only shasum -a 256. The test PATH
+// contains exactly the external tools install.sh needs, sha256sum excluded.
+func TestInstallShasumFallbackOnDarwin(t *testing.T) {
+	if _, err := exec.LookPath("shasum"); err != nil {
+		t.Skip("shasum not available on this host")
+	}
+	bin := t.TempDir()
+	for _, tool := range []string{"mktemp", "rm", "awk", "tar", "mkdir", "install", "shasum", "curl", "gzip"} {
+		path, err := exec.LookPath(tool)
+		require.NoError(t, err, "missing %s for hermetic PATH", tool)
+		require.NoError(t, os.Symlink(path, filepath.Join(bin, tool)))
+	}
+	// t.Setenv forbids t.Parallel; env is inherited by the script below.
+	t.Setenv("PATH", bin)
+
+	const tag, ver = "v1.2.3", "1.2.3"
+	asset := "postern_" + ver + "_darwin_arm64.tar.gz"
+	tarball, sum := fakeTarball(t, "#!/bin/sh\necho 'postern fake "+ver+"'\n")
+	srv := serveRelease(t, tag, asset, tarball, sum, "")
+	installDir := t.TempDir()
+
+	_, stderr, err := runInstall(t, map[string]string{
+		"POSTERN_OS":          "darwin",
+		"POSTERN_ARCH":        "arm64",
+		"POSTERN_VERSION":     tag,
+		"POSTERN_BASE_URL":    srv.URL,
+		"POSTERN_INSTALL_DIR": installDir,
+	})
+	require.NoError(t, err, "install.sh failed; stderr:\n%s", stderr)
+	_, statErr := os.Stat(filepath.Join(installDir, "postern"))
+	require.NoError(t, statErr)
 }


### PR DESCRIPTION
## Problem

Releases were linux-only. The darwin targets (amd64, arm64) need to ship archives that install.sh can serve on macOS.

OSS goreleaser has no native split/merge (`release --split` + `continue --merge` is Pro-only), so the cross-platform flow is built from two workflow jobs against one config.

## Evidence

- goreleaser v2.16 OSS subcommands: only build/release/check/healthcheck/init/man/schema; `skips.Build` has no `build` key, so a publish run cannot skip building. Source: goreleaser@google/goreleaser v2.16.0 `cmd/root.go`, `internal/skips/skips.go`.
- Split & Merge docs are marked Pro-only (www/content/customization/general/partial.md).
- Host-based filtering works in OSS via per-build `skip` templates evaluated with `.Runtime.Goos` (`internal/pipe/build/build.go`, `internal/tmpl/tmpl.go`).
- goreleaser picks no cross-arch C compiler for darwin cgo; CC must be pinned per target.

## Changes

- .goreleaser.yaml
  - new `postern-darwin` build id: goos darwin, goarch amd64+arm64, CGO_ENABLED=1, clang `-arch` overrides so amd64 builds on the arm64 macos runner.
  - host-GOOS `skip` filters: each run builds only what its machine can (`{{ eq .Runtime.Goos "darwin" }}` / `ne`). Snapshot runs stay linux-only: exactly 2 tar.gz + 2 SBOMs as the CI job asserts.
  - post-build hook ad-hoc codesigns darwin binaries (`codesign --sign - --force`) before archiving. Notarization (Developer ID + staple) is a deliberate follow-up, not included here.
  - stale CGO comment corrected: keyring requires cgo on darwin (Security.framework); the 1Password SDK ships a working !cgo variant and pins neither way.
  - `signs:` block removed: signing moved to release.yml because each single run's checksums.txt covers only its own half; the bundle must sign the merged file.
- release.yml
  - new `goreleaser-darwin` job (macos-latest): builds darwin targets, produces archives + SBOMs + checksum slice, uploads as workflow artifact; publishes nothing.
  - `goreleaser` job (ubuntu) keeps linux builds, docker push + manifest signing, and publishing; then merges the checksum slices, signs the merged checksums.txt with keyless cosign, and uploads it plus the darwin assets via `gh release upload --clobber`. Gated on the macos job succeeding.
- install.sh
  - accepts Darwin (`uname Darwin`), reusing the existing arch mapping (arm64 already mapped).
  - sha256sum with `shasum -a 256` fallback where GNU coreutils is absent (stock macOS). POSTERN_OS/POSTERN_ARCH/POSTERN_BASE_URL test seams unchanged.
- test/install/install_test.go
  - darwin happy-path cases for both arches pinning asset naming to the goreleaser name_template (`postern_<ver>_darwin_<arch>.tar.gz`).
  - unsupported-OS rejection case.
  - hermetic-PATH test exercising the shasum fallback end-to-end (no sha256sum on PATH).

## Acceptance

- [x] goreleaser check passes (v2.16.0)
- [x] snapshot smoke run in devcontainer: exactly 2 tar.gz + 2 SBOMs, linux-only; darwin targets present in config with correct GOOS/arch matrix and CGO setting
- [x] install.sh handles Darwin end-to-end: `go test ./test/install/...` green; full `go test -race ./...` green; bash -n clean
- [x] shellcheck clean (downloaded v0.10.0 locally; not in devcontainer)
- [x] gofumpt / golangci-lint clean

Not verifiable locally: the macos release path itself (first real tag run will exercise it).