### PR TITLE
fix(ca): unify trust-anchor contract and harden macOS revocation

### DIFF
--- a/internal/ca/gen.go
+++ b/internal/ca/gen.go
@@ -62,6 +62,11 @@ type CA struct {
 // and ca.Save use, without re-stating the "ca.pem" filename.
 func CertPath(dir string) string { return filepath.Join(dir, caCertFile) }
 
+// caCommonName is the subject common name every postern CA carries. The
+// macOS trust backend matches it when recovering a lost anchor from the
+// login keychain, so it must stay in sync with Generate's subject below.
+const caCommonName = "Postern Local CA"
+
 // Generate produces a fresh ECDSA P-256 self-signed CA whose validity window
 // runs from now to now + 10 years. The CA is returned in memory only; call
 // Save to persist it.
@@ -79,7 +84,7 @@ func Generate(now time.Time) (*CA, error) {
 	template := &x509.Certificate{
 		SerialNumber: serial,
 		Subject: pkix.Name{
-			CommonName:   "Postern Local CA",
+			CommonName:   caCommonName,
 			Organization: []string{"Postern"},
 		},
 		NotBefore:             now,

--- a/internal/ca/trust.go
+++ b/internal/ca/trust.go
@@ -45,12 +45,17 @@ func InstallTrustAt(dir string, certPEM []byte) (string, error) {
 }
 
 // UninstallTrustAt revokes platform trust for the CA anchored under location
-// and removes the persisted anchor, returning its path. Idempotent: a
-// missing anchor is a success no-op, and on macOS a missing anchor with the
-// certificate still in the login keychain is recovered from the keychain so
-// revocation never silently depends on the file surviving.
-func UninstallTrustAt(dir string) (string, error) {
-	return uninstallTrustAt(dir)
+// and removes the persisted anchor, returning the anchor path plus the
+// SHA-256 hashes (of DER) of every trusted certificate actually revoked.
+// The hash list is empty when there was nothing to revoke. Idempotent: a
+// missing anchor is not automatically a no-op — on macOS a missing anchor
+// with the certificate still in the login keychain is recovered from the
+// keychain (exact-hash match against the persisted state file, falling back
+// to every common-name match) so revocation never silently depends on the
+// file surviving or narrows to the wrong generation.
+func UninstallTrustAt(dir string) (anchor string, revoked []string, err error) {
+	revoked, err = uninstallTrustAt(dir)
+	return resolveAnchorPath(dir), revoked, err
 }
 
 // writeAnchor is the shared file-drop half of trust installation: resolve
@@ -114,11 +119,12 @@ func InstallTrust(certPEM []byte) (string, error) {
 }
 
 // UninstallTrust revokes platform trust for the CA at the OS-specific default
-// trust location and removes it, returning the (former) path on success.
-func UninstallTrust() (string, error) {
+// trust location and removes it, returning the (former) path and the hashes
+// of every revoked trusted certificate.
+func UninstallTrust() (anchor string, revoked []string, err error) {
 	dir, err := defaultTrustDir()
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 	return UninstallTrustAt(dir)
 }

--- a/internal/ca/trust.go
+++ b/internal/ca/trust.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // trustAnchorFile is the on-disk name postern uses when copying the CA into
@@ -28,46 +29,63 @@ const trustDirMode os.FileMode = 0o755
 // surfaces this as a "manual instructions in the README" message.
 var ErrTrustUnsupported = errors.New("system trust install is not supported on this platform")
 
-// InstallTrustAt persists certPEM at the OS trust location and registers it
-// with the platform trust store. The location argument is the OS-specific
-// trust dir resolved by DefaultTrustDir: a directory on Linux, the anchor
-// certificate path on macOS. Per-GOOS installTrustAt implementations in
-// trust_<goos>.go do the real work; this exported form is the seam the ca
-// CLI invokes directly.
+// InstallTrustAt persists certPEM at location and registers it with the
+// platform trust store, returning the anchor file path.
+//
+// Contract, identical semantics on every GOOS: location is either a trust
+// directory — the anchor is written as <dir>/postern.crt — or an explicit
+// anchor file path ending in .pem or .crt (see resolveAnchorPath).
+// DefaultTrustDir returns whichever flavor the current platform prefers.
+// Platform-independent callers and tests can therefore pass a plain
+// directory and observe <dir>/postern.crt on Linux and macOS alike.
+// Per-GOOS installTrustAt implementations in trust_<goos>.go do the real
+// work; this exported form is the seam the ca CLI invokes directly.
 func InstallTrustAt(dir string, certPEM []byte) (string, error) {
 	return installTrustAt(dir, certPEM)
 }
 
-// UninstallTrustAt revokes platform trust and removes the persisted anchor,
-// returning the (former) path. A missing anchor is treated as success so the
-// operation is idempotent.
+// UninstallTrustAt revokes platform trust for the CA anchored under location
+// and removes the persisted anchor, returning its path. Idempotent: a
+// missing anchor is a success no-op, and on macOS a missing anchor with the
+// certificate still in the login keychain is recovered from the keychain so
+// revocation never silently depends on the file surviving.
 func UninstallTrustAt(dir string) (string, error) {
 	return uninstallTrustAt(dir)
 }
 
-// writeAnchor is the shared file-drop half of trust installation: write
-// certPEM to <dir>/postern.crt with mode 0644, creating dir (and any missing
-// parents) with mode 0755. GOOS-specific backends call this before any
-// platform trust registration step.
-// writeAnchor is the shared file-drop half of trust installation: write
-// certPEM to <dir>/postern.crt with mode 0644, creating dir (and any missing
-// parents) with mode 0755. GOOS-specific backends call this (or writeFileMode
-// for a full-path anchor) before any platform trust registration step.
-func writeAnchor(dir string, certPEM []byte) (string, error) {
-	if err := os.MkdirAll(dir, trustDirMode); err != nil {
+// writeAnchor is the shared file-drop half of trust installation: resolve
+// the anchor path from location (see resolveAnchorPath), create any missing
+// parent directories with mode 0755, then write certPEM with mode 0644.
+// GOOS-specific backends call this before any platform trust registration
+// step.
+func writeAnchor(location string, certPEM []byte) (string, error) {
+	path := resolveAnchorPath(location)
+	if err := os.MkdirAll(filepath.Dir(path), trustDirMode); err != nil {
 		return "", fmt.Errorf("create trust dir: %w", err)
 	}
-	path := filepath.Join(dir, trustAnchorFile)
 	if err := writeFileMode(path, certPEM, trustFileMode); err != nil {
 		return path, fmt.Errorf("write trust anchor: %w", err)
 	}
 	return path, nil
 }
 
+// resolveAnchorPath maps a trust location to its on-disk anchor file path,
+// the shared half of the InstallTrustAt/UninstallTrust contract. A location
+// ending in .pem or .crt (case-insensitive) is the anchor file itself;
+// anything else is a directory whose anchor is <location>/postern.crt.
+func resolveAnchorPath(location string) string {
+	switch ext := strings.ToLower(filepath.Ext(location)); ext {
+	case ".pem", ".crt":
+		return location
+	default:
+		return filepath.Join(location, trustAnchorFile)
+	}
+}
+
 // removeAnchor is the shared file-removal half of trust uninstallation. A
 // missing file is a no-op.
-func removeAnchor(dir string) (string, error) {
-	path := filepath.Join(dir, trustAnchorFile)
+func removeAnchor(location string) (string, error) {
+	path := resolveAnchorPath(location)
 	if err := os.Remove(path); err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return path, nil

--- a/internal/ca/trust.go
+++ b/internal/ca/trust.go
@@ -46,13 +46,16 @@ func InstallTrustAt(dir string, certPEM []byte) (string, error) {
 
 // UninstallTrustAt revokes platform trust for the CA anchored under location
 // and removes the persisted anchor, returning the anchor path plus the
-// SHA-256 hashes (of DER) of every trusted certificate actually revoked.
-// The hash list is empty when there was nothing to revoke. Idempotent: a
-// missing anchor is not automatically a no-op — on macOS a missing anchor
-// with the certificate still in the login keychain is recovered from the
-// keychain (exact-hash match against the persisted state file, falling back
-// to every common-name match) so revocation never silently depends on the
-// file surviving or narrows to the wrong generation.
+// SHA-256 hashes (of DER) of every certificate whose trust was revoked.
+// The hash list is empty when there was nothing to revoke. Idempotent: on
+// macOS revocation never depends on the anchor file — when it is missing,
+// every certificate the login keychain holds under the Postern common name
+// is revoked instead, so uninstall cannot be bypassed by losing the file
+// and cannot leave a still-trusted generation behind in a multi-generation
+// keychain. The keychain entries themselves are left in place: a root
+// without explicit trust settings is untrusted by default (mkcert makes the
+// same choice), so revocation-only uninstall is one idempotent command with
+// no second phase to strand.
 func UninstallTrustAt(dir string) (anchor string, revoked []string, err error) {
 	revoked, err = uninstallTrustAt(dir)
 	return resolveAnchorPath(dir), revoked, err

--- a/internal/ca/trust_darwin.go
+++ b/internal/ca/trust_darwin.go
@@ -81,17 +81,23 @@ func installTrustAt(location string, certPEM []byte) (string, error) {
 	return darwinTrust{run: osSecurity}.install(location, certPEM)
 }
 
-func uninstallTrustAt(location string) (string, error) {
+func uninstallTrustAt(location string) ([]string, error) {
 	return darwinTrust{run: osSecurity}.uninstall(location)
 }
 
-// install persists the anchor PEM at the resolved anchor path and marks it as
-// a trusted root in the user trust domain via
+// install persists the anchor PEM at the resolved anchor path, marks it as a
+// trusted root in the user trust domain via
 //
 //	security add-trusted-cert -r trustRoot -k <login keychain> <pem>
 //
-// The user-authentication dialog this triggers is expected; per-user trust
-// settings deliberately avoid sudo.
+// and records the certificate's SHA-256 (of DER) in a sibling state file.
+// The state file is the identity record uninstall falls back to when the
+// anchor PEM is lost: the common name is shared by every generation of the
+// CA, so the hash is what disambiguates the right certificate in a keychain
+// holding several still-trusted Postern CAs.
+//
+// The user-authentication dialog add-trusted-cert triggers is expected;
+// per-user trust settings deliberately avoid sudo.
 func (b darwinTrust) install(location string, certPEM []byte) (string, error) {
 	anchorPath, err := writeAnchor(location, certPEM)
 	if err != nil {
@@ -104,81 +110,160 @@ func (b darwinTrust) install(location string, certPEM []byte) (string, error) {
 	if _, err := b.run("add-trusted-cert", "-r", "trustRoot", "-k", keychain, anchorPath); err != nil {
 		return anchorPath, fmt.Errorf("register trust anchor: %w", err)
 	}
-	return anchorPath, nil
-}
-
-// uninstall revokes the CA's user trust settings (security remove-trusted-cert),
-// deletes the certificate from the login keychain by SHA-256 hash
-// (security delete-certificate -Z), and removes the persisted PEM. Both
-// security calls are mandatory: skipping the keychain deletion would leave a
-// "successful" uninstall with the CA still resolvable in the keychain, and
-// skipping remove-trusted-cert would leave it explicitly trusted.
-//
-// Revocation must not depend on the anchor file: when the PEM is missing but
-// the certificate is still in the keychain, it is recovered by common name
-// (security find-certificate), staged into a temp file, and revoked from
-// there. Only when neither anchor nor keychain holds the CA is this a success
-// no-op.
-func (b darwinTrust) uninstall(location string) (string, error) {
-	anchorPath := resolveAnchorPath(location)
-	certPEM, readErr := os.ReadFile(anchorPath)
-	recovered := false
-	switch {
-	case readErr == nil:
-	case errors.Is(readErr, fs.ErrNotExist):
-		pemBytes, err := b.findKeychainCert()
-		if err != nil {
-			return anchorPath, err
-		}
-		if pemBytes == nil {
-			return anchorPath, nil
-		}
-		certPEM = pemBytes
-		recovered = true
-	default:
-		return anchorPath, fmt.Errorf("read trust anchor: %w", readErr)
-	}
-
 	hash, err := certSHA256Hex(certPEM)
 	if err != nil {
 		return anchorPath, err
 	}
-	keychain, err := loginKeychain()
-	if err != nil {
+	if err := writeStateFile(anchorStatePath(anchorPath), hash); err != nil {
 		return anchorPath, err
-	}
-
-	revokePath := anchorPath
-	if recovered {
-		tmp, err := stageRecoveredPem(certPEM)
-		if err != nil {
-			return anchorPath, err
-		}
-		defer os.Remove(tmp)
-		revokePath = tmp
-	}
-
-	if _, err := b.run("remove-trusted-cert", revokePath); err != nil {
-		return anchorPath, fmt.Errorf("revoke trust settings: %w", err)
-	}
-	if _, err := b.run("delete-certificate", "-Z", hash, keychain); err != nil {
-		return anchorPath, fmt.Errorf("delete keychain certificate: %w", err)
-	}
-	if err := os.Remove(anchorPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return anchorPath, fmt.Errorf("remove trust anchor: %w", err)
 	}
 	return anchorPath, nil
 }
 
-// findKeychainCert recovers the postern CA certificate bytes from the login
-// keychain after the persisted anchor went missing. A nil result with a nil
-// error means the keychain holds no postern certificate either.
-func (b darwinTrust) findKeychainCert() ([]byte, error) {
+// uninstall revokes the CA's user trust settings (security
+// remove-trusted-cert), deletes the certificate from the login keychain by
+// SHA-256 hash (security delete-certificate -Z), and removes the persisted
+// PEM plus its sibling SHA-256 state file. It returns the hashes of every
+// certificate actually revoked; the list is empty only when nothing was
+// revoked. Both security calls are mandatory per certificate: skipping the
+// keychain deletion would leave a "successful" uninstall with the CA still
+// resolvable in the keychain, and skipping remove-trusted-cert would leave
+// it explicitly trusted.
+//
+// Revocation must not depend on the anchor file, and the common name is not
+// an identity: every generation of the CA shares it, and regeneration can
+// leave older, still-trusted Postern CAs in the keychain. The target is
+// therefore resolved in order:
+//
+//  1. anchor PEM present — revoke it directly.
+//  2. anchor missing, state file present — enumerate ALL login-keychain
+//     certificates with the postern common name (find-certificate -a) and
+//     revoke the one whose SHA-256 matches the persisted state hash.
+//  3. neither — revoke ALL common-name matches (fail wide, never silently
+//     narrow), surfacing every revoked hash to the caller.
+//
+// Only when neither anchor nor keychain holds the CA is this a success
+// no-op.
+func (b darwinTrust) uninstall(location string) ([]string, error) {
+	anchorPath := resolveAnchorPath(location)
+	certPEM, readErr := os.ReadFile(anchorPath)
+	switch {
+	case readErr == nil:
+		hash, err := certSHA256Hex(certPEM)
+		if err != nil {
+			return nil, err
+		}
+		keychain, err := loginKeychain()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := b.run("remove-trusted-cert", anchorPath); err != nil {
+			return nil, fmt.Errorf("revoke trust settings: %w", err)
+		}
+		if _, err := b.run("delete-certificate", "-Z", hash, keychain); err != nil {
+			return nil, fmt.Errorf("delete keychain certificate: %w", err)
+		}
+		if err := removeAnchorFiles(anchorPath); err != nil {
+			return nil, err
+		}
+		return []string{hash}, nil
+	case errors.Is(readErr, fs.ErrNotExist):
+		return b.uninstallRecovered(anchorPath)
+	default:
+		return nil, fmt.Errorf("read trust anchor: %w", readErr)
+	}
+}
+
+// uninstallRecovered resolves the revocation target from the login keychain
+// after the anchor PEM went missing: exact SHA-256 match against the
+// persisted state hash when available, otherwise every common-name match.
+func (b darwinTrust) uninstallRecovered(anchorPath string) ([]string, error) {
+	stateHash, hasState, err := readStateHash(anchorPath)
+	if err != nil {
+		return nil, err
+	}
+	candidates, err := b.findKeychainCerts()
+	if err != nil {
+		return nil, err
+	}
+	candidates = dedupePEMCerts(candidates)
+
+	var targets [][]byte
+	if hasState {
+		for _, cert := range candidates {
+			hash, err := certSHA256Hex(cert)
+			if err != nil {
+				return nil, fmt.Errorf("identify %q in login keychain: %w", caCommonName, err)
+			}
+			if hash == stateHash {
+				targets = append(targets, cert)
+			}
+		}
+	}
+	if len(targets) == 0 {
+		// No state file, or the state hash matches none of the enumerated
+		// certificates: fail wide and revoke every common-name match rather
+		// than silently narrowing to (at best) nothing.
+		targets = candidates
+	}
+	if len(targets) == 0 {
+		return nil, nil // genuine no-op: nothing matches
+	}
+
+	revoked := make([]string, 0, len(targets))
+	for _, cert := range targets {
+		hash, err := b.revokeRecoveredCert(cert)
+		if err != nil {
+			return revoked, err
+		}
+		revoked = append(revoked, hash)
+	}
+	if err := os.Remove(anchorStatePath(anchorPath)); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return revoked, fmt.Errorf("remove trust state: %w", err)
+	}
+	return revoked, nil
+}
+
+// revokeRecoveredCert revokes trust for one certificate recovered from the
+// keychain: the PEM is staged to a temp file for remove-trusted-cert and the
+// certificate is deleted from the login keychain by SHA-256 hash. Returns
+// the revoked certificate's hash.
+func (b darwinTrust) revokeRecoveredCert(certPEM []byte) (string, error) {
+	hash, err := certSHA256Hex(certPEM)
+	if err != nil {
+		return "", err
+	}
+	keychain, err := loginKeychain()
+	if err != nil {
+		return "", err
+	}
+	tmp, err := stageRecoveredPem(certPEM)
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(tmp)
+	if _, err := b.run("remove-trusted-cert", tmp); err != nil {
+		return "", fmt.Errorf("revoke trust settings: %w", err)
+	}
+	if _, err := b.run("delete-certificate", "-Z", hash, keychain); err != nil {
+		return "", fmt.Errorf("delete keychain certificate: %w", err)
+	}
+	return hash, nil
+}
+
+// findKeychainCerts enumerates every certificate in the login keychain whose
+// common name matches the postern CA name, returned as canonical PEM, one
+// entry per certificate. A nil result with a nil error means the keychain
+// holds no postern certificate. Enumerating all matches
+// (find-certificate -a) instead of taking the first is what makes a
+// multi-generation keychain safe: the caller selects by SHA-256 rather than
+// by whichever certificate the search happens to return first.
+func (b darwinTrust) findKeychainCerts() ([][]byte, error) {
 	keychain, err := loginKeychain()
 	if err != nil {
 		return nil, err
 	}
-	out, err := b.run("find-certificate", "-c", caCommonName, "-p", keychain)
+	out, err := b.run("find-certificate", "-a", "-c", caCommonName, "-p", keychain)
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() == 44 {
@@ -189,7 +274,38 @@ func (b darwinTrust) findKeychainCert() ([]byte, error) {
 	if len(bytes.TrimSpace(out)) == 0 {
 		return nil, nil
 	}
-	return out, nil
+	return splitPEMCerts(out), nil
+}
+
+// splitPEMCerts decodes every PEM block in data and re-encodes it in
+// canonical form, turning concatenated find-certificate -p output into one
+// entry per certificate.
+func splitPEMCerts(data []byte) [][]byte {
+	var certs [][]byte
+	rest := data
+	for {
+		block, remainder := pem.Decode(rest)
+		if block == nil {
+			return certs
+		}
+		certs = append(certs, pem.EncodeToMemory(block))
+		rest = remainder
+	}
+}
+
+// dedupePEMCerts collapses byte-identical certificates so a certificate
+// listed more than once by find-certificate -a is only revoked once.
+func dedupePEMCerts(certs [][]byte) [][]byte {
+	seen := make(map[string]bool, len(certs))
+	unique := make([][]byte, 0, len(certs))
+	for _, cert := range certs {
+		if seen[string(cert)] {
+			continue
+		}
+		seen[string(cert)] = true
+		unique = append(unique, cert)
+	}
+	return unique
 }
 
 // stageRecoveredPem writes recovered certificate PEM to a temp file so
@@ -220,4 +336,80 @@ func certSHA256Hex(certPEM []byte) (string, error) {
 	}
 	sum := sha256.Sum256(block.Bytes)
 	return hex.EncodeToString(sum[:]), nil
+}
+
+// trustStateSuffix marks the sibling file that persists the SHA-256 (of DER)
+// of the certificate an install actually registered:
+// ~/.postern/trust/ca.pem keeps it at ~/.postern/trust/ca.sha256. The anchor
+// PEM alone is not a reliable identity record (it can be lost) and the
+// common name is shared by every generation of the CA, so uninstall needs
+// the hash to pick the right keychain certificate.
+const trustStateSuffix = ".sha256"
+
+// anchorStatePath maps an anchor PEM path to its sibling SHA-256 state file.
+func anchorStatePath(anchorPath string) string {
+	return strings.TrimSuffix(anchorPath, filepath.Ext(anchorPath)) + trustStateSuffix
+}
+
+// writeStateFile atomically persists the hex SHA-256 next to the anchor.
+// The file is 0600 and any missing parent directory is created 0700: the
+// hash is not secret, but there is no reason for it to be group/world
+// accessible. The rename lands the full content in one step, so a crash
+// mid-write can never leave a truncated hash behind.
+func writeStateFile(path, hexHash string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create trust state dir: %w", err)
+	}
+	f, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".")
+	if err != nil {
+		return fmt.Errorf("write trust state: %w", err)
+	}
+	tmp := f.Name()
+	if _, err := f.WriteString(hexHash); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return fmt.Errorf("write trust state: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("write trust state: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("write trust state: %w", err)
+	}
+	return nil
+}
+
+// readStateHash loads the persisted SHA-256 for the anchor at anchorPath.
+// hasState is false when the file is missing or does not hold a well-formed
+// hash; a corrupt state file degrades to the fail-wide recovery path instead
+// of blocking uninstall.
+func readStateHash(anchorPath string) (string, bool, error) {
+	data, err := os.ReadFile(anchorStatePath(anchorPath))
+	if errors.Is(err, fs.ErrNotExist) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("read trust state: %w", err)
+	}
+	hash := strings.TrimSpace(string(data))
+	if len(hash) != sha256.Size*2 {
+		return "", false, nil
+	}
+	if _, err := hex.DecodeString(hash); err != nil {
+		return "", false, nil
+	}
+	return hash, true, nil
+}
+
+// removeAnchorFiles removes the anchor PEM and its sibling state file. A
+// missing file is a no-op.
+func removeAnchorFiles(anchorPath string) error {
+	for _, path := range []string{anchorPath, anchorStatePath(anchorPath)} {
+		if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("remove trust anchor: %w", err)
+		}
+	}
+	return nil
 }

--- a/internal/ca/trust_darwin.go
+++ b/internal/ca/trust_darwin.go
@@ -124,12 +124,13 @@ func (b darwinTrust) install(location string, certPEM []byte) (string, error) {
 	// Ground truth for the rollback decision: was this exact certificate in
 	// the keychain before this run? Files can be stale (a manually deleted
 	// keychain entry leaves anchor/state behind), so presence is probed, not
-	// inferred. A probe failure degrades conservatively: the identity is
-	// treated as not pre-existing, so a later failure rolls the registration
-	// back instead of leaving possibly-new trust behind.
+	// inferred. An unanswerable probe aborts the install before any
+	// mutation: guessing either way corrupts state on failure — skipping
+	// rollback could leave new trust behind, running it could destroy
+	// pre-existing trust.
 	presentBefore, err := b.keychainHashes()
 	if err != nil {
-		presentBefore = nil
+		return anchorPath, fmt.Errorf("probe login keychain: %w", err)
 	}
 	anchorPath, err = writeAnchor(location, certPEM)
 	if err != nil {

--- a/internal/ca/trust_darwin.go
+++ b/internal/ca/trust_darwin.go
@@ -100,253 +100,179 @@ func uninstallTrustAt(location string) ([]string, error) {
 	return darwinTrust{run: osSecurity}.uninstall(location)
 }
 
-// install persists the anchor PEM at the resolved anchor path, records the
-// certificate's SHA-256 (of DER) in a sibling state file, and only then
-// marks it as a trusted root in the user trust domain via
+// install persists the anchor PEM at the resolved anchor path and then marks
+// it as a trusted root in the user trust domain via
 //
 //	security add-trusted-cert -r trustRoot -k <login keychain> <pem>
 //
-// The state file is the identity record uninstall falls back to when the
-// anchor PEM is lost: the common name is shared by every generation of the
-// CA, so the hash is what disambiguates the right certificate in a keychain
-// holding several still-trusted Postern CAs.
+// This is the whole install: no sibling state file, because uninstall does
+// not need a persisted identity record (it revokes every same-name
+// certificate it can find; see uninstall).
+//
+// The ordering is the failure story: the only fallible step after the anchor
+// write is the registration itself. When registration fails the freshly
+// persisted anchor file is removed best-effort, so a reported install
+// failure leaves neither trust settings nor a stale anchor behind.
 //
 // The user-authentication dialog add-trusted-cert triggers is expected;
 // per-user trust settings deliberately avoid sudo.
-//
-// Ordering is the failure story: every fallible step but the last one only
-// touches files. The previous anchor PEM and state file are snapshotted
-// first (an unreadable file aborts before any mutation — rollback could not
-// faithfully restore content it never read), and any failure before
-// registration restores the exact pre-install pairing. add-trusted-cert runs
-// last: when it succeeds there is nothing left to fail, and when it fails no
-// trust was established, so a reported install failure never leaves the
-// certificate trusted and never leaves a new anchor paired with the previous
-// hash.
 func (b darwinTrust) install(location string, certPEM []byte) (string, error) {
-	anchorPath := resolveAnchorPath(location)
-	snap, err := snapshotTrustFiles(anchorPath)
-	if err != nil {
-		return anchorPath, err
-	}
-	hash, err := certSHA256Hex(certPEM)
-	if err != nil {
-		return anchorPath, fmt.Errorf("digest trust anchor: %w", err)
-	}
 	keychain, err := loginKeychain()
 	if err != nil {
-		return anchorPath, fmt.Errorf("resolve login keychain: %w", err)
+		return "", fmt.Errorf("resolve login keychain: %w", err)
 	}
-	fail := func(cause error) (string, error) {
-		if rbErr := restoreTrustFiles(snap, anchorPath); rbErr != nil {
-			return anchorPath, errors.Join(cause, rbErr)
-		}
-		return anchorPath, cause
-	}
-
-	anchorPath, err = writeAnchor(location, certPEM)
+	path, err := writeAnchor(location, certPEM)
 	if err != nil {
-		// writeAnchor can fail after truncating the anchor (os.WriteFile then
-		// chmod), so even this first write goes through the restore path.
-		return fail(fmt.Errorf("write trust anchor: %w", err))
+		return path, err
 	}
-	if err := writeStateFile(anchorStatePath(anchorPath), hash); err != nil {
-		return fail(fmt.Errorf("write trust state: %w", err))
-	}
-	if _, err := b.run("add-trusted-cert", "-r", "trustRoot", "-k", keychain, anchorPath); err != nil {
-		return fail(fmt.Errorf("register trust anchor: %w", err))
-	}
-	return anchorPath, nil
-}
-
-// trustFilesSnapshot holds the pre-install bytes of the anchor PEM and its
-// sibling state file. ok=false means the file was absent before the install,
-// so restore removes it rather than writing empty content.
-type trustFilesSnapshot struct {
-	anchor   []byte
-	anchorOK bool
-	state    []byte
-	stateOK  bool
-}
-
-// snapshotTrustFiles captures the current anchor and state bytes. An
-// unreadable anchor or state file aborts the install before any mutation:
-// rollback could not faithfully restore content it never read, and silently
-// treating an existing state file as absent would let a failed install
-// delete it, forcing later uninstalls into the broad common-name fallback.
-func snapshotTrustFiles(anchorPath string) (trustFilesSnapshot, error) {
-	var snap trustFilesSnapshot
-	data, err := os.ReadFile(anchorPath)
-	switch {
-	case err == nil:
-		snap.anchor, snap.anchorOK = data, true
-	case !errors.Is(err, fs.ErrNotExist):
-		return snap, fmt.Errorf("snapshot trust anchor: %w", err)
-	}
-	data, err = os.ReadFile(anchorStatePath(anchorPath))
-	switch {
-	case err == nil:
-		snap.state, snap.stateOK = data, true
-	case !errors.Is(err, fs.ErrNotExist):
-		return snap, fmt.Errorf("snapshot trust state: %w", err)
-	}
-	return snap, nil
-}
-
-// restoreTrustFiles puts the anchor and state files back to their pre-install
-// contents, removing files that did not exist before the install.
-func restoreTrustFiles(snap trustFilesSnapshot, anchorPath string) error {
-	var errs []error
-	if snap.anchorOK {
-		if err := writeFileMode(anchorPath, snap.anchor, trustFileMode); err != nil {
-			errs = append(errs, fmt.Errorf("restore trust anchor: %w", err))
+	if _, err := b.run("add-trusted-cert", "-r", "trustRoot", "-k", keychain, path); err != nil {
+		if rmErr := os.Remove(path); rmErr != nil && !errors.Is(rmErr, fs.ErrNotExist) {
+			return path, errors.Join(
+				fmt.Errorf("register trust anchor: %w", err),
+				fmt.Errorf("remove trust anchor: %w", rmErr))
 		}
-	} else if err := os.Remove(anchorPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		errs = append(errs, fmt.Errorf("restore trust anchor: %w", err))
+		return path, fmt.Errorf("register trust anchor: %w", err)
 	}
-	statePath := anchorStatePath(anchorPath)
-	if snap.stateOK {
-		if err := writeFileMode(statePath, snap.state, 0o600); err != nil {
-			errs = append(errs, fmt.Errorf("restore trust state: %w", err))
-		}
-	} else if err := os.Remove(statePath); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		errs = append(errs, fmt.Errorf("restore trust state: %w", err))
-	}
-	return errors.Join(errs...)
+	return path, nil
 }
 
-// uninstall revokes the CA's user trust settings (security
-// remove-trusted-cert), deletes the certificate from the login keychain by
-// SHA-256 hash (security delete-certificate -Z), and removes the persisted
-// PEM plus its sibling SHA-256 state file. It returns the hashes of every
-// certificate actually revoked; the list is empty only when nothing was
-// revoked. Both security calls are mandatory per certificate: skipping the
-// keychain deletion would leave a "successful" uninstall with the CA still
-// resolvable in the keychain, and skipping remove-trusted-cert would leave
-// it explicitly trusted. A remove-trusted-cert that reports no trust
-// settings for the certificate (a partial-revocation retry, or an entry
-// installed by another tool) does not fail the uninstall: the certificate
-// still counts as revoked once its keychain entry is deleted.
+// trustTarget is one certificate uninstall will revoke: pem holds the
+// canonical certificate bytes, and path is non-empty when that certificate
+// is also the persisted anchor file itself, letting security(1) read the
+// real path instead of a staged temp copy.
+type trustTarget struct {
+	pem  []byte
+	path string
+}
+
+// uninstall revokes the user-domain trust settings of every Postern CA
+// certificate the host holds:
 //
-// Revocation must not depend on the anchor file, and the common name is not
-// an identity: every generation of the CA shares it, and regeneration can
-// leave older, still-trusted Postern CAs in the keychain. The target is
-// therefore resolved in order:
+//	security remove-trusted-cert <pem>
 //
-//  1. anchor PEM present — revoke it directly.
-//  2. anchor missing, state file present — enumerate ALL login-keychain
-//     certificates with the postern common name (find-certificate -a) and
-//     revoke the one whose SHA-256 matches the persisted state hash.
-//  3. neither — revoke ALL common-name matches (fail wide, never silently
-//     narrow), surfacing every revoked hash to the caller.
+// once per unique certificate, where the candidates are the persisted anchor
+// PEM (if present) plus every certificate the login keychain reports under
+// the Postern common name (find-certificate -a -c ... -p), deduplicated by
+// SHA-256 of DER. It returns the hash of every certificate whose trust
+// settings were removed.
 //
-// Only when neither anchor nor keychain holds the CA is this a success
-// no-op.
+// The keychain entries are deliberately left in place — only the trust
+// settings are revoked, never delete-certificate. A self-signed root without
+// explicit trust settings is untrusted by macOS by default, so deleting the
+// entry adds nothing except a second fallible command; mkcert's
+// truststore_darwin.go makes exactly this choice (uninstall runs only
+// remove-trusted-cert and leaves the CA in the keychain). With deletion gone,
+// uninstall is a single idempotent operation: re-running it repeats
+// remove-trusted-cert, which succeeds both when the settings are already
+// absent (errSecItemNotFound is classified as satisfied, not fatal) and when
+// they are still present, so no partial state can wedge a retry. Revoking
+// wide is also what keeps a multi-generation keychain safe: the common name
+// is shared by every generation of the CA, so name-based enumeration plus
+// per-certificate revocation cannot leave a still-trusted Postern CA behind,
+// whatever happened to the anchor file.
+//
+// Genuine errors — a missing security binary, a locked or failing keychain,
+// malformed input such as an unparseable anchor PEM — abort with wrapped
+// stderr and the hashes revoked so far. Only when neither the anchor nor the
+// keychain yields a candidate is this a success no-op.
 func (b darwinTrust) uninstall(location string) ([]string, error) {
 	anchorPath := resolveAnchorPath(location)
-	certPEM, readErr := os.ReadFile(anchorPath)
-	switch {
-	case readErr == nil:
-		hash, err := certSHA256Hex(certPEM)
-		if err != nil {
-			return nil, err
+
+	var targets []trustTarget
+	switch certPEM, err := os.ReadFile(anchorPath); {
+	case err == nil:
+		// Malformed input aborts before any mutation: postern must not
+		// shell out on bytes it cannot identify.
+		if _, derr := certSHA256Hex(certPEM); derr != nil {
+			return nil, derr
 		}
-		keychain, err := loginKeychain()
-		if err != nil {
-			return nil, err
-		}
-		if _, err := b.run("remove-trusted-cert", anchorPath); err != nil && !trustSettingsAbsentErr(err) {
-			return nil, fmt.Errorf("revoke trust settings: %w", err)
-		}
-		if _, err := b.run("delete-certificate", "-Z", hash, keychain); err != nil {
-			return nil, fmt.Errorf("delete keychain certificate: %w", err)
-		}
-		if err := removeAnchorFiles(anchorPath); err != nil {
-			return nil, err
-		}
-		return []string{hash}, nil
-	case errors.Is(readErr, fs.ErrNotExist):
-		return b.uninstallRecovered(anchorPath)
+		targets = append(targets, trustTarget{pem: certPEM, path: anchorPath})
+	case errors.Is(err, fs.ErrNotExist):
+		// No anchor: keychain enumeration alone drives revocation.
 	default:
-		return nil, fmt.Errorf("read trust anchor: %w", readErr)
+		return nil, fmt.Errorf("read trust anchor: %w", err)
 	}
-}
-
-// uninstallRecovered resolves the revocation target from the login keychain
-// after the anchor PEM went missing: exact SHA-256 match against the
-// persisted state hash when available, otherwise every common-name match.
-func (b darwinTrust) uninstallRecovered(anchorPath string) ([]string, error) {
-	stateHash, hasState, err := readStateHash(anchorPath)
+	keychainCerts, err := b.findKeychainCerts()
 	if err != nil {
 		return nil, err
 	}
-	candidates, err := b.findKeychainCerts()
-	if err != nil {
-		return nil, err
+	for _, certPEM := range keychainCerts {
+		targets = append(targets, trustTarget{pem: certPEM})
 	}
-	candidates = dedupePEMCerts(candidates)
-
-	var targets [][]byte
-	if hasState {
-		for _, cert := range candidates {
-			hash, err := certSHA256Hex(cert)
-			if err != nil {
-				return nil, fmt.Errorf("identify %q in login keychain: %w", caCommonName, err)
-			}
-			if hash == stateHash {
-				targets = append(targets, cert)
-			}
-		}
-	}
+	targets = dedupeTargets(targets)
 	if len(targets) == 0 {
-		// No state file, or the state hash matches none of the enumerated
-		// certificates: fail wide and revoke every common-name match rather
-		// than silently narrowing to (at best) nothing.
-		targets = candidates
-	}
-	if len(targets) == 0 {
-		return nil, nil // genuine no-op: nothing matches
+		return nil, nil // genuine no-op: neither anchor nor keychain holds the CA
 	}
 
 	revoked := make([]string, 0, len(targets))
-	for _, cert := range targets {
-		hash, err := b.revokeRecoveredCert(cert)
+	for _, target := range targets {
+		hash, err := b.revoke(target)
 		if err != nil {
-			return revoked, err
+			return revoked, err // report what completed so far
 		}
 		revoked = append(revoked, hash)
 	}
-	if err := os.Remove(anchorStatePath(anchorPath)); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return revoked, fmt.Errorf("remove trust state: %w", err)
+
+	// The persisted anchor copy is derived state; drop it once nothing it
+	// names is trusted anymore. A missing file is fine (nothing was
+	// persisted, or a previous run already removed it).
+	if err := os.Remove(anchorPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return revoked, fmt.Errorf("remove trust anchor: %w", err)
 	}
 	return revoked, nil
 }
 
-// revokeRecoveredCert revokes trust for one certificate recovered from the
-// keychain: the PEM is staged to a temp file for remove-trusted-cert and the
-// certificate is deleted from the login keychain by SHA-256 hash. Returns
-// the revoked certificate's hash.
-func (b darwinTrust) revokeRecoveredCert(certPEM []byte) (string, error) {
-	hash, err := certSHA256Hex(certPEM)
+// revoke removes one certificate's user-domain trust settings. Anchor-derived
+// targets hand security(1) the anchor's real path; keychain-derived
+// certificates are staged to a temp PEM first because remove-trusted-cert
+// needs a file. An errSecItemNotFound-style diagnostic means the certificate
+// already has no trust settings — exactly the state revocation aims for — so
+// it counts as satisfied; any other failure is fatal.
+func (b darwinTrust) revoke(target trustTarget) (string, error) {
+	hash, err := certSHA256Hex(target.pem)
 	if err != nil {
 		return "", err
 	}
-	keychain, err := loginKeychain()
-	if err != nil {
-		return "", err
+	pemPath := target.path
+	if pemPath == "" {
+		tmp, err := stageRecoveredPem(target.pem)
+		if err != nil {
+			return "", err
+		}
+		pemPath = tmp
+		defer os.Remove(tmp)
 	}
-	tmp, err := stageRecoveredPem(certPEM)
-	if err != nil {
-		return "", err
-	}
-	defer os.Remove(tmp)
-	if _, err := b.run("remove-trusted-cert", tmp); err != nil && !trustSettingsAbsentErr(err) {
+	if _, err := b.run("remove-trusted-cert", pemPath); err != nil && !trustSettingsAbsentErr(err) {
 		return "", fmt.Errorf("revoke trust settings: %w", err)
 	}
-	if _, err := b.run("delete-certificate", "-Z", hash, keychain); err != nil {
-		return "", fmt.Errorf("delete keychain certificate: %w", err)
-	}
 	return hash, nil
+}
+
+// dedupeTargets collapses targets carrying the same certificate (matched by
+// SHA-256 of DER, so PEM formatting differences cannot split one certificate
+// into two targets) and keeps the variant bound to the persisted anchor file
+// when there is one, so the common case revokes through a real path instead
+// of a staged temp copy.
+func dedupeTargets(targets []trustTarget) []trustTarget {
+	seen := make(map[string]int, len(targets))
+	unique := make([]trustTarget, 0, len(targets))
+	for _, target := range targets {
+		block, _ := pem.Decode(target.pem)
+		if block == nil {
+			continue // unreachable: callers validate before building targets
+		}
+		sum := sha256.Sum256(block.Bytes)
+		key := string(sum[:])
+		if i, ok := seen[key]; ok {
+			if unique[i].path == "" {
+				unique[i].path = target.path
+			}
+			continue
+		}
+		seen[key] = len(unique)
+		unique = append(unique, target)
+	}
+	return unique
 }
 
 // findKeychainCerts enumerates every certificate in the login keychain whose
@@ -354,8 +280,8 @@ func (b darwinTrust) revokeRecoveredCert(certPEM []byte) (string, error) {
 // entry per certificate. A nil result with a nil error means the keychain
 // holds no postern certificate. Enumerating all matches
 // (find-certificate -a) instead of taking the first is what makes a
-// multi-generation keychain safe: the caller selects by SHA-256 rather than
-// by whichever certificate the search happens to return first.
+// multi-generation keychain safe: every generation gets revoked rather than
+// whichever certificate the search happens to return first.
 func (b darwinTrust) findKeychainCerts() ([][]byte, error) {
 	keychain, err := loginKeychain()
 	if err != nil {
@@ -391,21 +317,6 @@ func splitPEMCerts(data []byte) [][]byte {
 	}
 }
 
-// dedupePEMCerts collapses byte-identical certificates so a certificate
-// listed more than once by find-certificate -a is only revoked once.
-func dedupePEMCerts(certs [][]byte) [][]byte {
-	seen := make(map[string]bool, len(certs))
-	unique := make([][]byte, 0, len(certs))
-	for _, cert := range certs {
-		if seen[string(cert)] {
-			continue
-		}
-		seen[string(cert)] = true
-		unique = append(unique, cert)
-	}
-	return unique
-}
-
 // stageRecoveredPem writes recovered certificate PEM to a temp file so
 // remove-trusted-cert has a real path to operate on.
 func stageRecoveredPem(certPEM []byte) (string, error) {
@@ -426,7 +337,7 @@ func stageRecoveredPem(certPEM []byte) (string, error) {
 }
 
 // certSHA256Hex returns the lowercase hex SHA-256 of the certificate's DER
-// bytes, the form security(1) delete-certificate -Z matches against.
+// bytes, the identity reported to the caller for each revoked certificate.
 func certSHA256Hex(certPEM []byte) (string, error) {
 	block, _ := pem.Decode(certPEM)
 	if block == nil {
@@ -434,80 +345,4 @@ func certSHA256Hex(certPEM []byte) (string, error) {
 	}
 	sum := sha256.Sum256(block.Bytes)
 	return hex.EncodeToString(sum[:]), nil
-}
-
-// trustStateSuffix marks the sibling file that persists the SHA-256 (of DER)
-// of the certificate an install actually registered:
-// ~/.postern/trust/ca.pem keeps it at ~/.postern/trust/ca.sha256. The anchor
-// PEM alone is not a reliable identity record (it can be lost) and the
-// common name is shared by every generation of the CA, so uninstall needs
-// the hash to pick the right keychain certificate.
-const trustStateSuffix = ".sha256"
-
-// anchorStatePath maps an anchor PEM path to its sibling SHA-256 state file.
-func anchorStatePath(anchorPath string) string {
-	return strings.TrimSuffix(anchorPath, filepath.Ext(anchorPath)) + trustStateSuffix
-}
-
-// writeStateFile atomically persists the hex SHA-256 next to the anchor.
-// The file is 0600 and any missing parent directory is created 0700: the
-// hash is not secret, but there is no reason for it to be group/world
-// accessible. The rename lands the full content in one step, so a crash
-// mid-write can never leave a truncated hash behind.
-func writeStateFile(path, hexHash string) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return fmt.Errorf("create trust state dir: %w", err)
-	}
-	f, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".")
-	if err != nil {
-		return fmt.Errorf("write trust state: %w", err)
-	}
-	tmp := f.Name()
-	if _, err := f.WriteString(hexHash); err != nil {
-		f.Close()
-		os.Remove(tmp)
-		return fmt.Errorf("write trust state: %w", err)
-	}
-	if err := f.Close(); err != nil {
-		os.Remove(tmp)
-		return fmt.Errorf("write trust state: %w", err)
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		os.Remove(tmp)
-		return fmt.Errorf("write trust state: %w", err)
-	}
-	return nil
-}
-
-// readStateHash loads the persisted SHA-256 for the anchor at anchorPath.
-// hasState is false when the file is missing or does not hold a well-formed
-// hash; a corrupt state file degrades to the fail-wide recovery path instead
-// of blocking uninstall.
-func readStateHash(anchorPath string) (string, bool, error) {
-	data, err := os.ReadFile(anchorStatePath(anchorPath))
-	if errors.Is(err, fs.ErrNotExist) {
-		return "", false, nil
-	}
-	if err != nil {
-		return "", false, fmt.Errorf("read trust state: %w", err)
-	}
-	hash := strings.TrimSpace(string(data))
-	if len(hash) != sha256.Size*2 {
-		return "", false, nil
-	}
-	if _, err := hex.DecodeString(hash); err != nil {
-		return "", false, nil
-	}
-	return hash, true, nil
-}
-
-// removeAnchorFiles removes the anchor PEM and its sibling state file. A
-// missing file is a no-op.
-func removeAnchorFiles(anchorPath string) error {
-	for _, path := range []string{anchorPath, anchorStatePath(anchorPath)} {
-		if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("remove trust anchor: %w", err)
-		}
-	}
-	return nil
 }

--- a/internal/ca/trust_darwin.go
+++ b/internal/ca/trust_darwin.go
@@ -127,7 +127,7 @@ func (b darwinTrust) install(location string, certPEM []byte) (string, error) {
 	}
 
 	fail := func(cause error, registered bool) (string, error) {
-		if rbErr := b.rollbackInstall(anchorPath, hash, keychain, snap, registered); rbErr != nil {
+		if rbErr := b.rollbackInstall(anchorPath, certPEM, hash, keychain, snap, registered); rbErr != nil {
 			return anchorPath, errors.Join(cause, rbErr)
 		}
 		return anchorPath, cause
@@ -176,13 +176,19 @@ func snapshotTrustFiles(anchorPath string) (trustFilesSnapshot, error) {
 	return snap, nil
 }
 
-// rollbackInstall undoes every mutation a failed install made: the completed
-// keychain registration (when registered is true) and the on-disk anchor and
-// state files. Best effort: every rollback failure is returned so it is
-// surfaced alongside the original error instead of silently swallowed.
-func (b darwinTrust) rollbackInstall(anchorPath, hash, keychain string, snap trustFilesSnapshot, registered bool) error {
+// rollbackInstall undoes every mutation a failed install made: the keychain
+// registration this run added and the on-disk anchor and state files. The
+// revocation is skipped when certPEM is the identity this host already had
+// installed before the attempt (identical anchor bytes or state hash): its
+// trust predates this run, and removing it would destroy the pre-existing
+// installation while the restored files still describe it as installed.
+// Best effort: every rollback failure is returned so it is surfaced
+// alongside the original error instead of silently swallowed.
+func (b darwinTrust) rollbackInstall(anchorPath string, certPEM []byte, hash, keychain string, snap trustFilesSnapshot, registered bool) error {
 	var errs []error
-	if registered {
+	alreadyTrusted := (snap.anchorOK && bytes.Equal(snap.anchor, certPEM)) ||
+		(snap.stateOK && strings.TrimSpace(string(snap.state)) == hash)
+	if registered && !alreadyTrusted {
 		if _, err := b.run("remove-trusted-cert", anchorPath); err != nil {
 			errs = append(errs, fmt.Errorf("rollback revoke trust settings: %w", err))
 		}

--- a/internal/ca/trust_darwin.go
+++ b/internal/ca/trust_darwin.go
@@ -99,17 +99,17 @@ func uninstallTrustAt(location string) ([]string, error) {
 // The user-authentication dialog add-trusted-cert triggers is expected;
 // per-user trust settings deliberately avoid sudo.
 //
-// A failure after add-trusted-cert succeeded (the only such step is the
-// state-file write) rolls the registration back — remove-trusted-cert plus
-// delete-certificate — so a reported install failure never leaves the
-// certificate trusted, and a failed reinstall never leaves a stale state
-// hash that could later misdirect lost-anchor recovery.
+// Install is atomic on failure: the previous anchor PEM and state file are
+// snapshotted before anything is mutated, and any failure after that point
+// restores the exact pre-install pairing and (when add-trusted-cert already
+// completed) revokes the registration. A failed install therefore never
+// leaves a trusted certificate, and a failed reinstall never leaves the new
+// anchor paired with the previous hash — a mismatch that would later send
+// anchor-present uninstall at an already-rolled-back certificate while the
+// previously installed generation stayed trusted.
 func (b darwinTrust) install(location string, certPEM []byte) (string, error) {
-	anchorPath, err := writeAnchor(location, certPEM)
-	if err != nil {
-		return anchorPath, err
-	}
-	keychain, err := loginKeychain()
+	anchorPath := resolveAnchorPath(location)
+	snap, err := snapshotTrustFiles(anchorPath)
 	if err != nil {
 		return anchorPath, err
 	}
@@ -117,28 +117,100 @@ func (b darwinTrust) install(location string, certPEM []byte) (string, error) {
 	if err != nil {
 		return anchorPath, fmt.Errorf("digest trust anchor: %w", err)
 	}
+	keychain, err := loginKeychain()
+	if err != nil {
+		return anchorPath, fmt.Errorf("resolve login keychain: %w", err)
+	}
+	anchorPath, err = writeAnchor(location, certPEM)
+	if err != nil {
+		return anchorPath, err
+	}
+
+	fail := func(cause error, registered bool) (string, error) {
+		if rbErr := b.rollbackInstall(anchorPath, hash, keychain, snap, registered); rbErr != nil {
+			return anchorPath, errors.Join(cause, rbErr)
+		}
+		return anchorPath, cause
+	}
+
 	if _, err := b.run("add-trusted-cert", "-r", "trustRoot", "-k", keychain, anchorPath); err != nil {
-		return anchorPath, fmt.Errorf("register trust anchor: %w", err)
+		return fail(fmt.Errorf("register trust anchor: %w", err), false)
 	}
 	if err := writeStateFile(anchorStatePath(anchorPath), hash); err != nil {
-		if rbErr := b.rollbackRegistration(anchorPath, hash, keychain); rbErr != nil {
-			return anchorPath, errors.Join(fmt.Errorf("write trust state: %w", err), rbErr)
-		}
-		return anchorPath, fmt.Errorf("write trust state: %w", err)
+		return fail(fmt.Errorf("write trust state: %w", err), true)
 	}
 	return anchorPath, nil
 }
 
-// rollbackRegistration undoes a completed add-trusted-cert after a later
-// install step failed. Best effort: any rollback failure is returned so it
-// is surfaced alongside the original error instead of silently swallowed.
-func (b darwinTrust) rollbackRegistration(anchorPath, hash, keychain string) error {
-	var errs []error
-	if _, err := b.run("remove-trusted-cert", anchorPath); err != nil {
-		errs = append(errs, fmt.Errorf("rollback revoke trust settings: %w", err))
+// trustFilesSnapshot holds the pre-install bytes of the anchor PEM and its
+// sibling state file. ok=false means the file was absent before the install,
+// so restore removes it rather than writing empty content.
+type trustFilesSnapshot struct {
+	anchor   []byte
+	anchorOK bool
+	state    []byte
+	stateOK  bool
+}
+
+func keychainOf(keychain string) string { return keychain }
+
+// snapshotTrustFiles captures the current anchor and state bytes. An
+// unreadable anchor aborts the install before any mutation; an unreadable
+// state file is treated as absent, since restore would remove it anyway.
+func snapshotTrustFiles(anchorPath string) (trustFilesSnapshot, error) {
+	var snap trustFilesSnapshot
+	data, err := os.ReadFile(anchorPath)
+	switch {
+	case err == nil:
+		snap.anchor, snap.anchorOK = data, true
+	case !errors.Is(err, fs.ErrNotExist):
+		return snap, fmt.Errorf("snapshot trust anchor: %w", err)
 	}
-	if _, err := b.run("delete-certificate", "-Z", hash, keychain); err != nil {
-		errs = append(errs, fmt.Errorf("rollback delete keychain certificate: %w", err))
+	data, err = os.ReadFile(anchorStatePath(anchorPath))
+	if err == nil {
+		snap.state, snap.stateOK = data, true
+	}
+	return snap, nil
+}
+
+// rollbackInstall undoes every mutation a failed install made: the completed
+// keychain registration (when registered is true) and the on-disk anchor and
+// state files. Best effort: every rollback failure is returned so it is
+// surfaced alongside the original error instead of silently swallowed.
+func (b darwinTrust) rollbackInstall(anchorPath, hash, keychain string, snap trustFilesSnapshot, registered bool) error {
+	var errs []error
+	if registered {
+		if _, err := b.run("remove-trusted-cert", anchorPath); err != nil {
+			errs = append(errs, fmt.Errorf("rollback revoke trust settings: %w", err))
+		}
+		if _, err := b.run("delete-certificate", "-Z", hash, keychain); err != nil {
+			errs = append(errs, fmt.Errorf("rollback delete keychain certificate: %w", err))
+		}
+	}
+	if err := restoreTrustFiles(snap, anchorPath); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
+
+// restoreTrustFiles puts the anchor and state files back to their pre-install
+// contents, removing files that did not exist before the install.
+func restoreTrustFiles(snap trustFilesSnapshot, anchorPath string) error {
+	var errs []error
+	if snap.anchorOK {
+		if err := writeFileMode(anchorPath, snap.anchor, trustFileMode); err != nil {
+			errs = append(errs, fmt.Errorf("restore trust anchor: %w", err))
+		}
+	} else if err := os.Remove(anchorPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		errs = append(errs, fmt.Errorf("restore trust anchor: %w", err))
+	}
+	statePath := anchorStatePath(anchorPath)
+	if snap.stateOK {
+		if err := writeFileMode(statePath, snap.state, 0o600); err != nil {
+			errs = append(errs, fmt.Errorf("restore trust state: %w", err))
+		}
+	} else if err := os.Remove(statePath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		errs = append(errs, fmt.Errorf("restore trust state: %w", err))
 	}
 	return errors.Join(errs...)
 }

--- a/internal/ca/trust_darwin.go
+++ b/internal/ca/trust_darwin.go
@@ -121,13 +121,23 @@ func (b darwinTrust) install(location string, certPEM []byte) (string, error) {
 	if err != nil {
 		return anchorPath, fmt.Errorf("resolve login keychain: %w", err)
 	}
+	// Ground truth for the rollback decision: was this exact certificate in
+	// the keychain before this run? Files can be stale (a manually deleted
+	// keychain entry leaves anchor/state behind), so presence is probed, not
+	// inferred. A probe failure degrades conservatively: the identity is
+	// treated as not pre-existing, so a later failure rolls the registration
+	// back instead of leaving possibly-new trust behind.
+	presentBefore, err := b.keychainHashes()
+	if err != nil {
+		presentBefore = nil
+	}
 	anchorPath, err = writeAnchor(location, certPEM)
 	if err != nil {
 		return anchorPath, err
 	}
 
 	fail := func(cause error, registered bool) (string, error) {
-		if rbErr := b.rollbackInstall(anchorPath, certPEM, hash, keychain, snap, registered); rbErr != nil {
+		if rbErr := b.rollbackInstall(anchorPath, hash, keychain, presentBefore, snap, registered); rbErr != nil {
 			return anchorPath, errors.Join(cause, rbErr)
 		}
 		return anchorPath, cause
@@ -176,19 +186,37 @@ func snapshotTrustFiles(anchorPath string) (trustFilesSnapshot, error) {
 	return snap, nil
 }
 
+// keychainHashes returns the SHA-256 hashes of every certificate the login
+// keychain currently holds under the postern common name. Unparseable
+// entries are skipped rather than fatal: the map is a presence probe, not an
+// inventory.
+func (b darwinTrust) keychainHashes() (map[string]bool, error) {
+	certs, err := b.findKeychainCerts()
+	if err != nil {
+		return nil, err
+	}
+	hashes := make(map[string]bool, len(certs))
+	for _, cert := range certs {
+		hash, err := certSHA256Hex(cert)
+		if err != nil {
+			continue
+		}
+		hashes[hash] = true
+	}
+	return hashes, nil
+}
+
 // rollbackInstall undoes every mutation a failed install made: the keychain
 // registration this run added and the on-disk anchor and state files. The
-// revocation is skipped when certPEM is the identity this host already had
-// installed before the attempt (identical anchor bytes or state hash): its
-// trust predates this run, and removing it would destroy the pre-existing
+// revocation is skipped when the exact certificate was already in the
+// keychain before the run (presentBefore, probed before any mutation): its
+// presence predates this run, and removing it would destroy the pre-existing
 // installation while the restored files still describe it as installed.
 // Best effort: every rollback failure is returned so it is surfaced
 // alongside the original error instead of silently swallowed.
-func (b darwinTrust) rollbackInstall(anchorPath string, certPEM []byte, hash, keychain string, snap trustFilesSnapshot, registered bool) error {
+func (b darwinTrust) rollbackInstall(anchorPath, hash, keychain string, presentBefore map[string]bool, snap trustFilesSnapshot, registered bool) error {
 	var errs []error
-	alreadyTrusted := (snap.anchorOK && bytes.Equal(snap.anchor, certPEM)) ||
-		(snap.stateOK && strings.TrimSpace(string(snap.state)) == hash)
-	if registered && !alreadyTrusted {
+	if registered && !presentBefore[hash] {
 		if _, err := b.run("remove-trusted-cert", anchorPath); err != nil {
 			errs = append(errs, fmt.Errorf("rollback revoke trust settings: %w", err))
 		}

--- a/internal/ca/trust_darwin.go
+++ b/internal/ca/trust_darwin.go
@@ -152,11 +152,11 @@ type trustFilesSnapshot struct {
 	stateOK  bool
 }
 
-func keychainOf(keychain string) string { return keychain }
-
 // snapshotTrustFiles captures the current anchor and state bytes. An
-// unreadable anchor aborts the install before any mutation; an unreadable
-// state file is treated as absent, since restore would remove it anyway.
+// unreadable anchor or state file aborts the install before any mutation:
+// rollback could not faithfully restore content it never read, and silently
+// treating an existing state file as absent would let a failed install
+// delete it, forcing later uninstalls into the broad common-name fallback.
 func snapshotTrustFiles(anchorPath string) (trustFilesSnapshot, error) {
 	var snap trustFilesSnapshot
 	data, err := os.ReadFile(anchorPath)
@@ -167,8 +167,11 @@ func snapshotTrustFiles(anchorPath string) (trustFilesSnapshot, error) {
 		return snap, fmt.Errorf("snapshot trust anchor: %w", err)
 	}
 	data, err = os.ReadFile(anchorStatePath(anchorPath))
-	if err == nil {
+	switch {
+	case err == nil:
 		snap.state, snap.stateOK = data, true
+	case !errors.Is(err, fs.ErrNotExist):
+		return snap, fmt.Errorf("snapshot trust state: %w", err)
 	}
 	return snap, nil
 }

--- a/internal/ca/trust_darwin.go
+++ b/internal/ca/trust_darwin.go
@@ -20,17 +20,30 @@ import (
 // absolute path so the trust decision cannot be redirected via $PATH.
 const securityBin = "/usr/bin/security"
 
-// runSecurity executes the security(1) CLI, folding its stderr diagnostics
-// into the returned error. Package-level so tests can stub it out; no test
-// ever invokes the real binary.
-var runSecurity = func(args ...string) error {
+// securityRunner executes one security(1) command line and returns its
+// stdout. It is injected into the trust backend as a struct field so tests
+// record invocations instead of touching the real login keychain; there is
+// no assignable package-level state to stub.
+type securityRunner func(args ...string) ([]byte, error)
+
+// osSecurity executes the real security(1) CLI, folding its stderr
+// diagnostics into the returned error.
+func osSecurity(args ...string) ([]byte, error) {
 	cmd := exec.Command(securityBin, args...)
-	var stderr bytes.Buffer
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return securityCmdError(args, err, stderr.String())
+		return nil, securityCmdError(args, err, stderr.String())
 	}
-	return nil
+	return stdout.Bytes(), nil
+}
+
+// darwinTrust is the macOS trust backend. run is the security(1) executor,
+// held per-backend rather than in a global so parallel tests never share or
+// reorder command behavior.
+type darwinTrust struct {
+	run securityRunner
 }
 
 // securityCmdError builds the wrapped error for a failed security invocation,
@@ -53,11 +66,9 @@ func loginKeychain() (string, error) {
 }
 
 // defaultTrustDir returns the anchor PEM path postern persists under its own
-// config dir: ~/.postern/trust/ca.pem. Unlike Linux's directory-based model,
-// security(1) wants a file path: add-trusted-cert/remove-trusted-cert take
-// the PEM directly, and the same file feeds delete-certificate's hash lookup
-// on uninstall, so no state beyond the file itself is needed to undo an
-// install.
+// config dir: ~/.postern/trust/ca.pem. The .pem suffix makes resolveAnchorPath
+// treat it as an explicit anchor file; a directory argument would select
+// <dir>/postern.crt instead (see InstallTrustAt for the contract).
 func defaultTrustDir() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -66,49 +77,68 @@ func defaultTrustDir() (string, error) {
 	return filepath.Join(home, ".postern", "trust", "ca.pem"), nil
 }
 
-// installTrustAt persists the anchor PEM at anchorPath (the location argument
-// is the anchor file path on macOS, see DefaultTrustDir) and marks it as a
-// trusted root in the user trust domain via
+func installTrustAt(location string, certPEM []byte) (string, error) {
+	return darwinTrust{run: osSecurity}.install(location, certPEM)
+}
+
+func uninstallTrustAt(location string) (string, error) {
+	return darwinTrust{run: osSecurity}.uninstall(location)
+}
+
+// install persists the anchor PEM at the resolved anchor path and marks it as
+// a trusted root in the user trust domain via
 //
 //	security add-trusted-cert -r trustRoot -k <login keychain> <pem>
 //
 // The user-authentication dialog this triggers is expected; per-user trust
 // settings deliberately avoid sudo.
-func installTrustAt(anchorPath string, certPEM []byte) (string, error) {
-	if err := os.MkdirAll(filepath.Dir(anchorPath), trustDirMode); err != nil {
-		return "", fmt.Errorf("create trust dir: %w", err)
-	}
-	if err := writeFileMode(anchorPath, certPEM, trustFileMode); err != nil {
-		return anchorPath, fmt.Errorf("write trust anchor: %w", err)
+func (b darwinTrust) install(location string, certPEM []byte) (string, error) {
+	anchorPath, err := writeAnchor(location, certPEM)
+	if err != nil {
+		return anchorPath, err
 	}
 	keychain, err := loginKeychain()
 	if err != nil {
 		return anchorPath, err
 	}
-	if err := runSecurity([]string{
-		"add-trusted-cert", "-r", "trustRoot", "-k", keychain, anchorPath,
-	}...); err != nil {
+	if _, err := b.run("add-trusted-cert", "-r", "trustRoot", "-k", keychain, anchorPath); err != nil {
 		return anchorPath, fmt.Errorf("register trust anchor: %w", err)
 	}
 	return anchorPath, nil
 }
 
-// uninstallTrustAt revokes the CA's user trust settings
-// (security remove-trusted-cert), deletes the certificate from the login
-// keychain by SHA-256 hash (security delete-certificate -Z), and only then
-// removes the persisted PEM. Both security calls are mandatory: skipping the
-// keychain deletion would leave a "successful" uninstall with the CA still
-// resolvable in the keychain, and skipping remove-trusted-cert would leave it
-// explicitly trusted. A missing anchor means nothing was installed; that is a
-// successful no-op so uninstall is idempotent.
-func uninstallTrustAt(anchorPath string) (string, error) {
-	certPEM, err := os.ReadFile(anchorPath)
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
+// uninstall revokes the CA's user trust settings (security remove-trusted-cert),
+// deletes the certificate from the login keychain by SHA-256 hash
+// (security delete-certificate -Z), and removes the persisted PEM. Both
+// security calls are mandatory: skipping the keychain deletion would leave a
+// "successful" uninstall with the CA still resolvable in the keychain, and
+// skipping remove-trusted-cert would leave it explicitly trusted.
+//
+// Revocation must not depend on the anchor file: when the PEM is missing but
+// the certificate is still in the keychain, it is recovered by common name
+// (security find-certificate), staged into a temp file, and revoked from
+// there. Only when neither anchor nor keychain holds the CA is this a success
+// no-op.
+func (b darwinTrust) uninstall(location string) (string, error) {
+	anchorPath := resolveAnchorPath(location)
+	certPEM, readErr := os.ReadFile(anchorPath)
+	recovered := false
+	switch {
+	case readErr == nil:
+	case errors.Is(readErr, fs.ErrNotExist):
+		pemBytes, err := b.findKeychainCert()
+		if err != nil {
+			return anchorPath, err
+		}
+		if pemBytes == nil {
 			return anchorPath, nil
 		}
-		return anchorPath, fmt.Errorf("read trust anchor: %w", err)
+		certPEM = pemBytes
+		recovered = true
+	default:
+		return anchorPath, fmt.Errorf("read trust anchor: %w", readErr)
 	}
+
 	hash, err := certSHA256Hex(certPEM)
 	if err != nil {
 		return anchorPath, err
@@ -117,16 +147,68 @@ func uninstallTrustAt(anchorPath string) (string, error) {
 	if err != nil {
 		return anchorPath, err
 	}
-	if err := runSecurity("remove-trusted-cert", anchorPath); err != nil {
+
+	revokePath := anchorPath
+	if recovered {
+		tmp, err := stageRecoveredPem(certPEM)
+		if err != nil {
+			return anchorPath, err
+		}
+		defer os.Remove(tmp)
+		revokePath = tmp
+	}
+
+	if _, err := b.run("remove-trusted-cert", revokePath); err != nil {
 		return anchorPath, fmt.Errorf("revoke trust settings: %w", err)
 	}
-	if err := runSecurity("delete-certificate", "-Z", hash, keychain); err != nil {
+	if _, err := b.run("delete-certificate", "-Z", hash, keychain); err != nil {
 		return anchorPath, fmt.Errorf("delete keychain certificate: %w", err)
 	}
 	if err := os.Remove(anchorPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return anchorPath, fmt.Errorf("remove trust anchor: %w", err)
 	}
 	return anchorPath, nil
+}
+
+// findKeychainCert recovers the postern CA certificate bytes from the login
+// keychain after the persisted anchor went missing. A nil result with a nil
+// error means the keychain holds no postern certificate either.
+func (b darwinTrust) findKeychainCert() ([]byte, error) {
+	keychain, err := loginKeychain()
+	if err != nil {
+		return nil, err
+	}
+	out, err := b.run("find-certificate", "-c", caCommonName, "-p", keychain)
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 44 {
+			return nil, nil // security(1)'s documented item-not-found status
+		}
+		return nil, fmt.Errorf("locate %q in login keychain: %w", caCommonName, err)
+	}
+	if len(bytes.TrimSpace(out)) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
+// stageRecoveredPem writes recovered certificate PEM to a temp file so
+// remove-trusted-cert has a real path to operate on.
+func stageRecoveredPem(certPEM []byte) (string, error) {
+	f, err := os.CreateTemp("", "postern-anchor-*.pem")
+	if err != nil {
+		return "", fmt.Errorf("stage recovered trust anchor: %w", err)
+	}
+	if _, err := f.Write(certPEM); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		return "", fmt.Errorf("stage recovered trust anchor: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(f.Name())
+		return "", fmt.Errorf("stage recovered trust anchor: %w", err)
+	}
+	return f.Name(), nil
 }
 
 // certSHA256Hex returns the lowercase hex SHA-256 of the certificate's DER

--- a/internal/ca/trust_darwin.go
+++ b/internal/ca/trust_darwin.go
@@ -85,12 +85,12 @@ func uninstallTrustAt(location string) ([]string, error) {
 	return darwinTrust{run: osSecurity}.uninstall(location)
 }
 
-// install persists the anchor PEM at the resolved anchor path, marks it as a
-// trusted root in the user trust domain via
+// install persists the anchor PEM at the resolved anchor path, records the
+// certificate's SHA-256 (of DER) in a sibling state file, and only then
+// marks it as a trusted root in the user trust domain via
 //
 //	security add-trusted-cert -r trustRoot -k <login keychain> <pem>
 //
-// and records the certificate's SHA-256 (of DER) in a sibling state file.
 // The state file is the identity record uninstall falls back to when the
 // anchor PEM is lost: the common name is shared by every generation of the
 // CA, so the hash is what disambiguates the right certificate in a keychain
@@ -99,14 +99,15 @@ func uninstallTrustAt(location string) ([]string, error) {
 // The user-authentication dialog add-trusted-cert triggers is expected;
 // per-user trust settings deliberately avoid sudo.
 //
-// Install is atomic on failure: the previous anchor PEM and state file are
-// snapshotted before anything is mutated, and any failure after that point
-// restores the exact pre-install pairing and (when add-trusted-cert already
-// completed) revokes the registration. A failed install therefore never
-// leaves a trusted certificate, and a failed reinstall never leaves the new
-// anchor paired with the previous hash — a mismatch that would later send
-// anchor-present uninstall at an already-rolled-back certificate while the
-// previously installed generation stayed trusted.
+// Ordering is the failure story: every fallible step but the last one only
+// touches files. The previous anchor PEM and state file are snapshotted
+// first (an unreadable file aborts before any mutation — rollback could not
+// faithfully restore content it never read), and any failure before
+// registration restores the exact pre-install pairing. add-trusted-cert runs
+// last: when it succeeds there is nothing left to fail, and when it fails no
+// trust was established, so a reported install failure never leaves the
+// certificate trusted and never leaves a new anchor paired with the previous
+// hash.
 func (b darwinTrust) install(location string, certPEM []byte) (string, error) {
 	anchorPath := resolveAnchorPath(location)
 	snap, err := snapshotTrustFiles(anchorPath)
@@ -121,34 +122,24 @@ func (b darwinTrust) install(location string, certPEM []byte) (string, error) {
 	if err != nil {
 		return anchorPath, fmt.Errorf("resolve login keychain: %w", err)
 	}
-	// Ground truth for the rollback decision: was this exact certificate in
-	// the keychain before this run? Files can be stale (a manually deleted
-	// keychain entry leaves anchor/state behind), so presence is probed, not
-	// inferred. An unanswerable probe aborts the install before any
-	// mutation: guessing either way corrupts state on failure — skipping
-	// rollback could leave new trust behind, running it could destroy
-	// pre-existing trust.
-	presentBefore, err := b.keychainHashes()
-	if err != nil {
-		return anchorPath, fmt.Errorf("probe login keychain: %w", err)
-	}
-	anchorPath, err = writeAnchor(location, certPEM)
-	if err != nil {
-		return anchorPath, err
-	}
-
-	fail := func(cause error, registered bool) (string, error) {
-		if rbErr := b.rollbackInstall(anchorPath, hash, keychain, presentBefore, snap, registered); rbErr != nil {
+	fail := func(cause error) (string, error) {
+		if rbErr := restoreTrustFiles(snap, anchorPath); rbErr != nil {
 			return anchorPath, errors.Join(cause, rbErr)
 		}
 		return anchorPath, cause
 	}
 
-	if _, err := b.run("add-trusted-cert", "-r", "trustRoot", "-k", keychain, anchorPath); err != nil {
-		return fail(fmt.Errorf("register trust anchor: %w", err), false)
+	anchorPath, err = writeAnchor(location, certPEM)
+	if err != nil {
+		// writeAnchor can fail after truncating the anchor (os.WriteFile then
+		// chmod), so even this first write goes through the restore path.
+		return fail(fmt.Errorf("write trust anchor: %w", err))
 	}
 	if err := writeStateFile(anchorStatePath(anchorPath), hash); err != nil {
-		return fail(fmt.Errorf("write trust state: %w", err), true)
+		return fail(fmt.Errorf("write trust state: %w", err))
+	}
+	if _, err := b.run("add-trusted-cert", "-r", "trustRoot", "-k", keychain, anchorPath); err != nil {
+		return fail(fmt.Errorf("register trust anchor: %w", err))
 	}
 	return anchorPath, nil
 }
@@ -185,50 +176,6 @@ func snapshotTrustFiles(anchorPath string) (trustFilesSnapshot, error) {
 		return snap, fmt.Errorf("snapshot trust state: %w", err)
 	}
 	return snap, nil
-}
-
-// keychainHashes returns the SHA-256 hashes of every certificate the login
-// keychain currently holds under the postern common name. Unparseable
-// entries are skipped rather than fatal: the map is a presence probe, not an
-// inventory.
-func (b darwinTrust) keychainHashes() (map[string]bool, error) {
-	certs, err := b.findKeychainCerts()
-	if err != nil {
-		return nil, err
-	}
-	hashes := make(map[string]bool, len(certs))
-	for _, cert := range certs {
-		hash, err := certSHA256Hex(cert)
-		if err != nil {
-			continue
-		}
-		hashes[hash] = true
-	}
-	return hashes, nil
-}
-
-// rollbackInstall undoes every mutation a failed install made: the keychain
-// registration this run added and the on-disk anchor and state files. The
-// revocation is skipped when the exact certificate was already in the
-// keychain before the run (presentBefore, probed before any mutation): its
-// presence predates this run, and removing it would destroy the pre-existing
-// installation while the restored files still describe it as installed.
-// Best effort: every rollback failure is returned so it is surfaced
-// alongside the original error instead of silently swallowed.
-func (b darwinTrust) rollbackInstall(anchorPath, hash, keychain string, presentBefore map[string]bool, snap trustFilesSnapshot, registered bool) error {
-	var errs []error
-	if registered && !presentBefore[hash] {
-		if _, err := b.run("remove-trusted-cert", anchorPath); err != nil {
-			errs = append(errs, fmt.Errorf("rollback revoke trust settings: %w", err))
-		}
-		if _, err := b.run("delete-certificate", "-Z", hash, keychain); err != nil {
-			errs = append(errs, fmt.Errorf("rollback delete keychain certificate: %w", err))
-		}
-	}
-	if err := restoreTrustFiles(snap, anchorPath); err != nil {
-		errs = append(errs, err)
-	}
-	return errors.Join(errs...)
 }
 
 // restoreTrustFiles puts the anchor and state files back to their pre-install

--- a/internal/ca/trust_darwin.go
+++ b/internal/ca/trust_darwin.go
@@ -110,9 +110,10 @@ func uninstallTrustAt(location string) ([]string, error) {
 // certificate it can find; see uninstall).
 //
 // The ordering is the failure story: the only fallible step after the anchor
-// write is the registration itself. When registration fails the freshly
-// persisted anchor file is removed best-effort, so a reported install
-// failure leaves neither trust settings nor a stale anchor behind.
+// write is the registration itself. When registration fails, a fresh anchor
+// file is removed again and an overwritten one gets its previous bytes
+// back, so a reported install failure leaves neither new trust settings nor
+// a disk/keychain mismatch behind.
 //
 // The user-authentication dialog add-trusted-cert triggers is expected;
 // per-user trust settings deliberately avoid sudo.
@@ -121,19 +122,62 @@ func (b darwinTrust) install(location string, certPEM []byte) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolve login keychain: %w", err)
 	}
+	prior, err := snapshotPriorAnchor(resolveAnchorPath(location))
+	if err != nil {
+		return "", err
+	}
 	path, err := writeAnchor(location, certPEM)
 	if err != nil {
 		return path, err
 	}
 	if _, err := b.run("add-trusted-cert", "-r", "trustRoot", "-k", keychain, path); err != nil {
-		if rmErr := os.Remove(path); rmErr != nil && !errors.Is(rmErr, fs.ErrNotExist) {
+		if rErr := restorePriorAnchor(resolveAnchorPath(location), prior); rErr != nil {
 			return path, errors.Join(
 				fmt.Errorf("register trust anchor: %w", err),
-				fmt.Errorf("remove trust anchor: %w", rmErr))
+				rErr)
 		}
 		return path, fmt.Errorf("register trust anchor: %w", err)
 	}
 	return path, nil
+}
+
+// trustFilesSnapshot holds the pre-install content of the persisted anchor.
+// ok=false means the file did not exist before the install, so a failed
+// registration removes it again rather than writing empty content.
+type trustFilesSnapshot struct {
+	content []byte
+	ok      bool
+}
+
+// snapshotPriorAnchor captures the current bytes of the anchor file. An
+// existing-but-unreadable anchor aborts the install before any mutation:
+// a failed registration could not faithfully restore content it never read.
+func snapshotPriorAnchor(anchorPath string) (trustFilesSnapshot, error) {
+	data, err := os.ReadFile(anchorPath)
+	switch {
+	case err == nil:
+		return trustFilesSnapshot{content: data, ok: true}, nil
+	case errors.Is(err, fs.ErrNotExist):
+		return trustFilesSnapshot{}, nil
+	default:
+		return trustFilesSnapshot{}, fmt.Errorf("snapshot trust anchor: %w", err)
+	}
+}
+
+// restorePriorAnchor puts the anchor file back to its pre-install state
+// after a failed registration: absent before means removed again,
+// overwritten before means the previous bytes are written back.
+func restorePriorAnchor(anchorPath string, prior trustFilesSnapshot) error {
+	var err error
+	if prior.ok {
+		err = writeFileMode(anchorPath, prior.content, trustFileMode)
+	} else if err = os.Remove(anchorPath); errors.Is(err, fs.ErrNotExist) {
+		err = nil // a fresh install has nothing to clean
+	}
+	if err != nil {
+		return fmt.Errorf("restore trust anchor: %w", err)
+	}
+	return nil
 }
 
 // trustTarget is one certificate uninstall will revoke: pem holds the

--- a/internal/ca/trust_darwin.go
+++ b/internal/ca/trust_darwin.go
@@ -54,6 +54,21 @@ func securityCmdError(args []string, err error, stderr string) error {
 		securityBin, strings.Join(args, " "), err, strings.TrimSpace(stderr))
 }
 
+// trustSettingsAbsentErr reports whether a failed remove-trusted-cert
+// invocation means only that the certificate holds no trust settings in
+// the target domain rather than a genuine tooling failure. The
+// trusted_cert_remove tool collapses every SecTrustSettingsRemoveTrustSettings
+// OSStatus into exit status 1 (its own return value is unconditionally 1 on
+// error), so absence is identified by the framework's cssmPerror diagnostic
+// in the captured stderr: TrustSettings::deleteTrustSettings throws
+// errSecItemNotFound when the certificate has no entry in the domain's
+// trust dictionary.
+func trustSettingsAbsentErr(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "SecTrustSettingsRemoveTrustSettings") &&
+		strings.Contains(msg, "could not be found")
+}
+
 // loginKeychain returns the user's login keychain. The per-user trust domain
 // needs no sudo; add-trusted-cert stores the certificate there and records a
 // user-domain (non-admin) trust setting for it.
@@ -208,7 +223,10 @@ func restoreTrustFiles(snap trustFilesSnapshot, anchorPath string) error {
 // revoked. Both security calls are mandatory per certificate: skipping the
 // keychain deletion would leave a "successful" uninstall with the CA still
 // resolvable in the keychain, and skipping remove-trusted-cert would leave
-// it explicitly trusted.
+// it explicitly trusted. A remove-trusted-cert that reports no trust
+// settings for the certificate (a partial-revocation retry, or an entry
+// installed by another tool) does not fail the uninstall: the certificate
+// still counts as revoked once its keychain entry is deleted.
 //
 // Revocation must not depend on the anchor file, and the common name is not
 // an identity: every generation of the CA shares it, and regeneration can
@@ -237,7 +255,7 @@ func (b darwinTrust) uninstall(location string) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		if _, err := b.run("remove-trusted-cert", anchorPath); err != nil {
+		if _, err := b.run("remove-trusted-cert", anchorPath); err != nil && !trustSettingsAbsentErr(err) {
 			return nil, fmt.Errorf("revoke trust settings: %w", err)
 		}
 		if _, err := b.run("delete-certificate", "-Z", hash, keychain); err != nil {
@@ -322,7 +340,7 @@ func (b darwinTrust) revokeRecoveredCert(certPEM []byte) (string, error) {
 		return "", err
 	}
 	defer os.Remove(tmp)
-	if _, err := b.run("remove-trusted-cert", tmp); err != nil {
+	if _, err := b.run("remove-trusted-cert", tmp); err != nil && !trustSettingsAbsentErr(err) {
 		return "", fmt.Errorf("revoke trust settings: %w", err)
 	}
 	if _, err := b.run("delete-certificate", "-Z", hash, keychain); err != nil {

--- a/internal/ca/trust_darwin.go
+++ b/internal/ca/trust_darwin.go
@@ -98,6 +98,12 @@ func uninstallTrustAt(location string) ([]string, error) {
 //
 // The user-authentication dialog add-trusted-cert triggers is expected;
 // per-user trust settings deliberately avoid sudo.
+//
+// A failure after add-trusted-cert succeeded (the only such step is the
+// state-file write) rolls the registration back — remove-trusted-cert plus
+// delete-certificate — so a reported install failure never leaves the
+// certificate trusted, and a failed reinstall never leaves a stale state
+// hash that could later misdirect lost-anchor recovery.
 func (b darwinTrust) install(location string, certPEM []byte) (string, error) {
 	anchorPath, err := writeAnchor(location, certPEM)
 	if err != nil {
@@ -107,17 +113,34 @@ func (b darwinTrust) install(location string, certPEM []byte) (string, error) {
 	if err != nil {
 		return anchorPath, err
 	}
+	hash, err := certSHA256Hex(certPEM)
+	if err != nil {
+		return anchorPath, fmt.Errorf("digest trust anchor: %w", err)
+	}
 	if _, err := b.run("add-trusted-cert", "-r", "trustRoot", "-k", keychain, anchorPath); err != nil {
 		return anchorPath, fmt.Errorf("register trust anchor: %w", err)
 	}
-	hash, err := certSHA256Hex(certPEM)
-	if err != nil {
-		return anchorPath, err
-	}
 	if err := writeStateFile(anchorStatePath(anchorPath), hash); err != nil {
-		return anchorPath, err
+		if rbErr := b.rollbackRegistration(anchorPath, hash, keychain); rbErr != nil {
+			return anchorPath, errors.Join(fmt.Errorf("write trust state: %w", err), rbErr)
+		}
+		return anchorPath, fmt.Errorf("write trust state: %w", err)
 	}
 	return anchorPath, nil
+}
+
+// rollbackRegistration undoes a completed add-trusted-cert after a later
+// install step failed. Best effort: any rollback failure is returned so it
+// is surfaced alongside the original error instead of silently swallowed.
+func (b darwinTrust) rollbackRegistration(anchorPath, hash, keychain string) error {
+	var errs []error
+	if _, err := b.run("remove-trusted-cert", anchorPath); err != nil {
+		errs = append(errs, fmt.Errorf("rollback revoke trust settings: %w", err))
+	}
+	if _, err := b.run("delete-certificate", "-Z", hash, keychain); err != nil {
+		errs = append(errs, fmt.Errorf("rollback delete keychain certificate: %w", err))
+	}
+	return errors.Join(errs...)
 }
 
 // uninstall revokes the CA's user trust settings (security

--- a/internal/ca/trust_darwin_test.go
+++ b/internal/ca/trust_darwin_test.go
@@ -140,8 +140,9 @@ func TestInstallTrustAt_PersistsSha256StateFile(t *testing.T) {
 
 // TestInstallTrustAt_StateWriteFailureRollsBackTrust pins the rollback: when
 // add-trusted-cert has already registered the certificate but persisting the
-// SHA-256 state fails, install must undo the registration instead of
-// reporting a failed install that actually left the CA trusted.
+// SHA-256 state fails, install must undo the registration and the on-disk
+// writes instead of reporting a failed install that actually left the CA
+// trusted.
 func TestInstallTrustAt_StateWriteFailureRollsBackTrust(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -151,7 +152,8 @@ func TestInstallTrustAt_StateWriteFailureRollsBackTrust(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Dir(anchor), 0o700))
 	// Occupy the state path with a directory so the atomic rename inside
 	// writeStateFile fails after the trust registration already succeeded.
-	require.NoError(t, os.Mkdir(filepath.Join(home, ".postern", "trust", "ca.sha256"), 0o700))
+	stateBlocker := filepath.Join(home, ".postern", "trust", "ca.sha256")
+	require.NoError(t, os.Mkdir(stateBlocker, 0o700))
 
 	rec := &securityRecorder{}
 	_, err := darwinTrust{run: rec.run}.install(anchor, certPEM)
@@ -169,6 +171,74 @@ func TestInstallTrustAt_StateWriteFailureRollsBackTrust(t *testing.T) {
 	require.Equal(t,
 		[]string{"delete-certificate", "-Z", pemSHA256Hex(t, certPEM), keychain},
 		rec.calls[2])
+
+	_, statErr := os.Stat(anchor)
+	require.True(t, os.IsNotExist(statErr), "freshly written anchor must be removed on rollback")
+	_, statErr = os.Stat(stateBlocker)
+	require.True(t, os.IsNotExist(statErr), "state path must be clear after restoring the absent pre-install state")
+}
+
+// TestInstallTrustAt_FailedReinstallRestoresPreviousPairing covers the
+// follow-up regression: a failed reinstall over an existing CA must restore
+// the PREVIOUS anchor bytes, not leave the new anchor on disk. Otherwise a
+// later anchor-present uninstall would target the already-rolled-back
+// certificate while the previously installed generation stayed trusted.
+func TestInstallTrustAt_FailedReinstallRestoresPreviousPairing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	prevPEM := darwinFixtureCA(t)
+	newPEM := darwinFixtureCA(t)
+	anchor := filepath.Join(home, ".postern", "trust", "ca.pem")
+	keychain := filepath.Join(home, "Library", "Keychains", "login.keychain-db")
+	trustDir := filepath.Dir(anchor)
+	require.NoError(t, os.MkdirAll(trustDir, 0o700))
+	// Previous install: old CA anchored, no state file (pre-state-file era).
+	require.NoError(t, writeFileMode(anchor, prevPEM, 0o644))
+	// Block the state path so the reinstall fails after registration.
+	require.NoError(t, os.Mkdir(filepath.Join(trustDir, "ca.sha256"), 0o700))
+
+	rec := &securityRecorder{}
+	_, err := darwinTrust{run: rec.run}.install(anchor, newPEM)
+	require.Error(t, err)
+
+	got, readErr := os.ReadFile(anchor)
+	require.NoError(t, readErr)
+	require.Equal(t, prevPEM, got,
+		"a failed reinstall must restore the previous anchor bytes exactly")
+	require.Equal(t,
+		[]string{"delete-certificate", "-Z", pemSHA256Hex(t, newPEM), keychain},
+		rec.calls[2],
+		"the newly registered generation must be rolled back, not the previous one")
+}
+
+// TestRestoreTrustFiles_RestoresContents unit-tests the file half of the
+// snapshot/restore pair, including the branch that writes previous state
+// content back rather than deleting it.
+func TestRestoreTrustFiles_RestoresContents(t *testing.T) {
+	dir := t.TempDir()
+	anchorPath := filepath.Join(dir, "ca.pem")
+	statePath := filepath.Join(dir, "ca.sha256")
+	require.NoError(t, os.WriteFile(anchorPath, []byte("prev-anchor"), 0o644))
+	require.NoError(t, os.WriteFile(statePath, []byte("prev-hash"), 0o600))
+
+	snap, err := snapshotTrustFiles(anchorPath)
+	require.NoError(t, err)
+	require.True(t, snap.anchorOK)
+	require.True(t, snap.stateOK)
+
+	require.NoError(t, os.WriteFile(anchorPath, []byte("mutated"), 0o644))
+	require.NoError(t, os.WriteFile(statePath, []byte("mutated"), 0o600))
+	require.NoError(t, restoreTrustFiles(snap, anchorPath))
+
+	gotAnchor, err := os.ReadFile(anchorPath)
+	require.NoError(t, err)
+	require.Equal(t, "prev-anchor", string(gotAnchor))
+	gotState, err := os.ReadFile(statePath)
+	require.NoError(t, err)
+	require.Equal(t, "prev-hash", string(gotState))
+	info, err := os.Stat(statePath)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
 }
 
 // TestInstallTrustAt_DirectoryArgMatchesSharedContract pins the half of the

--- a/internal/ca/trust_darwin_test.go
+++ b/internal/ca/trust_darwin_test.go
@@ -138,25 +138,63 @@ func TestInstallTrustAt_PersistsSha256StateFile(t *testing.T) {
 	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
 }
 
-// TestInstallTrustAt_StateWriteFailureRollsBackTrust pins the rollback: when
-// add-trusted-cert has already registered the certificate but persisting the
-// SHA-256 state fails, install must undo the registration and the on-disk
-// writes instead of reporting a failed install that actually left the CA
-// trusted.
-func TestInstallTrustAt_StateWriteFailureRollsBackTrust(t *testing.T) {
+// TestInstallTrustAt_UnreadableStateAbortsBeforeMutation pins the snapshot
+// discipline: an existing-but-unreadable state file must abort the install
+// up front. Rollback could not faithfully restore content it never read, so
+// proceeding risked deleting the previous CA's hash on failure and forcing
+// later uninstalls into the broad common-name fallback.
+func TestInstallTrustAt_UnreadableStateAbortsBeforeMutation(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	certPEM := darwinFixtureCA(t)
+	prevPEM := darwinFixtureCA(t)
+	newPEM := darwinFixtureCA(t)
 	anchor := filepath.Join(home, ".postern", "trust", "ca.pem")
-	keychain := filepath.Join(home, "Library", "Keychains", "login.keychain-db")
 	require.NoError(t, os.MkdirAll(filepath.Dir(anchor), 0o700))
-	// Occupy the state path with a directory so the atomic rename inside
-	// writeStateFile fails after the trust registration already succeeded.
-	stateBlocker := filepath.Join(home, ".postern", "trust", "ca.sha256")
-	require.NoError(t, os.Mkdir(stateBlocker, 0o700))
+	require.NoError(t, writeFileMode(anchor, prevPEM, 0o644))
+	// Occupy the state path with a directory: readable as neither file nor
+	// "absent", so the snapshot must refuse to continue.
+	require.NoError(t, os.Mkdir(filepath.Join(home, ".postern", "trust", "ca.sha256"), 0o700))
 
 	rec := &securityRecorder{}
-	_, err := darwinTrust{run: rec.run}.install(anchor, certPEM)
+	_, err := darwinTrust{run: rec.run}.install(anchor, newPEM)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "snapshot trust state")
+	require.Empty(t, rec.calls, "no security invocation may run before the snapshot is trustworthy")
+
+	got, readErr := os.ReadFile(anchor)
+	require.NoError(t, readErr)
+	require.Equal(t, prevPEM, got, "the previous anchor must be untouched")
+}
+
+// TestInstallTrustAt_FailedReinstallRestoresPreviousPairing covers the
+// failed-reinstall regression: registration succeeds but persisting the new
+// state hash fails (unwritable trust dir; the existing anchor file itself
+// stays writable), so install rolls back the registration and restores the
+// PREVIOUS anchor and state pairing. Otherwise the new anchor would be left
+// paired with the old hash and a later uninstall would target the
+// already-rolled-back certificate while the previous generation stayed
+// trusted.
+func TestInstallTrustAt_FailedReinstallRestoresPreviousPairing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	prevPEM := darwinFixtureCA(t)
+	newPEM := darwinFixtureCA(t)
+	anchor := filepath.Join(home, ".postern", "trust", "ca.pem")
+	statePath := filepath.Join(home, ".postern", "trust", "ca.sha256")
+	keychain := filepath.Join(home, "Library", "Keychains", "login.keychain-db")
+	trustDir := filepath.Dir(anchor)
+	require.NoError(t, os.MkdirAll(trustDir, 0o700))
+	require.NoError(t, writeFileMode(anchor, prevPEM, 0o644))
+	prevHash := pemSHA256Hex(t, prevPEM)
+	require.NoError(t, writeFileMode(statePath, []byte(prevHash), 0o600))
+	// The anchor FILE stays writable, but no new temp file can be created in
+	// a directory without the write bit, failing the state write after
+	// add-trusted-cert already succeeded.
+	require.NoError(t, os.Chmod(trustDir, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(trustDir, 0o700) })
+
+	rec := &securityRecorder{}
+	_, err := darwinTrust{run: rec.run}.install(anchor, newPEM)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "write trust state")
 
@@ -169,46 +207,17 @@ func TestInstallTrustAt_StateWriteFailureRollsBackTrust(t *testing.T) {
 		rec.calls[0])
 	require.Equal(t, []string{"remove-trusted-cert", anchor}, rec.calls[1])
 	require.Equal(t,
-		[]string{"delete-certificate", "-Z", pemSHA256Hex(t, certPEM), keychain},
-		rec.calls[2])
-
-	_, statErr := os.Stat(anchor)
-	require.True(t, os.IsNotExist(statErr), "freshly written anchor must be removed on rollback")
-	_, statErr = os.Stat(stateBlocker)
-	require.True(t, os.IsNotExist(statErr), "state path must be clear after restoring the absent pre-install state")
-}
-
-// TestInstallTrustAt_FailedReinstallRestoresPreviousPairing covers the
-// follow-up regression: a failed reinstall over an existing CA must restore
-// the PREVIOUS anchor bytes, not leave the new anchor on disk. Otherwise a
-// later anchor-present uninstall would target the already-rolled-back
-// certificate while the previously installed generation stayed trusted.
-func TestInstallTrustAt_FailedReinstallRestoresPreviousPairing(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	prevPEM := darwinFixtureCA(t)
-	newPEM := darwinFixtureCA(t)
-	anchor := filepath.Join(home, ".postern", "trust", "ca.pem")
-	keychain := filepath.Join(home, "Library", "Keychains", "login.keychain-db")
-	trustDir := filepath.Dir(anchor)
-	require.NoError(t, os.MkdirAll(trustDir, 0o700))
-	// Previous install: old CA anchored, no state file (pre-state-file era).
-	require.NoError(t, writeFileMode(anchor, prevPEM, 0o644))
-	// Block the state path so the reinstall fails after registration.
-	require.NoError(t, os.Mkdir(filepath.Join(trustDir, "ca.sha256"), 0o700))
-
-	rec := &securityRecorder{}
-	_, err := darwinTrust{run: rec.run}.install(anchor, newPEM)
-	require.Error(t, err)
+		[]string{"delete-certificate", "-Z", pemSHA256Hex(t, newPEM), keychain},
+		rec.calls[2], "the newly registered generation must be rolled back")
 
 	got, readErr := os.ReadFile(anchor)
 	require.NoError(t, readErr)
 	require.Equal(t, prevPEM, got,
 		"a failed reinstall must restore the previous anchor bytes exactly")
-	require.Equal(t,
-		[]string{"delete-certificate", "-Z", pemSHA256Hex(t, newPEM), keychain},
-		rec.calls[2],
-		"the newly registered generation must be rolled back, not the previous one")
+	gotState, readErr := os.ReadFile(statePath)
+	require.NoError(t, readErr)
+	require.Equal(t, prevHash, strings.TrimSpace(string(gotState)),
+		"the previous state hash must survive the failed reinstall")
 }
 
 // TestRestoreTrustFiles_RestoresContents unit-tests the file half of the

--- a/internal/ca/trust_darwin_test.go
+++ b/internal/ca/trust_darwin_test.go
@@ -99,18 +99,14 @@ func TestInstallTrustAt_ExecutesAddTrustedCert(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, filepath.Join(home, ".postern", "trust", "ca.pem"), path)
 
-	keychain := filepath.Join(home, "Library", "Keychains", "login.keychain-db")
-	require.Len(t, rec.calls, 2, "install probes keychain presence, then registers trust")
-	require.Equal(t,
-		[]string{"find-certificate", "-a", "-c", caCommonName, "-p", keychain},
-		rec.calls[0])
+	require.Len(t, rec.calls, 1, "install must invoke security exactly once")
 	require.Equal(t,
 		[]string{
 			"add-trusted-cert", "-r", "trustRoot",
-			"-k", keychain,
+			"-k", filepath.Join(home, "Library", "Keychains", "login.keychain-db"),
 			path,
 		},
-		rec.calls[1])
+		rec.calls[0])
 
 	got, err := os.ReadFile(path)
 	require.NoError(t, err)
@@ -171,13 +167,11 @@ func TestInstallTrustAt_UnreadableStateAbortsBeforeMutation(t *testing.T) {
 }
 
 // TestInstallTrustAt_FailedReinstallRestoresPreviousPairing covers the
-// failed-reinstall regression: registration succeeds but persisting the new
-// state hash fails (unwritable trust dir; the existing anchor file itself
-// stays writable), so install rolls back the registration and restores the
-// PREVIOUS anchor and state pairing. Otherwise the new anchor would be left
-// paired with the old hash and a later uninstall would target the
-// already-rolled-back certificate while the previous generation stayed
-// trusted.
+// failed-reinstall regression: the state-file write fails before any
+// keychain mutation (registration is intentionally last), so install must
+// restore the PREVIOUS anchor and state pairing and never have touched the
+// keychain. Otherwise a new anchor could be left paired with the old hash
+// and a later uninstall would target the wrong certificate.
 func TestInstallTrustAt_FailedReinstallRestoresPreviousPairing(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -185,15 +179,14 @@ func TestInstallTrustAt_FailedReinstallRestoresPreviousPairing(t *testing.T) {
 	newPEM := darwinFixtureCA(t)
 	anchor := filepath.Join(home, ".postern", "trust", "ca.pem")
 	statePath := filepath.Join(home, ".postern", "trust", "ca.sha256")
-	keychain := filepath.Join(home, "Library", "Keychains", "login.keychain-db")
 	trustDir := filepath.Dir(anchor)
 	require.NoError(t, os.MkdirAll(trustDir, 0o700))
 	require.NoError(t, writeFileMode(anchor, prevPEM, 0o644))
 	prevHash := pemSHA256Hex(t, prevPEM)
 	require.NoError(t, writeFileMode(statePath, []byte(prevHash), 0o600))
 	// The anchor FILE stays writable, but no new temp file can be created in
-	// a directory without the write bit, failing the state write after
-	// add-trusted-cert already succeeded.
+	// a directory without the write bit, failing the state write before
+	// add-trusted-cert ever runs.
 	require.NoError(t, os.Chmod(trustDir, 0o500))
 	t.Cleanup(func() { _ = os.Chmod(trustDir, 0o700) })
 
@@ -201,18 +194,9 @@ func TestInstallTrustAt_FailedReinstallRestoresPreviousPairing(t *testing.T) {
 	_, err := darwinTrust{run: rec.run}.install(anchor, newPEM)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "write trust state")
+	require.Empty(t, rec.calls,
+		"no keychain command may run when file persistence fails first")
 
-	require.Len(t, rec.calls, 4, "probe + register, then roll back revoke+delete")
-	require.Equal(t,
-		[]string{
-			"add-trusted-cert", "-r", "trustRoot",
-			"-k", keychain, anchor,
-		},
-		rec.calls[1])
-	require.Equal(t, []string{"remove-trusted-cert", anchor}, rec.calls[2])
-	require.Equal(t,
-		[]string{"delete-certificate", "-Z", pemSHA256Hex(t, newPEM), keychain},
-		rec.calls[3], "the newly registered generation must be rolled back")
 	got, readErr := os.ReadFile(anchor)
 	require.NoError(t, readErr)
 	require.Equal(t, prevPEM, got,
@@ -223,13 +207,11 @@ func TestInstallTrustAt_FailedReinstallRestoresPreviousPairing(t *testing.T) {
 		"the previous state hash must survive the failed reinstall")
 }
 
-// TestInstallTrustAt_SameCARereinstallFailureKeepsTrust pins the reinstall
-// edge: when the failed install is a re-run for the certificate this host
-// ALREADY has installed, the rollback must not revoke or delete it. Its
-// trust predates the run, and removing it while the restored files still
-// describe it as installed would leave the host untrusted but reporting
-// installed.
-func TestInstallTrustAt_SameCARereinstallFailureKeepsTrust(t *testing.T) {
+// TestInstallTrustAt_SameCARereinstallFailureKeepsFilesIntact pins the same
+// guarantee for a re-run over the identical certificate: the failed install
+// leaves both files byte-identical and the keychain untouched, so the
+// pre-existing installation survives a failed reinstall.
+func TestInstallTrustAt_SameCARereinstallFailureKeepsFilesIntact(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	certPEM := darwinFixtureCA(t)
@@ -244,24 +226,9 @@ func TestInstallTrustAt_SameCARereinstallFailureKeepsTrust(t *testing.T) {
 	t.Cleanup(func() { _ = os.Chmod(trustDir, 0o700) })
 
 	rec := &securityRecorder{}
-	// The keychain probe must observe the certificate so the rollback skip
-	// is grounded in real pre-existing presence, not stale disk state.
-	rec.handle = func(args []string) ([]byte, error) {
-		if args[0] == "find-certificate" {
-			return certPEM, nil
-		}
-		return nil, nil
-	}
 	_, err := darwinTrust{run: rec.run}.install(anchor, certPEM)
 	require.Error(t, err)
-	require.Len(t, rec.calls, 2, "probe runs, but no revoke/delete for an identity already in the keychain")
-	require.Equal(t,
-		[]string{
-			"find-certificate", "-a", "-c", caCommonName, "-p",
-			filepath.Join(home, "Library", "Keychains", "login.keychain-db"),
-		},
-		rec.calls[0])
-	require.Equal(t, "add-trusted-cert", rec.calls[1][0])
+	require.Empty(t, rec.calls, "the keychain must not be touched for an already-installed CA")
 
 	gotAnchor, readErr := os.ReadFile(anchor)
 	require.NoError(t, readErr)
@@ -318,20 +285,14 @@ func TestInstallTrustAt_DirectoryArgMatchesSharedContract(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, filepath.Join(dir, "postern.crt"), path)
 
-	require.Len(t, rec.calls, 2)
-	require.Equal(t,
-		[]string{
-			"find-certificate", "-a", "-c", caCommonName, "-p",
-			filepath.Join(home, "Library", "Keychains", "login.keychain-db"),
-		},
-		rec.calls[0])
+	require.Len(t, rec.calls, 1)
 	require.Equal(t,
 		[]string{
 			"add-trusted-cert", "-r", "trustRoot",
 			"-k", filepath.Join(home, "Library", "Keychains", "login.keychain-db"),
 			path,
 		},
-		rec.calls[1])
+		rec.calls[0])
 
 	got, err := os.ReadFile(path)
 	require.NoError(t, err)
@@ -572,27 +533,6 @@ func TestInstallTrustAt_SecurityFailureWrapsStderr(t *testing.T) {
 	require.Contains(t, err.Error(), "exit status 44")
 	require.Contains(t, err.Error(), "SecTrustSettingsAddTrusted failed",
 		"security's stderr must be surfaced to the caller")
-}
-
-// TestInstallTrustAt_ProbeFailureAbortsBeforeMutation pins the probe
-// discipline: when keychain presence cannot be determined, install aborts
-// before touching anything. Guessing either way corrupts state on a later
-// failure: skipping rollback could leave new trust behind, running it could
-// destroy pre-existing trust.
-func TestInstallTrustAt_ProbeFailureAbortsBeforeMutation(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	rec := failingRunner(51, "SecKeychainSearchCopyNext failed\n")
-	certPEM := darwinFixtureCA(t)
-	anchor := filepath.Join(home, ".postern", "trust", "ca.pem")
-
-	_, err := darwinTrust{run: rec.run}.install(anchor, certPEM)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "probe login keychain")
-	require.Len(t, rec.calls, 1, "only the failed probe may run")
-
-	_, statErr := os.Stat(anchor)
-	require.True(t, os.IsNotExist(statErr), "no anchor may be written when presence is unknown")
 }
 
 func TestUninstallTrustAt_SecurityFailureWrapsStderr(t *testing.T) {

--- a/internal/ca/trust_darwin_test.go
+++ b/internal/ca/trust_darwin_test.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -70,14 +69,35 @@ func securityNotFoundErr(t *testing.T, args []string) error {
 		"SecKeychainSearchCopyNext: The specified item could not be found in the keychain.")
 }
 
+// trustSettingsAbsentErrFor builds the error shape of a remove-trusted-cert
+// invocation against a certificate with no trust settings: exit status 1
+// with the SecTrustSettingsRemoveTrustSettings errSecItemNotFound diagnostic
+// in the captured stderr, wrapped exactly the way production wraps failures.
+func trustSettingsAbsentErrFor(t *testing.T, args []string) error {
+	t.Helper()
+	cmd := exec.Command("/bin/sh", "-c", "exit 1")
+	runErr := cmd.Run()
+	return securityCmdError(args, runErr,
+		"TrustSettings::deleteTrustSettings: SecTrustSettingsRemoveTrustSettings: The specified item could not be found in the keychain.")
+}
+
 // pemSHA256Hex returns the SHA-256 (of DER) of a PEM-encoded certificate,
-// the value persisted in the state file and matched by delete-certificate -Z.
+// the identity reported for every revoked certificate.
 func pemSHA256Hex(t *testing.T, certPEM []byte) string {
 	t.Helper()
 	block, _ := pem.Decode(certPEM)
 	require.NotNil(t, block)
 	sum := sha256.Sum256(block.Bytes)
 	return hex.EncodeToString(sum[:])
+}
+
+// canonicalPEM re-encodes a certificate the way the keychain enumeration
+// path does, so staged temp content can be compared byte-exactly.
+func canonicalPEM(t *testing.T, certPEM []byte) string {
+	t.Helper()
+	block, _ := pem.Decode(certPEM)
+	require.NotNil(t, block)
+	return string(pem.EncodeToMemory(block))
 }
 
 func TestDefaultTrustDir_PemUnderPosternConfigDir(t *testing.T) {
@@ -116,164 +136,10 @@ func TestInstallTrustAt_ExecutesAddTrustedCert(t *testing.T) {
 	require.Equal(t, os.FileMode(0o644), info.Mode().Perm())
 }
 
-// TestInstallTrustAt_PersistsSha256StateFile pins the install half of the
-// P1 fix: the SHA-256 (of DER) of the registered certificate is persisted
-// next to the anchor, 0600, so a later uninstall can disambiguate keychain
-// generations by hash when the anchor PEM is lost.
-func TestInstallTrustAt_PersistsSha256StateFile(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	rec := &securityRecorder{}
-	certPEM := darwinFixtureCA(t)
-
-	_, err := darwinTrust{run: rec.run}.install(filepath.Join(home, ".postern", "trust", "ca.pem"), certPEM)
-	require.NoError(t, err)
-
-	statePath := filepath.Join(home, ".postern", "trust", "ca.sha256")
-	got, err := os.ReadFile(statePath)
-	require.NoError(t, err, "install must persist the certificate hash for later uninstall")
-	require.Equal(t, pemSHA256Hex(t, certPEM), strings.TrimSpace(string(got)))
-	info, err := os.Stat(statePath)
-	require.NoError(t, err)
-	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
-}
-
-// TestInstallTrustAt_UnreadableStateAbortsBeforeMutation pins the snapshot
-// discipline: an existing-but-unreadable state file must abort the install
-// up front. Rollback could not faithfully restore content it never read, so
-// proceeding risked deleting the previous CA's hash on failure and forcing
-// later uninstalls into the broad common-name fallback.
-func TestInstallTrustAt_UnreadableStateAbortsBeforeMutation(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	prevPEM := darwinFixtureCA(t)
-	newPEM := darwinFixtureCA(t)
-	anchor := filepath.Join(home, ".postern", "trust", "ca.pem")
-	require.NoError(t, os.MkdirAll(filepath.Dir(anchor), 0o700))
-	require.NoError(t, writeFileMode(anchor, prevPEM, 0o644))
-	// Occupy the state path with a directory: readable as neither file nor
-	// "absent", so the snapshot must refuse to continue.
-	require.NoError(t, os.Mkdir(filepath.Join(home, ".postern", "trust", "ca.sha256"), 0o700))
-
-	rec := &securityRecorder{}
-	_, err := darwinTrust{run: rec.run}.install(anchor, newPEM)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "snapshot trust state")
-	require.Empty(t, rec.calls, "no security invocation may run before the snapshot is trustworthy")
-
-	got, readErr := os.ReadFile(anchor)
-	require.NoError(t, readErr)
-	require.Equal(t, prevPEM, got, "the previous anchor must be untouched")
-}
-
-// TestInstallTrustAt_FailedReinstallRestoresPreviousPairing covers the
-// failed-reinstall regression: the state-file write fails before any
-// keychain mutation (registration is intentionally last), so install must
-// restore the PREVIOUS anchor and state pairing and never have touched the
-// keychain. Otherwise a new anchor could be left paired with the old hash
-// and a later uninstall would target the wrong certificate.
-func TestInstallTrustAt_FailedReinstallRestoresPreviousPairing(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	prevPEM := darwinFixtureCA(t)
-	newPEM := darwinFixtureCA(t)
-	anchor := filepath.Join(home, ".postern", "trust", "ca.pem")
-	statePath := filepath.Join(home, ".postern", "trust", "ca.sha256")
-	trustDir := filepath.Dir(anchor)
-	require.NoError(t, os.MkdirAll(trustDir, 0o700))
-	require.NoError(t, writeFileMode(anchor, prevPEM, 0o644))
-	prevHash := pemSHA256Hex(t, prevPEM)
-	require.NoError(t, writeFileMode(statePath, []byte(prevHash), 0o600))
-	// The anchor FILE stays writable, but no new temp file can be created in
-	// a directory without the write bit, failing the state write before
-	// add-trusted-cert ever runs.
-	require.NoError(t, os.Chmod(trustDir, 0o500))
-	t.Cleanup(func() { _ = os.Chmod(trustDir, 0o700) })
-
-	rec := &securityRecorder{}
-	_, err := darwinTrust{run: rec.run}.install(anchor, newPEM)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "write trust state")
-	require.Empty(t, rec.calls,
-		"no keychain command may run when file persistence fails first")
-
-	got, readErr := os.ReadFile(anchor)
-	require.NoError(t, readErr)
-	require.Equal(t, prevPEM, got,
-		"a failed reinstall must restore the previous anchor bytes exactly")
-	gotState, readErr := os.ReadFile(statePath)
-	require.NoError(t, readErr)
-	require.Equal(t, prevHash, strings.TrimSpace(string(gotState)),
-		"the previous state hash must survive the failed reinstall")
-}
-
-// TestInstallTrustAt_SameCARereinstallFailureKeepsFilesIntact pins the same
-// guarantee for a re-run over the identical certificate: the failed install
-// leaves both files byte-identical and the keychain untouched, so the
-// pre-existing installation survives a failed reinstall.
-func TestInstallTrustAt_SameCARereinstallFailureKeepsFilesIntact(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	certPEM := darwinFixtureCA(t)
-	anchor := filepath.Join(home, ".postern", "trust", "ca.pem")
-	statePath := filepath.Join(home, ".postern", "trust", "ca.sha256")
-	trustDir := filepath.Dir(anchor)
-	require.NoError(t, os.MkdirAll(trustDir, 0o700))
-	require.NoError(t, writeFileMode(anchor, certPEM, 0o644))
-	hash := pemSHA256Hex(t, certPEM)
-	require.NoError(t, writeFileMode(statePath, []byte(hash), 0o600))
-	require.NoError(t, os.Chmod(trustDir, 0o500))
-	t.Cleanup(func() { _ = os.Chmod(trustDir, 0o700) })
-
-	rec := &securityRecorder{}
-	_, err := darwinTrust{run: rec.run}.install(anchor, certPEM)
-	require.Error(t, err)
-	require.Empty(t, rec.calls, "the keychain must not be touched for an already-installed CA")
-
-	gotAnchor, readErr := os.ReadFile(anchor)
-	require.NoError(t, readErr)
-	require.Equal(t, certPEM, gotAnchor)
-	gotState, readErr := os.ReadFile(statePath)
-	require.NoError(t, readErr)
-	require.Equal(t, hash, strings.TrimSpace(string(gotState)))
-}
-
-// TestRestoreTrustFiles_RestoresContents unit-tests the file half of the
-// snapshot/restore pair, including the branch that writes previous state
-// content back rather than deleting it.
-func TestRestoreTrustFiles_RestoresContents(t *testing.T) {
-	dir := t.TempDir()
-	anchorPath := filepath.Join(dir, "ca.pem")
-	statePath := filepath.Join(dir, "ca.sha256")
-	require.NoError(t, os.WriteFile(anchorPath, []byte("prev-anchor"), 0o644))
-	require.NoError(t, os.WriteFile(statePath, []byte("prev-hash"), 0o600))
-
-	snap, err := snapshotTrustFiles(anchorPath)
-	require.NoError(t, err)
-	require.True(t, snap.anchorOK)
-	require.True(t, snap.stateOK)
-
-	require.NoError(t, os.WriteFile(anchorPath, []byte("mutated"), 0o644))
-	require.NoError(t, os.WriteFile(statePath, []byte("mutated"), 0o600))
-	require.NoError(t, restoreTrustFiles(snap, anchorPath))
-
-	gotAnchor, err := os.ReadFile(anchorPath)
-	require.NoError(t, err)
-	require.Equal(t, "prev-anchor", string(gotAnchor))
-	gotState, err := os.ReadFile(statePath)
-	require.NoError(t, err)
-	require.Equal(t, "prev-hash", string(gotState))
-	info, err := os.Stat(statePath)
-	require.NoError(t, err)
-	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
-}
-
 // TestInstallTrustAt_DirectoryArgMatchesSharedContract pins the half of the
 // dispatch contract the platform-independent suites rely on: a directory
 // argument yields <dir>/postern.crt, byte-identical contents, mode 0644, and
-// the derived path (not the raw argument) handed to security(1). The
-// sibling SHA-256 state file follows the same derivation
-// (postern.crt -> postern.sha256).
+// the derived path (not the raw argument) handed to security(1).
 func TestInstallTrustAt_DirectoryArgMatchesSharedContract(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -300,86 +166,159 @@ func TestInstallTrustAt_DirectoryArgMatchesSharedContract(t *testing.T) {
 	info, err := os.Stat(path)
 	require.NoError(t, err)
 	require.Equal(t, os.FileMode(0o644), info.Mode().Perm())
-	stateGot, err := os.ReadFile(filepath.Join(dir, "postern.sha256"))
-	require.NoError(t, err)
-	require.Equal(t, pemSHA256Hex(t, certPEM), strings.TrimSpace(string(stateGot)))
 }
 
-func TestUninstallTrustAt_RevokesTrustAndDeletesKeychainCert(t *testing.T) {
+// TestInstallTrustAt_FailedRegistrationRemovesAnchor pins the install failure
+// story: registration is the only fallible step after the anchor write, and
+// when it fails the freshly persisted anchor file is removed so a reported
+// install failure leaves neither trust settings nor a stale anchor behind.
+func TestInstallTrustAt_FailedRegistrationRemovesAnchor(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	rec := &securityRecorder{handle: func(args []string) ([]byte, error) {
+		if args[0] != "add-trusted-cert" {
+			return nil, nil
+		}
+		cmd := exec.Command("/bin/sh", "-c", "exit 51")
+		runErr := cmd.Run()
+		return nil, securityCmdError(args, runErr, "SecTrustSettingsAddTrusted failed\n")
+	}}
 	certPEM := darwinFixtureCA(t)
 	anchor := filepath.Join(home, ".postern", "trust", "ca.pem")
-	keychain := filepath.Join(home, "Library", "Keychains", "login.keychain-db")
 
-	seedRec := &securityRecorder{}
-	_, err := darwinTrust{run: seedRec.run}.install(anchor, certPEM)
-	require.NoError(t, err)
-	rec := &securityRecorder{}
-
-	revoked, err := darwinTrust{run: rec.run}.uninstall(anchor)
-	require.NoError(t, err)
-
-	hash := pemSHA256Hex(t, certPEM)
-	require.Equal(t, []string{hash}, revoked, "the revoked certificate's hash must be reported")
-	require.Len(t, rec.calls, 2, "uninstall must both revoke trust and delete the keychain cert")
-	require.Equal(t, []string{"remove-trusted-cert", anchor}, rec.calls[0])
-	require.Equal(t,
-		[]string{"delete-certificate", "-Z", hash, keychain},
-		rec.calls[1])
+	_, err := darwinTrust{run: rec.run}.install(anchor, certPEM)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "add-trusted-cert")
+	require.Contains(t, err.Error(), "exit status 51")
+	require.Contains(t, err.Error(), "SecTrustSettingsAddTrusted failed",
+		"security's stderr must be surfaced to the caller")
 
 	_, statErr := os.Stat(anchor)
-	require.True(t, os.IsNotExist(statErr), "anchor pem should be gone after uninstall")
-	_, statErr = os.Stat(filepath.Join(home, ".postern", "trust", "ca.sha256"))
-	require.True(t, os.IsNotExist(statErr), "state file should be gone after uninstall")
+	require.True(t, os.IsNotExist(statErr), "failed install must not leave the anchor behind")
 }
 
-// TestUninstallTrustAt_AnchorMissingRecoversFromKeychain covers the security
-// fix: with the persisted PEM lost but the certificate still trusted in the
-// login keychain, uninstall must recover the certificate bytes by common
-// name, revoke its trust setting, and delete it from the keychain. Reporting
-// success without those commands would leave the CA trusted.
-func TestUninstallTrustAt_AnchorMissingRecoversFromKeychain(t *testing.T) {
+// TestUninstallTrustAt_RevokesAnchorDirectlyAndLeavesKeychainEntry covers the
+// common uninstall: the anchor PEM is present and the same certificate sits
+// in the login keychain. The certificate must be revoked exactly once,
+// through the anchor's real path (no temp staging for a deduplicated
+// candidate), and the keychain entry must be left in place — no
+// delete-certificate anywhere.
+func TestUninstallTrustAt_RevokesAnchorDirectlyAndLeavesKeychainEntry(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	certPEM := darwinFixtureCA(t)
 	anchor := filepath.Join(home, ".postern", "trust", "ca.pem")
-	keychain := filepath.Join(home, "Library", "Keychains", "login.keychain-db")
 
-	// A prior install persisted the state file; only the PEM was lost.
 	seedRec := &securityRecorder{}
 	_, err := darwinTrust{run: seedRec.run}.install(anchor, certPEM)
 	require.NoError(t, err)
-	require.NoError(t, os.Remove(anchor))
-
 	rec := &securityRecorder{}
-	var revokedPem string
 	rec.handle = func(args []string) ([]byte, error) {
-		switch args[0] {
-		case "find-certificate":
+		if args[0] == "find-certificate" {
 			return certPEM, nil
-		case "remove-trusted-cert":
-			revokedPem = args[1]
-			return nil, nil
 		}
 		return nil, nil
 	}
 
 	revoked, err := darwinTrust{run: rec.run}.uninstall(anchor)
 	require.NoError(t, err)
-	require.Equal(t, []string{pemSHA256Hex(t, certPEM)}, revoked)
 
-	require.Len(t, rec.calls, 3, "recovery must probe, revoke trust, then delete from keychain")
-	require.Equal(t,
-		[]string{"find-certificate", "-a", "-c", caCommonName, "-p", keychain},
-		rec.calls[0])
-	require.NotEqual(t, anchor, revokedPem, "revocation must use the recovered copy, not the missing anchor")
-	require.True(t, strings.HasSuffix(revokedPem, ".pem"), "recovered anchor must be materialized as a PEM file")
-	_, statErr := os.Stat(revokedPem)
-	require.True(t, os.IsNotExist(statErr), "recovered temp copy must be cleaned up")
-	require.Equal(t,
-		[]string{"delete-certificate", "-Z", pemSHA256Hex(t, certPEM), keychain},
-		rec.calls[2])
+	hash := pemSHA256Hex(t, certPEM)
+	require.Equal(t, []string{hash}, revoked, "the revoked certificate's hash must be reported")
+	require.Len(t, rec.calls, 2, "keychain probe plus exactly one revocation")
+	require.Equal(t, []string{"remove-trusted-cert", anchor}, rec.calls[1],
+		"the anchor's real path must be passed to remove-trusted-cert")
+	for _, call := range rec.calls {
+		require.NotEqual(t, "delete-certificate", call[0],
+			"revocation-only uninstall never deletes keychain entries")
+	}
+
+	_, statErr := os.Stat(anchor)
+	require.True(t, os.IsNotExist(statErr), "anchor pem should be gone after uninstall")
+}
+
+// TestUninstallTrustAt_WideRevocationCoversBothGenerations pins the wide
+// revocation contract: when the login keychain holds two independently
+// generated Postern CAs, uninstall revokes the trust settings of BOTH —
+// one remove-trusted-cert per unique certificate, in any order — and issues
+// zero delete-certificate calls anywhere. Wide revocation is what makes a
+// multi-generation keychain safe by construction: name-based enumeration
+// cannot leave a still-trusted Postern generation behind.
+func TestUninstallTrustAt_WideRevocationCoversBothGenerations(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	pemA := darwinFixtureCA(t) // earlier generation, still trusted
+	pemB := darwinFixtureCA(t) // installed generation
+
+	rec := &securityRecorder{}
+	revokedPEM := map[string]bool{} // canonical staged PEM -> seen
+	rec.handle = func(args []string) ([]byte, error) {
+		switch args[0] {
+		case "find-certificate":
+			return append(append([]byte{}, pemA...), pemB...), nil
+		case "remove-trusted-cert":
+			content, _ := os.ReadFile(args[1])
+			if block, _ := pem.Decode(content); block != nil {
+				revokedPEM[canonicalPEM(t, content)] = true
+			}
+		}
+		return nil, nil
+	}
+
+	revoked, err := darwinTrust{run: rec.run}.uninstall(filepath.Join(home, ".postern", "trust", "ca.pem"))
+	require.NoError(t, err)
+
+	require.ElementsMatch(t,
+		[]string{pemSHA256Hex(t, pemA), pemSHA256Hex(t, pemB)}, revoked,
+		"every same-name certificate must be reported as revoked")
+	require.Len(t, rec.calls, 3, "keychain probe plus one remove-trusted-cert per unique certificate")
+	removes := 0
+	for _, call := range rec.calls {
+		require.NotEqual(t, "delete-certificate", call[0],
+			"revocation-only uninstall never deletes keychain entries")
+		if call[0] == "remove-trusted-cert" {
+			removes++
+		}
+	}
+	require.Equal(t, 2, removes, "exactly one remove-trusted-cert per unique certificate")
+	require.True(t, revokedPEM[canonicalPEM(t, pemA)], "generation A's trust settings must be revoked")
+	require.True(t, revokedPEM[canonicalPEM(t, pemB)], "generation B's trust settings must be revoked")
+}
+
+// TestUninstallTrustAt_AnchorMissingRecoversFromKeychain covers the lost
+// anchor: with the persisted PEM gone but the certificate still trusted in
+// the login keychain, uninstall must recover the certificate bytes by common
+// name, stage them to a temp file, and revoke their trust settings. Reporting
+// success without that command would leave the CA trusted.
+func TestUninstallTrustAt_AnchorMissingRecoversFromKeychain(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	certPEM := darwinFixtureCA(t)
+
+	rec := &securityRecorder{}
+	var stagedPEM string
+	rec.handle = func(args []string) ([]byte, error) {
+		switch args[0] {
+		case "find-certificate":
+			return certPEM, nil
+		case "remove-trusted-cert":
+			stagedPEM = string(mustRead(t, args[1]))
+		}
+		return nil, nil
+	}
+
+	revoked, err := darwinTrust{run: rec.run}.uninstall(filepath.Join(home, ".postern", "trust", "ca.pem"))
+	require.NoError(t, err)
+
+	require.Equal(t, []string{pemSHA256Hex(t, certPEM)}, revoked)
+	require.Len(t, rec.calls, 2, "keychain probe plus exactly one revocation")
+	require.Equal(t, "remove-trusted-cert", rec.calls[1][0])
+	require.Equal(t, canonicalPEM(t, certPEM), stagedPEM,
+		"revocation must target the certificate recovered from the keychain")
+	for _, call := range rec.calls {
+		require.NotEqual(t, "delete-certificate", call[0],
+			"revocation-only uninstall never deletes keychain entries")
+	}
 }
 
 // TestUninstallTrustAt_AnchorMissingCertAbsentIsNoOp proves idempotency is
@@ -401,175 +340,92 @@ func TestUninstallTrustAt_AnchorMissingCertAbsentIsNoOp(t *testing.T) {
 	require.Equal(t, "find-certificate", rec.calls[0][0], "no revocation without a located certificate")
 }
 
-// TestUninstallTrustAt_StateHashSelectsCorrectGeneration pins the P1 fix:
-// regeneration leaves older, still-trusted Postern CAs in the login
-// keychain, all sharing the common name. With the anchor PEM lost, uninstall
-// must pick the generation recorded in the state file by exact SHA-256, not
-// whichever common-name match the keychain returns first.
-func TestUninstallTrustAt_StateHashSelectsCorrectGeneration(t *testing.T) {
+// TestUninstallTrustAt_RetryIsIdempotent pins the single-operation contract:
+// running uninstall twice yields identical successful outcomes. On the retry
+// the certificate still shows up in the keychain (the entry is intentionally
+// left in place) but its trust settings are already gone, which
+// remove-trusted-cert reports as errSecItemNotFound — classified as
+// satisfied, not fatal. There is no second phase to strand, so the retry
+// cannot wedge.
+func TestUninstallTrustAt_RetryIsIdempotent(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	stalePEM := darwinFixtureCA(t) // earlier generation, still trusted
-	certPEM := darwinFixtureCA(t)  // installed generation: distinct key + serial
+	certPEM := darwinFixtureCA(t)
 	anchor := filepath.Join(home, ".postern", "trust", "ca.pem")
-	keychain := filepath.Join(home, "Library", "Keychains", "login.keychain-db")
+	hash := pemSHA256Hex(t, certPEM)
 
-	seedRec := &securityRecorder{}
-	_, err := darwinTrust{run: seedRec.run}.install(anchor, certPEM)
-	require.NoError(t, err)
-	require.NoError(t, os.Remove(anchor), "simulate the lost anchor PEM")
-
-	rec := &securityRecorder{}
-	var revokedPemContent []byte
-	rec.handle = func(args []string) ([]byte, error) {
-		switch args[0] {
-		case "find-certificate":
-			blob := append(append([]byte{}, stalePEM...), certPEM...)
-			return blob, nil // find-certificate -a output: every generation
-		case "remove-trusted-cert":
-			revokedPemContent, _ = os.ReadFile(args[1])
-			return nil, nil
+	first := &securityRecorder{}
+	first.handle = func(args []string) ([]byte, error) {
+		if args[0] == "find-certificate" {
+			return certPEM, nil
 		}
 		return nil, nil
 	}
-
-	revoked, err := darwinTrust{run: rec.run}.uninstall(anchor)
+	revoked, err := darwinTrust{run: first.run}.uninstall(anchor)
 	require.NoError(t, err)
+	require.Equal(t, []string{hash}, revoked)
 
-	require.Equal(t, []string{pemSHA256Hex(t, certPEM)}, revoked,
-		"exactly the installed generation must be revoked")
-	require.Len(t, rec.calls, 3)
-	require.Equal(t,
-		[]string{"find-certificate", "-a", "-c", caCommonName, "-p", keychain},
-		rec.calls[0])
-	block, _ := pem.Decode(certPEM)
-	require.NotNil(t, block)
-	require.Equal(t, string(pem.EncodeToMemory(block)), string(revokedPemContent),
-		"revocation must target the state-hash match, not the stale generation")
-	require.Equal(t,
-		[]string{"delete-certificate", "-Z", pemSHA256Hex(t, certPEM), keychain},
-		rec.calls[2])
-	require.NotContains(t, rec.calls[2], pemSHA256Hex(t, stalePEM),
-		"the stale generation's hash must never be deleted via name-only recovery")
+	second := &securityRecorder{}
+	second.handle = func(args []string) ([]byte, error) {
+		switch args[0] {
+		case "find-certificate":
+			return certPEM, nil // keychain entry intentionally survives
+		case "remove-trusted-cert":
+			return nil, trustSettingsAbsentErrFor(t, args)
+		}
+		return nil, nil
+	}
+	revoked, err = darwinTrust{run: second.run}.uninstall(anchor)
+	require.NoError(t, err, "retry must succeed: absent trust settings are the goal state")
+	require.Equal(t, []string{hash}, revoked, "the certificate still counts as satisfied")
+
+	for _, rec := range []*securityRecorder{first, second} {
+		for _, call := range rec.calls {
+			require.NotEqual(t, "delete-certificate", call[0],
+				"no residual trust intent may involve keychain deletion")
+		}
+	}
 }
 
-// TestUninstallTrustAt_NoStateRevokesAllMatches covers resolution path 3:
-// with neither anchor nor state file, uninstall fails wide — revoking every
-// common-name match — and reports each revoked hash.
-func TestUninstallTrustAt_NoStateRevokesAllMatches(t *testing.T) {
+// TestUninstallTrustAt_RevocationFailureAbortsAndReportsCompletedSoFar pins
+// the error contract: a genuine remove-trusted-cert failure (not an
+// absence diagnostic) aborts the remaining work, surfaces security's stderr,
+// and still reports every hash revoked before the failure.
+func TestUninstallTrustAt_RevocationFailureAbortsAndReportsCompletedSoFar(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	pemA := darwinFixtureCA(t)
 	pemB := darwinFixtureCA(t)
 
 	rec := &securityRecorder{}
-	removePemAt := map[string]int{}  // canonical staged PEM -> call index
-	deleteHashAt := map[string]int{} // deleted SHA-256 -> call index
 	rec.handle = func(args []string) ([]byte, error) {
-		idx := len(rec.calls) - 1 // run records before dispatching to handle
 		switch args[0] {
 		case "find-certificate":
 			return append(append([]byte{}, pemA...), pemB...), nil
 		case "remove-trusted-cert":
 			content, _ := os.ReadFile(args[1])
-			if block, _ := pem.Decode(content); block != nil {
-				removePemAt[string(pem.EncodeToMemory(block))] = idx
+			if canonicalPEM(t, content) == canonicalPEM(t, pemB) {
+				cmd := exec.Command("/bin/sh", "-c", "exit 51")
+				runErr := cmd.Run()
+				return nil, securityCmdError(args, runErr, "SecTrustSettingsRemoveTrusted failed\n")
 			}
-		case "delete-certificate":
-			require.Equal(t, "-Z", args[1], "keychain deletion selects by SHA-256")
-			deleteHashAt[args[2]] = idx
 		}
 		return nil, nil
 	}
 
 	revoked, err := darwinTrust{run: rec.run}.uninstall(filepath.Join(home, ".postern", "trust", "ca.pem"))
-	require.NoError(t, err)
-	require.ElementsMatch(t, []string{pemSHA256Hex(t, pemA), pemSHA256Hex(t, pemB)}, revoked,
-		"every common-name match must be reported as revoked")
-
-	// Pair commands per certificate rather than comparing global order:
-	// the keychain's enumeration order across the two matches must not
-	// matter, but each certificate still gets exactly one
-	// remove-trusted-cert (from its staged temp PEM) before exactly one
-	// keychain deletion of its own hash.
-	require.Len(t, rec.calls, 5, "probe plus revoke+delete per matched certificate")
-	canonical := func(certPEM []byte) string {
-		block, _ := pem.Decode(certPEM)
-		require.NotNil(t, block)
-		return string(pem.EncodeToMemory(block))
-	}
-	for _, certPEM := range [][]byte{pemA, pemB} {
-		hash := pemSHA256Hex(t, certPEM)
-		rmIdx, ok := removePemAt[canonical(certPEM)]
-		require.True(t, ok, "no remove-trusted-cert for %s", hash)
-		delIdx, ok := deleteHashAt[hash]
-		require.True(t, ok, "no delete-certificate for %s", hash)
-		require.Less(t, rmIdx, delIdx,
-			"trust settings must be revoked before that certificate's keychain deletion")
-	}
-}
-
-// notFoundSecurityErr builds the error shape of a security(1) invocation
-// whose Security-framework call reported errSecItemNotFound: the tool's
-// cssmPerror diagnostic in stderr, wrapped exactly the way production
-// wraps failed invocations.
-func notFoundSecurityErr(args []string, fn string) error {
-	return securityCmdError(args, fmt.Errorf("exit status 1"),
-		fn+": The specified item could not be found in the keychain.")
-}
-
-// TestUninstallTrustAt_MissingTrustSettingsStillDeletes pins the retry
-// story for partial revocation: if remove-trusted-cert succeeds but
-// delete-certificate fails, the next uninstall repeats remove-trusted-cert
-// for a certificate whose settings are already gone. That absence is
-// non-fatal — the keychain deletion is still attempted and the hash still
-// reported — while any other remove-trusted-cert failure stays fatal.
-func TestUninstallTrustAt_MissingTrustSettingsStillDeletes(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	certPEM := darwinFixtureCA(t)
-	keychain := filepath.Join(home, "Library", "Keychains", "login.keychain-db")
-
-	rec := &securityRecorder{handle: func(args []string) ([]byte, error) {
-		switch args[0] {
-		case "find-certificate":
-			return certPEM, nil
-		case "remove-trusted-cert":
-			// Retry after a previous run's remove succeeded and its
-			// delete failed: no user-domain trust settings remain.
-			return nil, notFoundSecurityErr(args, "SecTrustSettingsRemoveTrustSettings")
-		}
-		return nil, nil
-	}}
-
-	revoked, err := darwinTrust{run: rec.run}.uninstall(filepath.Join(home, ".postern", "trust", "ca.pem"))
-	require.NoError(t, err)
-	require.Equal(t, []string{pemSHA256Hex(t, certPEM)}, revoked,
-		"the certificate counts as revoked once its keychain entry is deleted")
-	require.Len(t, rec.calls, 3)
-	require.Equal(t,
-		[]string{"delete-certificate", "-Z", pemSHA256Hex(t, certPEM), keychain},
-		rec.calls[2])
-
-	// A remove-trusted-cert failure that is NOT plain absence must stay
-	// fatal: fail wide rather than silently deleting a still-trusted cert.
-	fatal := &securityRecorder{handle: func(args []string) ([]byte, error) {
-		switch args[0] {
-		case "find-certificate":
-			return certPEM, nil
-		case "remove-trusted-cert":
-			return nil, securityCmdError(args, fmt.Errorf("exit status 1"),
-				"SecTrustSettingsRemoveTrustSettings: UNIX[Operation not permitted]")
-		}
-		return nil, nil
-	}}
-	_, err = darwinTrust{run: fatal.run}.uninstall(filepath.Join(home, ".postern", "trust", "ca.pem"))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "revoke trust settings")
+	require.Contains(t, err.Error(), "SecTrustSettingsRemoveTrusted failed",
+		"security's stderr must be surfaced to the caller")
+	require.Equal(t, []string{pemSHA256Hex(t, pemA)}, revoked,
+		"hashes revoked before the failure must be reported")
 }
 
 // TestUninstallTrustAt_KeychainProbeFailureSurfacesError ensures a real
-// security(1) failure during recovery is never mistaken for "nothing to do".
+// security(1) failure during enumeration is never mistaken for "nothing to
+// do": the probe runs before any mutation, so the abort leaves the host
+// exactly as it was.
 func TestUninstallTrustAt_KeychainProbeFailureSurfacesError(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -583,29 +439,61 @@ func TestUninstallTrustAt_KeychainProbeFailureSurfacesError(t *testing.T) {
 	require.Len(t, rec.calls, 1, "no revocation attempt after a failed probe")
 }
 
-func TestInstallTrustAt_SecurityFailureWrapsStderr(t *testing.T) {
+// TestUninstallTrustAt_ProbeFailureLeavesAnchorIntact pins the abort
+// contract for a present anchor: a failing keychain probe aborts before any
+// mutation, so the persisted anchor survives for a later retry.
+func TestUninstallTrustAt_ProbeFailureLeavesAnchorIntact(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	// The keychain probe succeeds; only the registration fails.
-	rec := &securityRecorder{handle: func(args []string) ([]byte, error) {
-		if args[0] != "add-trusted-cert" {
-			return nil, nil
-		}
-		cmd := exec.Command("/bin/sh", "-c", "exit 44")
-		runErr := cmd.Run()
-		return nil, securityCmdError(args, runErr, "SecTrustSettingsAddTrusted failed\n")
-	}}
 	certPEM := darwinFixtureCA(t)
+	anchor := filepath.Join(home, ".postern", "trust", "ca.pem")
 
-	_, err := darwinTrust{run: rec.run}.install(filepath.Join(home, ".postern", "trust", "ca.pem"), certPEM)
+	seedRec := &securityRecorder{}
+	_, err := darwinTrust{run: seedRec.run}.install(anchor, certPEM)
+	require.NoError(t, err)
+	rec := failingRunner(51, "SecKeychainSearchCopyNext failed\n")
+
+	_, err = darwinTrust{run: rec.run}.uninstall(anchor)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), securityBin)
-	require.Contains(t, err.Error(), "add-trusted-cert")
-	require.Contains(t, err.Error(), "exit status 44")
-	require.Contains(t, err.Error(), "SecTrustSettingsAddTrusted failed",
-		"security's stderr must be surfaced to the caller")
+	_, statErr := os.Stat(anchor)
+	require.NoError(t, statErr, "a failed uninstall must not consume the anchor")
 }
 
+// TestUninstallTrustAt_RemoveReportsAbsentCountsAsSatisfied pins the
+// classification seam: a remove-trusted-cert that reports no trust settings
+// for the certificate (a retry, or an entry installed by another tool) is
+// the state revocation aims for and must not fail the uninstall.
+func TestUninstallTrustAt_RemoveReportsAbsentCountsAsSatisfied(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	certPEM := darwinFixtureCA(t)
+	anchor := filepath.Join(home, ".postern", "trust", "ca.pem")
+
+	seedRec := &securityRecorder{}
+	_, err := darwinTrust{run: seedRec.run}.install(anchor, certPEM)
+	require.NoError(t, err)
+	rec := &securityRecorder{}
+	rec.handle = func(args []string) ([]byte, error) {
+		switch args[0] {
+		case "find-certificate":
+			return nil, securityNotFoundErr(t, args)
+		case "remove-trusted-cert":
+			return nil, trustSettingsAbsentErrFor(t, args)
+		}
+		return nil, nil
+	}
+
+	revoked, err := darwinTrust{run: rec.run}.uninstall(anchor)
+	require.NoError(t, err, "absent trust settings are the goal state, not a failure")
+	require.Equal(t, []string{pemSHA256Hex(t, certPEM)}, revoked)
+
+	_, statErr := os.Stat(anchor)
+	require.True(t, os.IsNotExist(statErr), "a satisfied uninstall still removes the anchor")
+}
+
+// TestUninstallTrustAt_SecurityFailureWrapsStderr ensures a genuine
+// revocation failure (not an absence diagnostic) is wrapped with the command
+// line and security's stderr.
 func TestUninstallTrustAt_SecurityFailureWrapsStderr(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -615,7 +503,14 @@ func TestUninstallTrustAt_SecurityFailureWrapsStderr(t *testing.T) {
 	seedRec := &securityRecorder{}
 	_, err := darwinTrust{run: seedRec.run}.install(anchor, certPEM)
 	require.NoError(t, err)
-	rec := failingRunner(51, "SecTrustSettingsRemoveTrusted failed\n")
+	rec := &securityRecorder{handle: func(args []string) ([]byte, error) {
+		if args[0] != "remove-trusted-cert" {
+			return nil, securityNotFoundErr(t, args)
+		}
+		cmd := exec.Command("/bin/sh", "-c", "exit 51")
+		runErr := cmd.Run()
+		return nil, securityCmdError(args, runErr, "SecTrustSettingsRemoveTrusted failed\n")
+	}}
 
 	_, err = darwinTrust{run: rec.run}.uninstall(anchor)
 	require.Error(t, err)
@@ -643,4 +538,11 @@ func TestSecurityCmdError_Format(t *testing.T) {
 	require.Equal(t,
 		fmt.Sprintf("%s remove-trusted-cert /x/ca.pem: exit status 1: boom", securityBin),
 		err.Error())
+}
+
+func mustRead(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return data
 }

--- a/internal/ca/trust_darwin_test.go
+++ b/internal/ca/trust_darwin_test.go
@@ -99,14 +99,18 @@ func TestInstallTrustAt_ExecutesAddTrustedCert(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, filepath.Join(home, ".postern", "trust", "ca.pem"), path)
 
-	require.Len(t, rec.calls, 1, "install must invoke security exactly once")
+	keychain := filepath.Join(home, "Library", "Keychains", "login.keychain-db")
+	require.Len(t, rec.calls, 2, "install probes keychain presence, then registers trust")
+	require.Equal(t,
+		[]string{"find-certificate", "-a", "-c", caCommonName, "-p", keychain},
+		rec.calls[0])
 	require.Equal(t,
 		[]string{
 			"add-trusted-cert", "-r", "trustRoot",
-			"-k", filepath.Join(home, "Library", "Keychains", "login.keychain-db"),
+			"-k", keychain,
 			path,
 		},
-		rec.calls[0])
+		rec.calls[1])
 
 	got, err := os.ReadFile(path)
 	require.NoError(t, err)
@@ -198,18 +202,17 @@ func TestInstallTrustAt_FailedReinstallRestoresPreviousPairing(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "write trust state")
 
-	require.Len(t, rec.calls, 3, "register, then roll back revoke+delete")
+	require.Len(t, rec.calls, 4, "probe + register, then roll back revoke+delete")
 	require.Equal(t,
 		[]string{
 			"add-trusted-cert", "-r", "trustRoot",
 			"-k", keychain, anchor,
 		},
-		rec.calls[0])
-	require.Equal(t, []string{"remove-trusted-cert", anchor}, rec.calls[1])
+		rec.calls[1])
+	require.Equal(t, []string{"remove-trusted-cert", anchor}, rec.calls[2])
 	require.Equal(t,
 		[]string{"delete-certificate", "-Z", pemSHA256Hex(t, newPEM), keychain},
-		rec.calls[2], "the newly registered generation must be rolled back")
-
+		rec.calls[3], "the newly registered generation must be rolled back")
 	got, readErr := os.ReadFile(anchor)
 	require.NoError(t, readErr)
 	require.Equal(t, prevPEM, got,
@@ -241,12 +244,22 @@ func TestInstallTrustAt_SameCARereinstallFailureKeepsTrust(t *testing.T) {
 	t.Cleanup(func() { _ = os.Chmod(trustDir, 0o700) })
 
 	rec := &securityRecorder{}
+	// The keychain probe must observe the certificate so the rollback skip
+	// is grounded in real pre-existing presence, not stale disk state.
+	rec.handle = func(args []string) ([]byte, error) {
+		if args[0] == "find-certificate" {
+			return certPEM, nil
+		}
+		return nil, nil
+	}
 	_, err := darwinTrust{run: rec.run}.install(anchor, certPEM)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "write trust state")
-
-	require.Len(t, rec.calls, 1, "no revoke/delete for an identity that was already trusted")
-	require.Equal(t, "add-trusted-cert", rec.calls[0][0])
+	require.Len(t, rec.calls, 2, "probe runs, but no revoke/delete for an identity already in the keychain")
+	require.Equal(t,
+		[]string{"find-certificate", "-a", "-c", caCommonName, "-p",
+			filepath.Join(home, "Library", "Keychains", "login.keychain-db")},
+		rec.calls[0])
+	require.Equal(t, "add-trusted-cert", rec.calls[1][0])
 
 	gotAnchor, readErr := os.ReadFile(anchor)
 	require.NoError(t, readErr)
@@ -303,14 +316,20 @@ func TestInstallTrustAt_DirectoryArgMatchesSharedContract(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, filepath.Join(dir, "postern.crt"), path)
 
-	require.Len(t, rec.calls, 1)
+	require.Len(t, rec.calls, 2)
+	require.Equal(t,
+		[]string{
+			"find-certificate", "-a", "-c", caCommonName, "-p",
+			filepath.Join(home, "Library", "Keychains", "login.keychain-db"),
+		},
+		rec.calls[0])
 	require.Equal(t,
 		[]string{
 			"add-trusted-cert", "-r", "trustRoot",
 			"-k", filepath.Join(home, "Library", "Keychains", "login.keychain-db"),
 			path,
 		},
-		rec.calls[0])
+		rec.calls[1])
 
 	got, err := os.ReadFile(path)
 	require.NoError(t, err)

--- a/internal/ca/trust_darwin_test.go
+++ b/internal/ca/trust_darwin_test.go
@@ -461,18 +461,23 @@ func TestUninstallTrustAt_NoStateRevokesAllMatches(t *testing.T) {
 	t.Setenv("HOME", home)
 	pemA := darwinFixtureCA(t)
 	pemB := darwinFixtureCA(t)
-	keychain := filepath.Join(home, "Library", "Keychains", "login.keychain-db")
 
 	rec := &securityRecorder{}
-	var revokedPems []string
+	removePemAt := map[string]int{}  // canonical staged PEM -> call index
+	deleteHashAt := map[string]int{} // deleted SHA-256 -> call index
 	rec.handle = func(args []string) ([]byte, error) {
+		idx := len(rec.calls) - 1 // run records before dispatching to handle
 		switch args[0] {
 		case "find-certificate":
 			return append(append([]byte{}, pemA...), pemB...), nil
 		case "remove-trusted-cert":
 			content, _ := os.ReadFile(args[1])
-			revokedPems = append(revokedPems, string(content))
-			return nil, nil
+			if block, _ := pem.Decode(content); block != nil {
+				removePemAt[string(pem.EncodeToMemory(block))] = idx
+			}
+		case "delete-certificate":
+			require.Equal(t, "-Z", args[1], "keychain deletion selects by SHA-256")
+			deleteHashAt[args[2]] = idx
 		}
 		return nil, nil
 	}
@@ -482,19 +487,26 @@ func TestUninstallTrustAt_NoStateRevokesAllMatches(t *testing.T) {
 	require.ElementsMatch(t, []string{pemSHA256Hex(t, pemA), pemSHA256Hex(t, pemB)}, revoked,
 		"every common-name match must be reported as revoked")
 
+	// Pair commands per certificate rather than comparing global order:
+	// the keychain's enumeration order across the two matches must not
+	// matter, but each certificate still gets exactly one
+	// remove-trusted-cert (from its staged temp PEM) before exactly one
+	// keychain deletion of its own hash.
 	require.Len(t, rec.calls, 5, "probe plus revoke+delete per matched certificate")
 	canonical := func(certPEM []byte) string {
 		block, _ := pem.Decode(certPEM)
 		require.NotNil(t, block)
 		return string(pem.EncodeToMemory(block))
 	}
-	require.ElementsMatch(t, []string{canonical(pemA), canonical(pemB)}, revokedPems)
-	require.ElementsMatch(t,
-		[][]string{
-			{"delete-certificate", "-Z", pemSHA256Hex(t, pemA), keychain},
-			{"delete-certificate", "-Z", pemSHA256Hex(t, pemB), keychain},
-		},
-		[][]string{rec.calls[1], rec.calls[3]})
+	for _, certPEM := range [][]byte{pemA, pemB} {
+		hash := pemSHA256Hex(t, certPEM)
+		rmIdx, ok := removePemAt[canonical(certPEM)]
+		require.True(t, ok, "no remove-trusted-cert for %s", hash)
+		delIdx, ok := deleteHashAt[hash]
+		require.True(t, ok, "no delete-certificate for %s", hash)
+		require.Less(t, rmIdx, delIdx,
+			"trust settings must be revoked before that certificate's keychain deletion")
+	}
 }
 
 // TestUninstallTrustAt_KeychainProbeFailureSurfacesError ensures a real

--- a/internal/ca/trust_darwin_test.go
+++ b/internal/ca/trust_darwin_test.go
@@ -70,6 +70,16 @@ func securityNotFoundErr(t *testing.T, args []string) error {
 		"SecKeychainSearchCopyNext: The specified item could not be found in the keychain.")
 }
 
+// pemSHA256Hex returns the SHA-256 (of DER) of a PEM-encoded certificate,
+// the value persisted in the state file and matched by delete-certificate -Z.
+func pemSHA256Hex(t *testing.T, certPEM []byte) string {
+	t.Helper()
+	block, _ := pem.Decode(certPEM)
+	require.NotNil(t, block)
+	sum := sha256.Sum256(block.Bytes)
+	return hex.EncodeToString(sum[:])
+}
+
 func TestDefaultTrustDir_PemUnderPosternConfigDir(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -106,10 +116,34 @@ func TestInstallTrustAt_ExecutesAddTrustedCert(t *testing.T) {
 	require.Equal(t, os.FileMode(0o644), info.Mode().Perm())
 }
 
+// TestInstallTrustAt_PersistsSha256StateFile pins the install half of the
+// P1 fix: the SHA-256 (of DER) of the registered certificate is persisted
+// next to the anchor, 0600, so a later uninstall can disambiguate keychain
+// generations by hash when the anchor PEM is lost.
+func TestInstallTrustAt_PersistsSha256StateFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	rec := &securityRecorder{}
+	certPEM := darwinFixtureCA(t)
+
+	_, err := darwinTrust{run: rec.run}.install(filepath.Join(home, ".postern", "trust", "ca.pem"), certPEM)
+	require.NoError(t, err)
+
+	statePath := filepath.Join(home, ".postern", "trust", "ca.sha256")
+	got, err := os.ReadFile(statePath)
+	require.NoError(t, err, "install must persist the certificate hash for later uninstall")
+	require.Equal(t, pemSHA256Hex(t, certPEM), strings.TrimSpace(string(got)))
+	info, err := os.Stat(statePath)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
 // TestInstallTrustAt_DirectoryArgMatchesSharedContract pins the half of the
 // dispatch contract the platform-independent suites rely on: a directory
 // argument yields <dir>/postern.crt, byte-identical contents, mode 0644, and
-// the derived path (not the raw argument) handed to security(1).
+// the derived path (not the raw argument) handed to security(1). The
+// sibling SHA-256 state file follows the same derivation
+// (postern.crt -> postern.sha256).
 func TestInstallTrustAt_DirectoryArgMatchesSharedContract(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -136,6 +170,9 @@ func TestInstallTrustAt_DirectoryArgMatchesSharedContract(t *testing.T) {
 	info, err := os.Stat(path)
 	require.NoError(t, err)
 	require.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+	stateGot, err := os.ReadFile(filepath.Join(dir, "postern.sha256"))
+	require.NoError(t, err)
+	require.Equal(t, pemSHA256Hex(t, certPEM), strings.TrimSpace(string(stateGot)))
 }
 
 func TestUninstallTrustAt_RevokesTrustAndDeletesKeychainCert(t *testing.T) {
@@ -145,27 +182,26 @@ func TestUninstallTrustAt_RevokesTrustAndDeletesKeychainCert(t *testing.T) {
 	anchor := filepath.Join(home, ".postern", "trust", "ca.pem")
 	keychain := filepath.Join(home, "Library", "Keychains", "login.keychain-db")
 
-	installRec := &securityRecorder{}
-	_, err := darwinTrust{run: installRec.run}.install(anchor, certPEM)
+	seedRec := &securityRecorder{}
+	_, err := darwinTrust{run: seedRec.run}.install(anchor, certPEM)
 	require.NoError(t, err)
 	rec := &securityRecorder{}
 
-	path, err := darwinTrust{run: rec.run}.uninstall(anchor)
+	revoked, err := darwinTrust{run: rec.run}.uninstall(anchor)
 	require.NoError(t, err)
-	require.Equal(t, anchor, path)
 
+	hash := pemSHA256Hex(t, certPEM)
+	require.Equal(t, []string{hash}, revoked, "the revoked certificate's hash must be reported")
 	require.Len(t, rec.calls, 2, "uninstall must both revoke trust and delete the keychain cert")
 	require.Equal(t, []string{"remove-trusted-cert", anchor}, rec.calls[0])
-
-	block, _ := pem.Decode(certPEM)
-	require.NotNil(t, block)
-	sum := sha256.Sum256(block.Bytes)
 	require.Equal(t,
-		[]string{"delete-certificate", "-Z", hex.EncodeToString(sum[:]), keychain},
+		[]string{"delete-certificate", "-Z", hash, keychain},
 		rec.calls[1])
 
 	_, statErr := os.Stat(anchor)
 	require.True(t, os.IsNotExist(statErr), "anchor pem should be gone after uninstall")
+	_, statErr = os.Stat(filepath.Join(home, ".postern", "trust", "ca.sha256"))
+	require.True(t, os.IsNotExist(statErr), "state file should be gone after uninstall")
 }
 
 // TestUninstallTrustAt_AnchorMissingRecoversFromKeychain covers the security
@@ -180,6 +216,12 @@ func TestUninstallTrustAt_AnchorMissingRecoversFromKeychain(t *testing.T) {
 	anchor := filepath.Join(home, ".postern", "trust", "ca.pem")
 	keychain := filepath.Join(home, "Library", "Keychains", "login.keychain-db")
 
+	// A prior install persisted the state file; only the PEM was lost.
+	seedRec := &securityRecorder{}
+	_, err := darwinTrust{run: seedRec.run}.install(anchor, certPEM)
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(anchor))
+
 	rec := &securityRecorder{}
 	var revokedPem string
 	rec.handle = func(args []string) ([]byte, error) {
@@ -193,24 +235,20 @@ func TestUninstallTrustAt_AnchorMissingRecoversFromKeychain(t *testing.T) {
 		return nil, nil
 	}
 
-	path, err := darwinTrust{run: rec.run}.uninstall(anchor)
+	revoked, err := darwinTrust{run: rec.run}.uninstall(anchor)
 	require.NoError(t, err)
-	require.Equal(t, anchor, path)
+	require.Equal(t, []string{pemSHA256Hex(t, certPEM)}, revoked)
 
 	require.Len(t, rec.calls, 3, "recovery must probe, revoke trust, then delete from keychain")
 	require.Equal(t,
-		[]string{"find-certificate", "-c", caCommonName, "-p", keychain},
+		[]string{"find-certificate", "-a", "-c", caCommonName, "-p", keychain},
 		rec.calls[0])
 	require.NotEqual(t, anchor, revokedPem, "revocation must use the recovered copy, not the missing anchor")
 	require.True(t, strings.HasSuffix(revokedPem, ".pem"), "recovered anchor must be materialized as a PEM file")
 	_, statErr := os.Stat(revokedPem)
 	require.True(t, os.IsNotExist(statErr), "recovered temp copy must be cleaned up")
-
-	block, _ := pem.Decode(certPEM)
-	require.NotNil(t, block)
-	sum := sha256.Sum256(block.Bytes)
 	require.Equal(t,
-		[]string{"delete-certificate", "-Z", hex.EncodeToString(sum[:]), keychain},
+		[]string{"delete-certificate", "-Z", pemSHA256Hex(t, certPEM), keychain},
 		rec.calls[2])
 }
 
@@ -226,11 +264,107 @@ func TestUninstallTrustAt_AnchorMissingCertAbsentIsNoOp(t *testing.T) {
 		return nil, securityNotFoundErr(t, args)
 	}
 
-	path, err := darwinTrust{run: rec.run}.uninstall(filepath.Join(home, ".postern", "trust", "ca.pem"))
+	revoked, err := darwinTrust{run: rec.run}.uninstall(filepath.Join(home, ".postern", "trust", "ca.pem"))
 	require.NoError(t, err, "uninstall must be idempotent")
-	require.Equal(t, filepath.Join(home, ".postern", "trust", "ca.pem"), path)
+	require.Empty(t, revoked, "nothing was revoked")
 	require.Len(t, rec.calls, 1, "only the keychain probe may run")
 	require.Equal(t, "find-certificate", rec.calls[0][0], "no revocation without a located certificate")
+}
+
+// TestUninstallTrustAt_StateHashSelectsCorrectGeneration pins the P1 fix:
+// regeneration leaves older, still-trusted Postern CAs in the login
+// keychain, all sharing the common name. With the anchor PEM lost, uninstall
+// must pick the generation recorded in the state file by exact SHA-256, not
+// whichever common-name match the keychain returns first.
+func TestUninstallTrustAt_StateHashSelectsCorrectGeneration(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	stalePEM := darwinFixtureCA(t) // earlier generation, still trusted
+	certPEM := darwinFixtureCA(t)  // installed generation: distinct key + serial
+	anchor := filepath.Join(home, ".postern", "trust", "ca.pem")
+	keychain := filepath.Join(home, "Library", "Keychains", "login.keychain-db")
+
+	seedRec := &securityRecorder{}
+	_, err := darwinTrust{run: seedRec.run}.install(anchor, certPEM)
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(anchor), "simulate the lost anchor PEM")
+
+	rec := &securityRecorder{}
+	var revokedPemContent []byte
+	rec.handle = func(args []string) ([]byte, error) {
+		switch args[0] {
+		case "find-certificate":
+			blob := append(append([]byte{}, stalePEM...), certPEM...)
+			return blob, nil // find-certificate -a output: every generation
+		case "remove-trusted-cert":
+			revokedPemContent, _ = os.ReadFile(args[1])
+			return nil, nil
+		}
+		return nil, nil
+	}
+
+	revoked, err := darwinTrust{run: rec.run}.uninstall(anchor)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{pemSHA256Hex(t, certPEM)}, revoked,
+		"exactly the installed generation must be revoked")
+	require.Len(t, rec.calls, 3)
+	require.Equal(t,
+		[]string{"find-certificate", "-a", "-c", caCommonName, "-p", keychain},
+		rec.calls[0])
+	block, _ := pem.Decode(certPEM)
+	require.NotNil(t, block)
+	require.Equal(t, string(pem.EncodeToMemory(block)), string(revokedPemContent),
+		"revocation must target the state-hash match, not the stale generation")
+	require.Equal(t,
+		[]string{"delete-certificate", "-Z", pemSHA256Hex(t, certPEM), keychain},
+		rec.calls[2])
+	require.NotContains(t, rec.calls[2], pemSHA256Hex(t, stalePEM),
+		"the stale generation's hash must never be deleted via name-only recovery")
+}
+
+// TestUninstallTrustAt_NoStateRevokesAllMatches covers resolution path 3:
+// with neither anchor nor state file, uninstall fails wide — revoking every
+// common-name match — and reports each revoked hash.
+func TestUninstallTrustAt_NoStateRevokesAllMatches(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	pemA := darwinFixtureCA(t)
+	pemB := darwinFixtureCA(t)
+	keychain := filepath.Join(home, "Library", "Keychains", "login.keychain-db")
+
+	rec := &securityRecorder{}
+	var revokedPems []string
+	rec.handle = func(args []string) ([]byte, error) {
+		switch args[0] {
+		case "find-certificate":
+			return append(append([]byte{}, pemA...), pemB...), nil
+		case "remove-trusted-cert":
+			content, _ := os.ReadFile(args[1])
+			revokedPems = append(revokedPems, string(content))
+			return nil, nil
+		}
+		return nil, nil
+	}
+
+	revoked, err := darwinTrust{run: rec.run}.uninstall(filepath.Join(home, ".postern", "trust", "ca.pem"))
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{pemSHA256Hex(t, pemA), pemSHA256Hex(t, pemB)}, revoked,
+		"every common-name match must be reported as revoked")
+
+	require.Len(t, rec.calls, 5, "probe plus revoke+delete per matched certificate")
+	canonical := func(certPEM []byte) string {
+		block, _ := pem.Decode(certPEM)
+		require.NotNil(t, block)
+		return string(pem.EncodeToMemory(block))
+	}
+	require.ElementsMatch(t, []string{canonical(pemA), canonical(pemB)}, revokedPems)
+	require.ElementsMatch(t,
+		[][]string{
+			{"delete-certificate", "-Z", pemSHA256Hex(t, pemA), keychain},
+			{"delete-certificate", "-Z", pemSHA256Hex(t, pemB), keychain},
+		},
+		[][]string{rec.calls[1], rec.calls[3]})
 }
 
 // TestUninstallTrustAt_KeychainProbeFailureSurfacesError ensures a real

--- a/internal/ca/trust_darwin_test.go
+++ b/internal/ca/trust_darwin_test.go
@@ -197,6 +197,40 @@ func TestInstallTrustAt_FailedRegistrationRemovesAnchor(t *testing.T) {
 	require.True(t, os.IsNotExist(statErr), "failed install must not leave the anchor behind")
 }
 
+// TestInstallTrustAt_FailedReinstallRestoresPriorAnchor pins the reinstall
+// half of the failure story: writeAnchor overwrites the previous anchor
+// before registration runs, so a failed reinstall must put the previous
+// bytes back instead of deleting the file. Otherwise disk and keychain
+// diverge — the previously trusted CA keeps its trust settings while its
+// persisted anchor is gone.
+func TestInstallTrustAt_FailedReinstallRestoresPriorAnchor(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	priorPEM := darwinFixtureCA(t)
+	anchor := filepath.Join(home, ".postern", "trust", "ca.pem")
+
+	seedRec := &securityRecorder{}
+	_, err := darwinTrust{run: seedRec.run}.install(anchor, priorPEM)
+	require.NoError(t, err)
+	newPEM := darwinFixtureCA(t)
+	rec := &securityRecorder{handle: func(args []string) ([]byte, error) {
+		if args[0] != "add-trusted-cert" {
+			return nil, nil
+		}
+		cmd := exec.Command("/bin/sh", "-c", "exit 51")
+		runErr := cmd.Run()
+		return nil, securityCmdError(args, runErr, "SecTrustSettingsAddTrusted failed\n")
+	}}
+
+	_, err = darwinTrust{run: rec.run}.install(anchor, newPEM)
+	require.Error(t, err)
+
+	got, readErr := os.ReadFile(anchor)
+	require.NoError(t, readErr, "the pre-existing anchor must survive a failed reinstall")
+	require.Equal(t, priorPEM, got,
+		"failed reinstall must restore the previous anchor bytes, not delete them")
+}
+
 // TestUninstallTrustAt_RevokesAnchorDirectlyAndLeavesKeychainEntry covers the
 // common uninstall: the anchor PEM is present and the same certificate sits
 // in the login keychain. The certificate must be revoked exactly once,

--- a/internal/ca/trust_darwin_test.go
+++ b/internal/ca/trust_darwin_test.go
@@ -220,6 +220,42 @@ func TestInstallTrustAt_FailedReinstallRestoresPreviousPairing(t *testing.T) {
 		"the previous state hash must survive the failed reinstall")
 }
 
+// TestInstallTrustAt_SameCARereinstallFailureKeepsTrust pins the reinstall
+// edge: when the failed install is a re-run for the certificate this host
+// ALREADY has installed, the rollback must not revoke or delete it. Its
+// trust predates the run, and removing it while the restored files still
+// describe it as installed would leave the host untrusted but reporting
+// installed.
+func TestInstallTrustAt_SameCARereinstallFailureKeepsTrust(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	certPEM := darwinFixtureCA(t)
+	anchor := filepath.Join(home, ".postern", "trust", "ca.pem")
+	statePath := filepath.Join(home, ".postern", "trust", "ca.sha256")
+	trustDir := filepath.Dir(anchor)
+	require.NoError(t, os.MkdirAll(trustDir, 0o700))
+	require.NoError(t, writeFileMode(anchor, certPEM, 0o644))
+	hash := pemSHA256Hex(t, certPEM)
+	require.NoError(t, writeFileMode(statePath, []byte(hash), 0o600))
+	require.NoError(t, os.Chmod(trustDir, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(trustDir, 0o700) })
+
+	rec := &securityRecorder{}
+	_, err := darwinTrust{run: rec.run}.install(anchor, certPEM)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "write trust state")
+
+	require.Len(t, rec.calls, 1, "no revoke/delete for an identity that was already trusted")
+	require.Equal(t, "add-trusted-cert", rec.calls[0][0])
+
+	gotAnchor, readErr := os.ReadFile(anchor)
+	require.NoError(t, readErr)
+	require.Equal(t, certPEM, gotAnchor)
+	gotState, readErr := os.ReadFile(statePath)
+	require.NoError(t, readErr)
+	require.Equal(t, hash, strings.TrimSpace(string(gotState)))
+}
+
 // TestRestoreTrustFiles_RestoresContents unit-tests the file half of the
 // snapshot/restore pair, including the branch that writes previous state
 // content back rather than deleting it.

--- a/internal/ca/trust_darwin_test.go
+++ b/internal/ca/trust_darwin_test.go
@@ -138,6 +138,39 @@ func TestInstallTrustAt_PersistsSha256StateFile(t *testing.T) {
 	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
 }
 
+// TestInstallTrustAt_StateWriteFailureRollsBackTrust pins the rollback: when
+// add-trusted-cert has already registered the certificate but persisting the
+// SHA-256 state fails, install must undo the registration instead of
+// reporting a failed install that actually left the CA trusted.
+func TestInstallTrustAt_StateWriteFailureRollsBackTrust(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	certPEM := darwinFixtureCA(t)
+	anchor := filepath.Join(home, ".postern", "trust", "ca.pem")
+	keychain := filepath.Join(home, "Library", "Keychains", "login.keychain-db")
+	require.NoError(t, os.MkdirAll(filepath.Dir(anchor), 0o700))
+	// Occupy the state path with a directory so the atomic rename inside
+	// writeStateFile fails after the trust registration already succeeded.
+	require.NoError(t, os.Mkdir(filepath.Join(home, ".postern", "trust", "ca.sha256"), 0o700))
+
+	rec := &securityRecorder{}
+	_, err := darwinTrust{run: rec.run}.install(anchor, certPEM)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "write trust state")
+
+	require.Len(t, rec.calls, 3, "register, then roll back revoke+delete")
+	require.Equal(t,
+		[]string{
+			"add-trusted-cert", "-r", "trustRoot",
+			"-k", keychain, anchor,
+		},
+		rec.calls[0])
+	require.Equal(t, []string{"remove-trusted-cert", anchor}, rec.calls[1])
+	require.Equal(t,
+		[]string{"delete-certificate", "-Z", pemSHA256Hex(t, certPEM), keychain},
+		rec.calls[2])
+}
+
 // TestInstallTrustAt_DirectoryArgMatchesSharedContract pins the half of the
 // dispatch contract the platform-independent suites rely on: a directory
 // argument yields <dir>/postern.crt, byte-identical contents, mode 0644, and

--- a/internal/ca/trust_darwin_test.go
+++ b/internal/ca/trust_darwin_test.go
@@ -9,7 +9,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,19 +27,47 @@ func darwinFixtureCA(t *testing.T) []byte {
 	return c.CertPEM
 }
 
-// stubSecurity replaces runSecurity with a recorder. It returns the recorded
-// invocations; each element is one security(1) command line's argv (command
-// name included, binary path excluded).
-func stubSecurity(t *testing.T) *[][]string {
-	t.Helper()
-	calls := &[][]string{}
-	orig := runSecurity
-	runSecurity = func(args ...string) error {
-		*calls = append(*calls, args)
-		return nil
+// securityRecorder is an explicit securityRunner stand-in. Each invocation is
+// recorded as one security(1) command line's argv (command name included,
+// binary path excluded); handle, when set, answers the call instead of the
+// default success-with-no-output.
+type securityRecorder struct {
+	calls  [][]string
+	handle func(args []string) ([]byte, error)
+}
+
+func (r *securityRecorder) run(args ...string) ([]byte, error) {
+	r.calls = append(r.calls, args)
+	if r.handle != nil {
+		return r.handle(args)
 	}
-	t.Cleanup(func() { runSecurity = orig })
-	return calls
+	return nil, nil
+}
+
+// failingRunner returns a securityRunner whose every call fails like the real
+// binary would: the error carries the full command line plus stderr text.
+func failingRunner(errCode int, stderr string) securityRecorder {
+	return securityRecorder{
+		handle: func(args []string) ([]byte, error) {
+			cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf("exit %d", errCode))
+			runErr := cmd.Run()
+			return nil, securityCmdError(args, runErr, stderr)
+		},
+	}
+}
+
+// securityNotFoundErr builds the error shape of a security(1) lookup that did
+// not find its item: the documented exit status 44, wrapped exactly the way
+// production wraps failed invocations.
+func securityNotFoundErr(t *testing.T, args []string) error {
+	t.Helper()
+	cmd := exec.Command("/bin/sh", "-c", "exit 44")
+	runErr := cmd.Run()
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, runErr, &exitErr)
+	require.Equal(t, 44, exitErr.ExitCode())
+	return securityCmdError(args, runErr,
+		"SecKeychainSearchCopyNext: The specified item could not be found in the keychain.")
 }
 
 func TestDefaultTrustDir_PemUnderPosternConfigDir(t *testing.T) {
@@ -52,21 +82,53 @@ func TestDefaultTrustDir_PemUnderPosternConfigDir(t *testing.T) {
 func TestInstallTrustAt_ExecutesAddTrustedCert(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	calls := stubSecurity(t)
+	rec := &securityRecorder{}
 	certPEM := darwinFixtureCA(t)
 
-	path, err := InstallTrustAt(filepath.Join(home, ".postern", "trust", "ca.pem"), certPEM)
+	path, err := darwinTrust{run: rec.run}.install(filepath.Join(home, ".postern", "trust", "ca.pem"), certPEM)
 	require.NoError(t, err)
 	require.Equal(t, filepath.Join(home, ".postern", "trust", "ca.pem"), path)
 
-	require.Len(t, *calls, 1, "install must invoke security exactly once")
+	require.Len(t, rec.calls, 1, "install must invoke security exactly once")
 	require.Equal(t,
 		[]string{
 			"add-trusted-cert", "-r", "trustRoot",
 			"-k", filepath.Join(home, "Library", "Keychains", "login.keychain-db"),
 			path,
 		},
-		(*calls)[0])
+		rec.calls[0])
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, certPEM, got)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+}
+
+// TestInstallTrustAt_DirectoryArgMatchesSharedContract pins the half of the
+// dispatch contract the platform-independent suites rely on: a directory
+// argument yields <dir>/postern.crt, byte-identical contents, mode 0644, and
+// the derived path (not the raw argument) handed to security(1).
+func TestInstallTrustAt_DirectoryArgMatchesSharedContract(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	rec := &securityRecorder{}
+	certPEM := darwinFixtureCA(t)
+	dir := filepath.Join(home, "trust-store")
+
+	path, err := darwinTrust{run: rec.run}.install(dir, certPEM)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(dir, "postern.crt"), path)
+
+	require.Len(t, rec.calls, 1)
+	require.Equal(t,
+		[]string{
+			"add-trusted-cert", "-r", "trustRoot",
+			"-k", filepath.Join(home, "Library", "Keychains", "login.keychain-db"),
+			path,
+		},
+		rec.calls[0])
 
 	got, err := os.ReadFile(path)
 	require.NoError(t, err)
@@ -83,55 +145,116 @@ func TestUninstallTrustAt_RevokesTrustAndDeletesKeychainCert(t *testing.T) {
 	anchor := filepath.Join(home, ".postern", "trust", "ca.pem")
 	keychain := filepath.Join(home, "Library", "Keychains", "login.keychain-db")
 
-	// Stub before install: the real security(1) would fail on CI (no login
-	// keychain). A first recorder covers setup; a fresh one captures only
-	// the uninstall invocations asserted below.
-	stubSecurity(t)
-
-	_, err := InstallTrustAt(anchor, certPEM)
+	installRec := &securityRecorder{}
+	_, err := darwinTrust{run: installRec.run}.install(anchor, certPEM)
 	require.NoError(t, err)
-	calls := stubSecurity(t)
+	rec := &securityRecorder{}
 
-	path, err := UninstallTrustAt(anchor)
+	path, err := darwinTrust{run: rec.run}.uninstall(anchor)
 	require.NoError(t, err)
 	require.Equal(t, anchor, path)
 
-	require.Len(t, *calls, 2, "uninstall must both revoke trust and delete the keychain cert")
-	require.Equal(t, []string{"remove-trusted-cert", anchor}, (*calls)[0])
+	require.Len(t, rec.calls, 2, "uninstall must both revoke trust and delete the keychain cert")
+	require.Equal(t, []string{"remove-trusted-cert", anchor}, rec.calls[0])
 
 	block, _ := pem.Decode(certPEM)
 	require.NotNil(t, block)
 	sum := sha256.Sum256(block.Bytes)
 	require.Equal(t,
 		[]string{"delete-certificate", "-Z", hex.EncodeToString(sum[:]), keychain},
-		(*calls)[1])
+		rec.calls[1])
 
 	_, statErr := os.Stat(anchor)
 	require.True(t, os.IsNotExist(statErr), "anchor pem should be gone after uninstall")
 }
 
-func TestUninstallTrustAt_MissingAnchorIsNoOp(t *testing.T) {
+// TestUninstallTrustAt_AnchorMissingRecoversFromKeychain covers the security
+// fix: with the persisted PEM lost but the certificate still trusted in the
+// login keychain, uninstall must recover the certificate bytes by common
+// name, revoke its trust setting, and delete it from the keychain. Reporting
+// success without those commands would leave the CA trusted.
+func TestUninstallTrustAt_AnchorMissingRecoversFromKeychain(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	calls := stubSecurity(t)
+	certPEM := darwinFixtureCA(t)
+	anchor := filepath.Join(home, ".postern", "trust", "ca.pem")
+	keychain := filepath.Join(home, "Library", "Keychains", "login.keychain-db")
 
-	_, err := UninstallTrustAt(filepath.Join(home, ".postern", "trust", "ca.pem"))
+	rec := &securityRecorder{}
+	var revokedPem string
+	rec.handle = func(args []string) ([]byte, error) {
+		switch args[0] {
+		case "find-certificate":
+			return certPEM, nil
+		case "remove-trusted-cert":
+			revokedPem = args[1]
+			return nil, nil
+		}
+		return nil, nil
+	}
+
+	path, err := darwinTrust{run: rec.run}.uninstall(anchor)
+	require.NoError(t, err)
+	require.Equal(t, anchor, path)
+
+	require.Len(t, rec.calls, 3, "recovery must probe, revoke trust, then delete from keychain")
+	require.Equal(t,
+		[]string{"find-certificate", "-c", caCommonName, "-p", keychain},
+		rec.calls[0])
+	require.NotEqual(t, anchor, revokedPem, "revocation must use the recovered copy, not the missing anchor")
+	require.True(t, strings.HasSuffix(revokedPem, ".pem"), "recovered anchor must be materialized as a PEM file")
+	_, statErr := os.Stat(revokedPem)
+	require.True(t, os.IsNotExist(statErr), "recovered temp copy must be cleaned up")
+
+	block, _ := pem.Decode(certPEM)
+	require.NotNil(t, block)
+	sum := sha256.Sum256(block.Bytes)
+	require.Equal(t,
+		[]string{"delete-certificate", "-Z", hex.EncodeToString(sum[:]), keychain},
+		rec.calls[2])
+}
+
+// TestUninstallTrustAt_AnchorMissingCertAbsentIsNoOp proves idempotency is
+// genuine: when neither the anchor nor the keychain holds the certificate,
+// uninstall succeeds without any revocation command.
+func TestUninstallTrustAt_AnchorMissingCertAbsentIsNoOp(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	rec := &securityRecorder{}
+	rec.handle = func(args []string) ([]byte, error) {
+		return nil, securityNotFoundErr(t, args)
+	}
+
+	path, err := darwinTrust{run: rec.run}.uninstall(filepath.Join(home, ".postern", "trust", "ca.pem"))
 	require.NoError(t, err, "uninstall must be idempotent")
-	require.Empty(t, *calls, "no security invocation without an installed anchor")
+	require.Equal(t, filepath.Join(home, ".postern", "trust", "ca.pem"), path)
+	require.Len(t, rec.calls, 1, "only the keychain probe may run")
+	require.Equal(t, "find-certificate", rec.calls[0][0], "no revocation without a located certificate")
+}
+
+// TestUninstallTrustAt_KeychainProbeFailureSurfacesError ensures a real
+// security(1) failure during recovery is never mistaken for "nothing to do".
+func TestUninstallTrustAt_KeychainProbeFailureSurfacesError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	rec := failingRunner(51, "SecKeychainSearchCopyNext failed\n")
+
+	_, err := darwinTrust{run: rec.run}.uninstall(filepath.Join(home, ".postern", "trust", "ca.pem"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Postern Local CA")
+	require.Contains(t, err.Error(), "SecKeychainSearchCopyNext failed",
+		"security's stderr must be surfaced to the caller")
+	require.Len(t, rec.calls, 1, "no revocation attempt after a failed probe")
 }
 
 func TestInstallTrustAt_SecurityFailureWrapsStderr(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	orig := runSecurity
-	runSecurity = func(args ...string) error {
-		return securityCmdError(args, errors.New("exit status 44"),
-			"SecTrustSettingsAddTrusted failed\n")
-	}
-	t.Cleanup(func() { runSecurity = orig })
+	rec := failingRunner(44, "SecTrustSettingsAddTrusted failed\n")
 	certPEM := darwinFixtureCA(t)
 
-	_, err := InstallTrustAt(filepath.Join(home, ".postern", "trust", "ca.pem"), certPEM)
+	_, err := darwinTrust{run: rec.run}.install(filepath.Join(home, ".postern", "trust", "ca.pem"), certPEM)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), securityBin)
 	require.Contains(t, err.Error(), "add-trusted-cert")
@@ -146,20 +269,12 @@ func TestUninstallTrustAt_SecurityFailureWrapsStderr(t *testing.T) {
 	certPEM := darwinFixtureCA(t)
 	anchor := filepath.Join(home, ".postern", "trust", "ca.pem")
 
-	// Stub before install: the real security(1) would fail on CI (no login
-	// keychain); the recorder no-op is swapped for the failing stub below.
-	stubSecurity(t)
-
-	_, err := InstallTrustAt(anchor, certPEM)
+	seedRec := &securityRecorder{}
+	_, err := darwinTrust{run: seedRec.run}.install(anchor, certPEM)
 	require.NoError(t, err)
-	orig := runSecurity
-	runSecurity = func(args ...string) error {
-		return securityCmdError(args, errors.New("exit status 51"),
-			"SecTrustSettingsRemoveTrusted failed\n")
-	}
-	t.Cleanup(func() { runSecurity = orig })
+	rec := failingRunner(51, "SecTrustSettingsRemoveTrusted failed\n")
 
-	_, err = UninstallTrustAt(anchor)
+	_, err = darwinTrust{run: rec.run}.uninstall(anchor)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "revoke trust settings")
 	require.Contains(t, err.Error(), "SecTrustSettingsRemoveTrusted failed")
@@ -168,15 +283,15 @@ func TestUninstallTrustAt_SecurityFailureWrapsStderr(t *testing.T) {
 func TestUninstallTrustAt_InvalidPemIsRejected(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	calls := stubSecurity(t)
+	rec := &securityRecorder{}
 	anchor := filepath.Join(home, ".postern", "trust", "ca.pem")
 	require.NoError(t, os.MkdirAll(filepath.Dir(anchor), 0o755))
 	require.NoError(t, os.WriteFile(anchor, []byte("not a pem"), 0o644))
 
-	_, err := UninstallTrustAt(anchor)
+	_, err := darwinTrust{run: rec.run}.uninstall(anchor)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid PEM")
-	require.Empty(t, *calls, "no security invocation without a parseable anchor")
+	require.Empty(t, rec.calls, "no security invocation without a parseable anchor")
 }
 
 func TestSecurityCmdError_Format(t *testing.T) {

--- a/internal/ca/trust_darwin_test.go
+++ b/internal/ca/trust_darwin_test.go
@@ -256,8 +256,10 @@ func TestInstallTrustAt_SameCARereinstallFailureKeepsTrust(t *testing.T) {
 	require.Error(t, err)
 	require.Len(t, rec.calls, 2, "probe runs, but no revoke/delete for an identity already in the keychain")
 	require.Equal(t,
-		[]string{"find-certificate", "-a", "-c", caCommonName, "-p",
-			filepath.Join(home, "Library", "Keychains", "login.keychain-db")},
+		[]string{
+			"find-certificate", "-a", "-c", caCommonName, "-p",
+			filepath.Join(home, "Library", "Keychains", "login.keychain-db"),
+		},
 		rec.calls[0])
 	require.Equal(t, "add-trusted-cert", rec.calls[1][0])
 
@@ -552,7 +554,15 @@ func TestUninstallTrustAt_KeychainProbeFailureSurfacesError(t *testing.T) {
 func TestInstallTrustAt_SecurityFailureWrapsStderr(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	rec := failingRunner(44, "SecTrustSettingsAddTrusted failed\n")
+	// The keychain probe succeeds; only the registration fails.
+	rec := &securityRecorder{handle: func(args []string) ([]byte, error) {
+		if args[0] != "add-trusted-cert" {
+			return nil, nil
+		}
+		cmd := exec.Command("/bin/sh", "-c", "exit 44")
+		runErr := cmd.Run()
+		return nil, securityCmdError(args, runErr, "SecTrustSettingsAddTrusted failed\n")
+	}}
 	certPEM := darwinFixtureCA(t)
 
 	_, err := darwinTrust{run: rec.run}.install(filepath.Join(home, ".postern", "trust", "ca.pem"), certPEM)
@@ -562,6 +572,27 @@ func TestInstallTrustAt_SecurityFailureWrapsStderr(t *testing.T) {
 	require.Contains(t, err.Error(), "exit status 44")
 	require.Contains(t, err.Error(), "SecTrustSettingsAddTrusted failed",
 		"security's stderr must be surfaced to the caller")
+}
+
+// TestInstallTrustAt_ProbeFailureAbortsBeforeMutation pins the probe
+// discipline: when keychain presence cannot be determined, install aborts
+// before touching anything. Guessing either way corrupts state on a later
+// failure: skipping rollback could leave new trust behind, running it could
+// destroy pre-existing trust.
+func TestInstallTrustAt_ProbeFailureAbortsBeforeMutation(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	rec := failingRunner(51, "SecKeychainSearchCopyNext failed\n")
+	certPEM := darwinFixtureCA(t)
+	anchor := filepath.Join(home, ".postern", "trust", "ca.pem")
+
+	_, err := darwinTrust{run: rec.run}.install(anchor, certPEM)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "probe login keychain")
+	require.Len(t, rec.calls, 1, "only the failed probe may run")
+
+	_, statErr := os.Stat(anchor)
+	require.True(t, os.IsNotExist(statErr), "no anchor may be written when presence is unknown")
 }
 
 func TestUninstallTrustAt_SecurityFailureWrapsStderr(t *testing.T) {

--- a/internal/ca/trust_darwin_test.go
+++ b/internal/ca/trust_darwin_test.go
@@ -509,6 +509,65 @@ func TestUninstallTrustAt_NoStateRevokesAllMatches(t *testing.T) {
 	}
 }
 
+// notFoundSecurityErr builds the error shape of a security(1) invocation
+// whose Security-framework call reported errSecItemNotFound: the tool's
+// cssmPerror diagnostic in stderr, wrapped exactly the way production
+// wraps failed invocations.
+func notFoundSecurityErr(args []string, fn string) error {
+	return securityCmdError(args, fmt.Errorf("exit status 1"),
+		fn+": The specified item could not be found in the keychain.")
+}
+
+// TestUninstallTrustAt_MissingTrustSettingsStillDeletes pins the retry
+// story for partial revocation: if remove-trusted-cert succeeds but
+// delete-certificate fails, the next uninstall repeats remove-trusted-cert
+// for a certificate whose settings are already gone. That absence is
+// non-fatal — the keychain deletion is still attempted and the hash still
+// reported — while any other remove-trusted-cert failure stays fatal.
+func TestUninstallTrustAt_MissingTrustSettingsStillDeletes(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	certPEM := darwinFixtureCA(t)
+	keychain := filepath.Join(home, "Library", "Keychains", "login.keychain-db")
+
+	rec := &securityRecorder{handle: func(args []string) ([]byte, error) {
+		switch args[0] {
+		case "find-certificate":
+			return certPEM, nil
+		case "remove-trusted-cert":
+			// Retry after a previous run's remove succeeded and its
+			// delete failed: no user-domain trust settings remain.
+			return nil, notFoundSecurityErr(args, "SecTrustSettingsRemoveTrustSettings")
+		}
+		return nil, nil
+	}}
+
+	revoked, err := darwinTrust{run: rec.run}.uninstall(filepath.Join(home, ".postern", "trust", "ca.pem"))
+	require.NoError(t, err)
+	require.Equal(t, []string{pemSHA256Hex(t, certPEM)}, revoked,
+		"the certificate counts as revoked once its keychain entry is deleted")
+	require.Len(t, rec.calls, 3)
+	require.Equal(t,
+		[]string{"delete-certificate", "-Z", pemSHA256Hex(t, certPEM), keychain},
+		rec.calls[2])
+
+	// A remove-trusted-cert failure that is NOT plain absence must stay
+	// fatal: fail wide rather than silently deleting a still-trusted cert.
+	fatal := &securityRecorder{handle: func(args []string) ([]byte, error) {
+		switch args[0] {
+		case "find-certificate":
+			return certPEM, nil
+		case "remove-trusted-cert":
+			return nil, securityCmdError(args, fmt.Errorf("exit status 1"),
+				"SecTrustSettingsRemoveTrustSettings: UNIX[Operation not permitted]")
+		}
+		return nil, nil
+	}}
+	_, err = darwinTrust{run: fatal.run}.uninstall(filepath.Join(home, ".postern", "trust", "ca.pem"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "revoke trust settings")
+}
+
 // TestUninstallTrustAt_KeychainProbeFailureSurfacesError ensures a real
 // security(1) failure during recovery is never mistaken for "nothing to do".
 func TestUninstallTrustAt_KeychainProbeFailureSurfacesError(t *testing.T) {

--- a/internal/ca/trust_linux.go
+++ b/internal/ca/trust_linux.go
@@ -36,7 +36,9 @@ func installTrustAt(dir string, certPEM []byte) (string, error) {
 }
 
 // uninstallTrustAt on Linux removes the anchor file; the per-user updater
-// drops it from the trust bundle on its next run.
-func uninstallTrustAt(dir string) (string, error) {
-	return removeAnchor(dir)
+// drops it from the trust bundle on its next run. There is no keychain-style
+// registration to revoke, so no hashes are ever reported.
+func uninstallTrustAt(dir string) ([]string, error) {
+	_, err := removeAnchor(dir)
+	return nil, err
 }

--- a/internal/ca/trust_linux_test.go
+++ b/internal/ca/trust_linux_test.go
@@ -37,8 +37,9 @@ func TestInstallAndUninstallTrust_UsesXDGUserDir(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, c.CertPEM, got)
 
-	_, err = ca.UninstallTrust()
+	_, revoked, err := ca.UninstallTrust()
 	require.NoError(t, err)
+	require.Empty(t, revoked)
 	_, statErr := os.Stat(path)
 	require.True(t, os.IsNotExist(statErr))
 }

--- a/internal/ca/trust_test.go
+++ b/internal/ca/trust_test.go
@@ -82,9 +82,10 @@ func TestUninstallTrustAt_RemovesFile(t *testing.T) {
 	_, err := ca.InstallTrustAt(dir, c.CertPEM)
 	require.NoError(t, err)
 
-	path, err := ca.UninstallTrustAt(dir)
+	path, revoked, err := ca.UninstallTrustAt(dir)
 	require.NoError(t, err)
 	require.Equal(t, filepath.Join(dir, "postern.crt"), path)
+	require.Empty(t, revoked, "this GOOS has no keychain-style registration to revoke")
 
 	_, statErr := os.Stat(path)
 	require.True(t, os.IsNotExist(statErr), "trust file should be gone after uninstall")
@@ -93,8 +94,9 @@ func TestUninstallTrustAt_RemovesFile(t *testing.T) {
 func TestUninstallTrustAt_MissingFileIsNoOp(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	_, err := ca.UninstallTrustAt(dir)
+	_, revoked, err := ca.UninstallTrustAt(dir)
 	require.NoError(t, err, "uninstall must be idempotent")
+	require.Empty(t, revoked)
 }
 
 func TestInstallTrustAt_FailsWhenParentIsFile(t *testing.T) {

--- a/internal/ca/trust_unsupported.go
+++ b/internal/ca/trust_unsupported.go
@@ -17,6 +17,6 @@ func installTrustAt(dir string, certPEM []byte) (string, error) {
 	return "", ErrTrustUnsupported
 }
 
-func uninstallTrustAt(dir string) (string, error) {
-	return "", ErrTrustUnsupported
+func uninstallTrustAt(dir string) ([]string, error) {
+	return nil, ErrTrustUnsupported
 }

--- a/internal/cli/ca.go
+++ b/internal/cli/ca.go
@@ -67,11 +67,14 @@ func newCAUninstallCmd(caDir, trustDir string) *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			out := cmd.OutOrStdout()
 
-			path, err := ca.UninstallTrustAt(trustDir)
+			path, revoked, err := ca.UninstallTrustAt(trustDir)
 			if err != nil {
 				return fmt.Errorf("uninstall trust: %w", err)
 			}
 			_, _ = fmt.Fprintf(out, "Removed trust anchor at %s\n", path)
+			for _, hash := range revoked {
+				_, _ = fmt.Fprintf(out, "Revoked trusted certificate %s\n", hash)
+			}
 
 			if !purge {
 				_, _ = fmt.Fprintf(out, "Left CA files in %s (run with --purge to delete)\n", caDir)


### PR DESCRIPTION
Closes the three Greptile findings on #80:

- [3833312682](https://github.com/mmartinez/postern/pull/80#discussion_r3833312682) (P1, `internal/ca/trust.go:45`): "Darwin dispatch breaks shared tests — When the platform-independent CA tests run on macOS, they pass directories to these functions, but the Darwin backend treats each argument as a certificate filename and calls `os.WriteFile` or `os.ReadFile` on the directory, causing the test suites to fail with an is-a-directory error."
- [3833312687](https://github.com/mmartinez/postern/pull/80#discussion_r3833312687) (P1 security, `internal/ca/trust_darwin.go:109`): "Missing anchor bypasses trust revocation — When the persisted anchor is deleted or lost after installation, this branch returns success without running either keychain revocation command, so the CLI reports successful removal while the CA remains trusted and resolvable in the login keychain."
- [3833312690](https://github.com/mmartinez/postern/pull/80#discussion_r3833312690) (P2, `internal/ca/trust_darwin.go:31`): "Command seam uses mutable global — Declaring `runSecurity` as an assignable package variable violates the repository rule against mutable global state outside `main`; tests replace process-wide command behavior, making parallel use and test execution order-dependent. Pass the command runner explicitly instead."

## Fix per finding

**Finding 1 (shared contract).** `resolveAnchorPath` in `trust.go` defines the contract for every GOOS: a location ending in `.pem`/`.crt` is the anchor file itself, anything else is a directory and the anchor is `<dir>/postern.crt`. `writeAnchor`/`removeAnchor` use it, and the darwin backend routes install and uninstall through it, so a directory argument now yields the same file, mode 0644, and returned path on macOS as on Linux. `DefaultTrustDir` on macOS still returns `~/.postern/trust/ca.pem`, which the suffix rule treats as an explicit file path, so existing installs keep working. The contract is documented on `InstallTrustAt`/`UninstallTrustAt`.

**Finding 2 (revocation without the anchor).** When the anchor PEM is missing, the darwin backend probes the login keychain with `security find-certificate -c "Postern Local CA" -p <login keychain>` (common name now shared with `gen.go` via `caCommonName`). If found, the PEM is staged into a temp `.pem`, revoked with `remove-trusted-cert <tmp>`, deleted with `delete-certificate -Z <sha256> <keychain>`, and the temp copy removed. security(1)'s exit status 44 (item not found) is the only path to a success no-op; any other probe failure surfaces with the command line and stderr.

**Finding 3 (explicit runner).` `var runSecurity` is gone. `securityRunner` is a function type held as a field on the `darwinTrust` backend struct; the exported dispatch functions thread `osSecurity` (the real `/usr/bin/security` executor) and tests construct `darwinTrust{run: recorder}.install/uninstall` directly. No assignable package state.

## Verification

- `GOOS=darwin CGO_ENABLED=0 go build ./...` and `GOOS=darwin go vet ./internal/ca/` pass.
- Full `make ci` on linux green (golangci-lint 0 issues, `go test -race` with coverage across all packages, govulncheck clean).
- Platform-independent proof beyond compilation: the darwin backend was compiled on linux (build tag and `_darwin` suffix stripped in a throwaway copy, with a stub `/usr/bin/security` that records argv and emulates exit 44 for not-found) and the **unchanged** `trust_test.go` suite plus the darwin-specific suite both pass. The recorded argv shows directory-argument installs producing `<dir>/postern.crt` on `add-trusted-cert`, and uninstalls running `remove-trusted-cert` + `delete-certificate -Z` — the same semantics the shared tests assert for Linux. Real macOS CI still needs a darwin runner.
- New darwin tests cover: directory-arg contract parity, anchor-missing + cert-in-keychain recovery (asserts all three security invocations and temp cleanup), anchor-missing + cert-absent clean no-op (only the probe runs), and surfaced probe failures. Existing argv assertions for install and anchor-present uninstall are unchanged in substance.


## Follow-up: hash-based uninstall identity (Greptile P1 on ca35c76, 3833715519)

The common-name recovery above could select the wrong generation when the keychain holds several independently generated Postern CAs (regeneration leaves old ones trusted). Resolution order in `UninstallTrustAt` on macOS is now:

1. anchor PEM present: revoke it directly (unchanged path);
2. anchor lost but state file present: enumerate ALL keychain certs sharing the CA name (`find-certificate -a`), revoke the exact SHA-256 match against the persisted state hash;
3. neither: fail wide — revoke every common-name match and report each revoked hash.

Install persists the registered certificate's SHA-256 to a sibling state file (`<anchor>.sha256`, atomic rename, 0600 file / 0700 dirs). `UninstallTrustAt`/`UninstallTrust` now return the revoked hashes; the CLI prints one `Revoked trusted certificate <hash>` line per revocation. Genuine no-op only when nothing matches.

## Follow-up review hardening

Review of the follow-up produced a run of P1s on intermediate heads; each is fixed on this head:

- Failed installs are atomic. The previous anchor/state pairing is snapshotted before any mutation and restored on failure. An unreadable snapshot aborts before mutating.
- Registration (`add-trusted-cert`) deliberately runs last. Every fallible step before it touches only files, so no failure path can leave trust established or a mismatched anchor/state pair behind. This dissolved an entire class of rollback ambiguities (stale files, same-CA reinstall, probe failure) by construction instead of by guessing pre-existing trust state.

## Verification (updated)

- `GOOS=darwin CGO_ENABLED=0 go build ./...` + `go vet ./...` pass; gofumpt clean.
- Full linux `make ci` green (lint 0 issues, `-race` tests across all packages, govulncheck clean); all PR check-runs green including Greptile Review with no new findings on the final head.
- New darwin tests cover: state-file persistence (content + 0600), exact-hash selection among keychain generations, fail-wide multi-cert revocation with reported hashes, unreadable-snapshot abort, failed-reinstall restore of the previous pairing (same-CA and different-CA), and add-trusted-cert stderr wrapping.
