### PR TITLE
test(config): fix flaky debounce panic by asserting settled state

### DIFF
--- a/internal/config/watcher_internal_test.go
+++ b/internal/config/watcher_internal_test.go
@@ -242,3 +242,66 @@ rules:
 		t.Fatal("update landing across the emission boundary was lost")
 	}
 }
+
+// TestWatcher_TornSaveConvergesAfterMidSaveRead pins recovery after a torn
+// save, driven through the stat-poll seam so no wall-clock margin decides
+// whether the pump observes the intermediate state. The file sits
+// truncated until the content is written below, so every debounce fire in
+// between necessarily reads the torn state; whatever the emission policy
+// does with it, the watcher must converge to the completed save.
+func TestWatcher_TornSaveConvergesAfterMidSaveRead(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(internalValidConfig), 0o600))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	fsw, err := fsnotify.NewWatcher() // no watches: the stat poll drives detection
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = fsw.Close() })
+
+	w := &fsWatcher{path: path, tickInterval: 20 * time.Millisecond}
+	events, err := w.startLocked(ctx, fsw)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	require.NoError(t, os.Truncate(path, 0))
+	select {
+	case <-events:
+		// The intermediate state surfaced; fine either way.
+	case <-time.After(2 * time.Second):
+		// Multiple tick + debounce cycles have already elapsed against the
+		// empty file, so suppression instead of surfacing is acceptable.
+	}
+
+	f, err := os.OpenFile(path, os.O_WRONLY, 0o600)
+	require.NoError(t, err)
+	_, err = f.WriteString(internalSecondValidConfig)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	var last Event
+	n := 0
+	settled := false
+	deadline := time.After(5 * time.Second)
+	for !settled {
+		idle := time.After(500 * time.Millisecond)
+		select {
+		case ev := <-events:
+			last = ev
+			n++
+		case <-idle:
+			settled = true
+		case <-deadline:
+			t.Fatal("watcher never converged to the completed save after a torn save")
+		}
+	}
+	require.GreaterOrEqual(t, n, 1, "content landing after a torn save must produce an emission")
+	require.LessOrEqual(t, n, 6, "torn save produced runaway emissions: %d", n)
+	require.NotNil(t, last.New, "final emission must carry a parsed config")
+	require.Equal(t, "api.two.example", last.New.Rules[0].Host,
+		"watcher must converge to the completed save after reading a torn state")
+}

--- a/internal/config/watcher_test.go
+++ b/internal/config/watcher_test.go
@@ -188,12 +188,10 @@ func TestWatcher_DebouncesRapidEdits(t *testing.T) {
 	events, err := w.Watch(ctx)
 	require.NoError(t, err)
 
-	// Three rapid in-place writes plus an atomic replace inside the
-	// debounce window. Under load the pump can lag the writer far enough
-	// that the debounce fires between individual saves (or mid-save, on a
-	// truncated file), so an emission may legally reflect an intermediate
-	// state; the watcher contract is convergence to the freshest state,
-	// not "first emission == last write".
+	// Under load the pump can lag the writer far enough that the debounce
+	// fires mid-burst or mid-save, so an emission may legally carry an
+	// intermediate state; the contract is convergence to the freshest
+	// state, not first-emission finality.
 	for range 3 {
 		require.NoError(t, os.WriteFile(path, []byte(watchedValidConfig), 0o600))
 	}
@@ -206,45 +204,6 @@ func TestWatcher_DebouncesRapidEdits(t *testing.T) {
 	require.NotEmpty(t, last.New.Rules, "final emission must carry the parsed rules")
 	require.Equal(t, "api.anthropic.com", last.New.Rules[0].Host,
 		"watcher must converge to the most recent write")
-}
-
-// TestWatcher_ConvergesAfterTornSave pins the recovery half of the debounce
-// contract. A save that stalls between truncate and write (editor or runner
-// descheduled mid-save) makes the debounce fire on an empty file; whatever
-// is emitted for that intermediate state must not wedge the watcher: once
-// the content lands it triggers a further emission, the watcher converges
-// to the completed save, and then goes quiet.
-func TestWatcher_ConvergesAfterTornSave(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	require.NoError(t, os.WriteFile(path, []byte(watchedValidConfig), 0o600))
-
-	w := config.NewWatcher(path)
-	t.Cleanup(func() { _ = w.Close() })
-
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
-	events, err := w.Watch(ctx)
-	require.NoError(t, err)
-
-	f, err := os.OpenFile(path, os.O_WRONLY, 0o600)
-	require.NoError(t, err)
-	require.NoError(t, f.Truncate(0))
-	// Hold the file empty past the 100ms debounce window so the watcher
-	// necessarily observes the intermediate state before the content lands.
-	time.Sleep(150 * time.Millisecond)
-	_, err = f.WriteString(watchedSecondValidConfig)
-	require.NoError(t, err)
-	require.NoError(t, f.Close())
-
-	last, n := drainUntilSettled(t, events)
-	require.GreaterOrEqual(t, n, 1, "torn save followed by content must produce an emission")
-	require.NotNil(t, last.New, "final emission must carry a parsed config")
-	require.Equal(t, "api.anthropic.com", last.New.Rules[0].Host,
-		"watcher must converge to the completed save after observing a torn state")
 }
 
 func TestWatcher_ClosesCleanly(t *testing.T) {

--- a/internal/config/watcher_test.go
+++ b/internal/config/watcher_test.go
@@ -39,6 +39,35 @@ func receiveEvent(t *testing.T, ch <-chan config.Event, budget time.Duration) co
 	}
 }
 
+// drainUntilSettled collects Watcher emissions until the stream has been
+// quiet for quietPeriod (comfortably more than one debounce window) or the
+// overall budget expires. It returns the last emission and how many arrived,
+// so callers can assert on the settled state rather than on whichever
+// emission happened to arrive first.
+func drainUntilSettled(t *testing.T, ch <-chan config.Event) (config.Event, int) {
+	t.Helper()
+	const (
+		quietPeriod = 500 * time.Millisecond // > debounceWindow with scheduling slack
+		budget      = 3 * time.Second
+	)
+	deadline := time.After(budget)
+	var last config.Event
+	n := 0
+	for {
+		idle := time.After(quietPeriod)
+		select {
+		case ev := <-ch:
+			last = ev
+			n++
+		case <-idle:
+			return last, n
+		case <-deadline:
+			t.Fatalf("watcher did not settle within %s", budget)
+			return last, n
+		}
+	}
+}
+
 const watchedValidConfig = `
 token:
   source: env
@@ -159,44 +188,63 @@ func TestWatcher_DebouncesRapidEdits(t *testing.T) {
 	events, err := w.Watch(ctx)
 	require.NoError(t, err)
 
-	// Three rapid writes inside the debounce window should coalesce to one
-	// emitted event with the latest content.
-	for i := 0; i < 3; i++ {
+	// Three rapid in-place writes plus an atomic replace inside the
+	// debounce window. Under load the pump can lag the writer far enough
+	// that the debounce fires between individual saves (or mid-save, on a
+	// truncated file), so an emission may legally reflect an intermediate
+	// state; the watcher contract is convergence to the freshest state,
+	// not "first emission == last write".
+	for range 3 {
 		require.NoError(t, os.WriteFile(path, []byte(watchedValidConfig), 0o600))
 	}
 	writeAtomic(t, path, []byte(watchedSecondValidConfig))
 
-	// Under CI load the rapid writes can straddle debounce windows, and a
-	// write observed mid-truncate parses as a transient empty config, so
-	// more than one event may be emitted. Require the stream to settle on
-	// the final write's content instead of assuming exactly one event.
-	var last config.Event
-	require.Eventually(t, func() bool {
-		select {
-		case ev := <-events:
-			last = ev
-			return len(last.New.Rules) > 0 && last.New.Rules[0].Host == "api.anthropic.com"
-		default:
-			return false
-		}
-	}, 3*time.Second, 10*time.Millisecond,
-		"events must settle on the last write; last event: %+v", last)
+	last, n := drainUntilSettled(t, events)
+	require.GreaterOrEqual(t, n, 1, "rapid edits must produce at least one emission")
+	require.LessOrEqual(t, n, 6, "debounce collapsed too few of the four edits: %d emissions", n)
+	require.NotNil(t, last.New, "final emission must carry a parsed config")
+	require.NotEmpty(t, last.New.Rules, "final emission must carry the parsed rules")
+	require.Equal(t, "api.anthropic.com", last.New.Rules[0].Host,
+		"watcher must converge to the most recent write")
+}
 
-	// After settling, earlier content must never reappear. Transient
-	// mid-write snapshots (empty rules) are tolerated; anything parsed must
-	// reflect the final write.
-	for {
-		select {
-		case ev := <-events:
-			if len(ev.New.Rules) == 0 {
-				continue
-			}
-			require.Equal(t, "api.anthropic.com", ev.New.Rules[0].Host,
-				"stale content must not be emitted after the final write")
-		case <-time.After(200 * time.Millisecond):
-			return
-		}
-	}
+// TestWatcher_ConvergesAfterTornSave pins the recovery half of the debounce
+// contract. A save that stalls between truncate and write (editor or runner
+// descheduled mid-save) makes the debounce fire on an empty file; whatever
+// is emitted for that intermediate state must not wedge the watcher: once
+// the content lands it triggers a further emission, the watcher converges
+// to the completed save, and then goes quiet.
+func TestWatcher_ConvergesAfterTornSave(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(watchedValidConfig), 0o600))
+
+	w := config.NewWatcher(path)
+	t.Cleanup(func() { _ = w.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	events, err := w.Watch(ctx)
+	require.NoError(t, err)
+
+	f, err := os.OpenFile(path, os.O_WRONLY, 0o600)
+	require.NoError(t, err)
+	require.NoError(t, f.Truncate(0))
+	// Hold the file empty past the 100ms debounce window so the watcher
+	// necessarily observes the intermediate state before the content lands.
+	time.Sleep(150 * time.Millisecond)
+	_, err = f.WriteString(watchedSecondValidConfig)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	last, n := drainUntilSettled(t, events)
+	require.GreaterOrEqual(t, n, 1, "torn save followed by content must produce an emission")
+	require.NotNil(t, last.New, "final emission must carry a parsed config")
+	require.Equal(t, "api.anthropic.com", last.New.Rules[0].Host,
+		"watcher must converge to the completed save after observing a torn state")
 }
 
 func TestWatcher_ClosesCleanly(t *testing.T) {

--- a/internal/runtime/lifecycle_test.go
+++ b/internal/runtime/lifecycle_test.go
@@ -173,6 +173,7 @@ func TestStalledHandshakeReaped(t *testing.T) {
 
 	start := time.Now()
 	_ = c.SetReadDeadline(time.Now().Add(5 * time.Second))
+
 	buf := make([]byte, 16)
 	_, err = c.Read(buf)
 	require.Error(t, err, "server must close the silent conn")
@@ -189,9 +190,6 @@ func TestIdleTunnelReapedAndGoroutinesSettle(t *testing.T) {
 	})
 	startRuntime(t, rt)
 
-	// Baseline taken with the runtime's own goroutines (serve, reaper) and
-	// the upstream accept loop already live.
-	before := goruntime.NumGoroutine()
 	client := dialTunnel(t, rt.Addr(), up.addr)
 	// The CONNECT exchange alone moves fewer than minProgressBytes, so push
 	// real tunnel traffic through to cross the progress threshold: this conn
@@ -213,14 +211,30 @@ func TestIdleTunnelReapedAndGoroutinesSettle(t *testing.T) {
 		t.Fatal("reaper never evicted the stalled tunnel")
 	}
 
-	// Leak check: after eviction the relay goroutines must actually exit.
-	// The bound is generous so scheduler noise under load cannot flake it,
-	// but a reaped tunnel that leaks its goroutines still fails here.
+	// Leak check scoped to this tunnel's relay goroutines: goproxy runs one
+	// copyAndClose per direction, and their stack frames name the function,
+	// so filtering a full stack dump on that frame ignores unrelated
+	// goroutine churn (GC workers, other tests' timers) that shifts a
+	// global NumGoroutine baseline. This test is serial, so any surviving
+	// copyAndClose stack belongs to a leaked tunnel relay.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		now := goruntime.NumGoroutine()
-		assert.LessOrEqual(c, now, before+2,
-			fmt.Sprintf("relay goroutines must settle at baseline %d after reap; observed %d", before, now))
+		assert.Zero(c, relayGoroutines(),
+			"reaped tunnel must not leave goproxy relay goroutines behind")
 	}, 10*time.Second, 100*time.Millisecond)
+}
+
+// relayGoroutines counts live goroutine stacks carrying goproxy's tunnel
+// relay frame (one copyAndClose per direction).
+func relayGoroutines() int {
+	buf := make([]byte, 4<<20)
+	n := goruntime.Stack(buf, true)
+	count := 0
+	for _, gs := range strings.Split(string(buf[:n]), "\n\n") {
+		if strings.Contains(gs, "goproxy.copyAndClose(") {
+			count++
+		}
+	}
+	return count
 }
 
 // TestOneByteStalledConnReapedAtTier1 pins the insufficient-progress tier:


### PR DESCRIPTION
## Root cause: test bug (not a production bug)

`TestWatcher_DebouncesRapidEdits` assumed the first emission after the burst equals the final write and indexed `ev.New.Rules[0]` unvalidated. Under CI load the pump can lag the writer far enough that the debounce fires while an in-place `os.WriteFile` sits between truncate and write; the emission then carries a parsed empty file: `&Config{Rules: []}` with two warning lints, so `Rules[0]` panics with exactly the observed signature.

Exact panic line (run 32526028079, linux race job):
`internal/config/watcher_test.go:170 +0x798` — `require.Equal(t, "api.anthropic.com", ev.New.Rules[0].Host, ...)`, `index out of range [0] with length 0`.

The other two referenced runs failed on unrelated jobs (`internal/ca` keychain assertions on macOS; goreleaser snapshot matrix assertion).

### Evidence

- Deterministic reproduction of the mechanism (external test package): truncate the config, hold it empty past the 100ms debounce window, then land the content. The watcher emits `Event{New: <cfg with 0 rules>, Lints: [2 warnings]}` to the consumer. Empty YAML parses to a non-nil config with zero rules and no `SeverityError` lint, which is precisely what line 170 indexed.
- Shape note: this is the nested form, not a reader straddling a write. The writer goroutine is descheduled mid-save for longer than the entire read, so even a stat bracket around the read would see a consistent empty file. A reactive watcher cannot distinguish a stalled writer from a genuinely saved empty file at a single instant.

### Contract interpretation

Per the documented contract (freshest-state semantics; collapse permitted; convergence guaranteed and separately pinned by `TestWatcher_NoLostUpdateAcrossEmissions` invariant), reporting an intermediate disk state is within contract. What was violated is the test's stronger assumption. Production behavior converges: the late content re-arms the debounce and a further emission carries the final state.

Known residual sharp edge, deliberately not changed here: a writer stalled longer than a full debounce window can still produce one intermediate emission before convergence (unavoidable for any reactive watcher without product-level policy, e.g. treating rule-less configs as fatal). Noted for a future decision; out of scope for this flake fix.

### Fix

Test-only:

- `TestWatcher_DebouncesRapidEdits` (`internal/config/watcher_test.go`) drains emissions until the stream is quiet for 500ms (> one debounce window), then asserts: at least one emission, at most six (runaway bound), and the last emission carries `api.anthropic.com`. Protective power kept: never-emitting watchers time out, stale-state watchers fail the content assertion, runaway emitters fail the bound.
- `TestWatcher_TornSaveConvergesAfterMidSaveRead` (`internal/config/watcher_internal_test.go`) pins torn-save recovery deterministically through the stat-poll seam: a bare fsnotify watcher (no events) plus a 20ms tick interval, the file held truncated across multiple tick + debounce cycles until the content lands. No wall-clock margin decides whether the pump observes the intermediate state; the assertion targets the convergence event, not catching the intermediate emission.
- `TestIdleTunnelReapedAndGoroutinesSettle` (`internal/runtime/lifecycle_test.go`, run 32531556939 flake) replaces the global `NumGoroutine` baseline+2 assertion with a targeted leak check: a full `runtime.Stack(all)` dump filtered to goproxy's `copyAndClose` relay frames (one goroutine per tunnel direction). Immune to unrelated goroutine churn; the reap-hook wait stays the primary deterministic signal. Mutation check: a live tunnel (idle timeout disabled, no reap) trips the assertion.

### Reproduction numbers

Before: CI-only; 1/3 referenced runs show this panic (linux -race job). Local natural reproduction not achieved in `-count=50 -race` on an unloaded 24-core host; mechanism reproduced deterministically via the torn-save sequence above against the old test (zero-rule emission delivered to consumer).

After (all in devcontainer, go1.26.6):

- `TestWatcher_DebouncesRapidEdits` + `TestWatcher_TornSaveConvergesAfterMidSaveRead` `-race -count=50`: green
- `GOMAXPROCS=2` + 10 busy-loop CPU-load workers, both watcher tests `-count=20`: green
- `TestIdleTunnelReapedAndGoroutinesSettle` `-race -count=50`: green; `GOMAXPROCS=1 -count=10`: green; `GOMAXPROCS=2` + busy CPU `-count=20`: green
- mutation check (stuck relay goroutine): leak assertion fails as required
- full `./internal/config/ ./internal/runtime/ -race`: green
- `make ci` (lint, full -race suite, govulncheck, licenses): green

Unrelated pre-existing flake observed once during local CI: `internal/credstore/bitwarden` `fork/exec ... bws: text file busy` (ETXTBSY exec'ing a freshly written fake binary); passed on retry and 5/5 reruns. Not touched by this diff.
